### PR TITLE
Fastboot tweaks.

### DIFF
--- a/src/core/misc.cc
+++ b/src/core/misc.cc
@@ -160,8 +160,6 @@ bool LoadCdrom() {
     char exename[256];
 
     if (!PCSX::g_emulator.settings.get<PCSX::Emulator::SettingHLE>()) {
-        if (!PCSX::g_emulator.settings.get<PCSX::Emulator::SettingSlowBoot>())
-            PCSX::g_emulator.m_psxCpu->m_psxRegs.pc = PCSX::g_emulator.m_psxCpu->m_psxRegs.GPR.n.ra;
         return true;
     }
 

--- a/src/core/psxemulator.h
+++ b/src/core/psxemulator.h
@@ -124,13 +124,13 @@ class Emulator {
     typedef Setting<VideoType, irqus::typestring<'V', 'i', 'd', 'e', 'o'>, PSX_TYPE_NTSC> SettingVideo;
     typedef Setting<CDDAType, irqus::typestring<'C', 'D', 'D', 'A'>, CDDA_ENABLED_LE> SettingCDDA;
     typedef Setting<bool, irqus::typestring<'H', 'L', 'E'>, true> SettingHLE;
-    typedef Setting<bool, irqus::typestring<'S', 'l', 'o', 'w', 'B', 'o', 'o', 't'>> SettingSlowBoot;
+    typedef Setting<bool, irqus::typestring<'F', 'a', 's', 't', 'B', 'o', 'o', 't'>, true> SettingFastBoot;
     typedef Setting<bool, irqus::typestring<'D', 'e', 'b', 'u', 'g'>> SettingDebug;
     typedef Setting<bool, irqus::typestring<'V', 'e', 'r', 'b', 'o', 's', 'e'>> SettingVerbose;
     typedef Setting<bool, irqus::typestring<'R', 'C', 'n', 't', 'F', 'i', 'x'>> SettingRCntFix;
     Settings<SettingStdout, SettingLogfile, SettingMcd1, SettingMcd2, SettingBios, SettingPpfDir, SettingPsxExe,
              SettingXa, SettingSioIrq, SettingSpuIrq, SettingBnWMdec, SettingAutoVideo, SettingVideo, SettingCDDA,
-             SettingHLE, SettingSlowBoot, SettingDebug, SettingVerbose, SettingRCntFix>
+             SettingHLE, SettingFastBoot, SettingDebug, SettingVerbose, SettingRCntFix>
         settings;
     class PcsxConfig {
       public:

--- a/src/core/r3000a.cc
+++ b/src/core/r3000a.cc
@@ -256,6 +256,8 @@ void PCSX::R3000Acpu::psxJumpTest() {
 
 void PCSX::R3000Acpu::psxExecuteBios() {
     while (m_psxRegs.pc != 0x80030000) ExecuteBlock();
+    if (g_emulator.settings.get<PCSX::Emulator::SettingFastBoot>())
+        m_psxRegs.pc =  m_psxRegs.GPR.n.ra;
 }
 
 void PCSX::R3000Acpu::psxSetPGXPMode(uint32_t pgxpMode) {

--- a/src/gui/gui.cc
+++ b/src/gui/gui.cc
@@ -543,7 +543,7 @@ bool PCSX::GUI::configure() {
         }
 
         changed |= ImGui::Checkbox("BIOS HLE", &settings.get<Emulator::SettingHLE>().value);
-        changed |= ImGui::Checkbox("Slow boot", &settings.get<Emulator::SettingSlowBoot>().value);
+        changed |= ImGui::Checkbox("Fast boot", &settings.get<Emulator::SettingFastBoot>().value);
     }
     ImGui::End();
 


### PR DESCRIPTION
- Slowboot -> Fastboot.
- Properly doing the fastboot hack in psxExecuteBios instead of LoadCdrom.