### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/spu/freeze.cc
+++ b/src/spu/freeze.cc
@@ -87,7 +87,7 @@ void PCSX::SPU::impl::save(SaveStates::SPU &spu) {
         data = s_chan[i].data;
         channel.get<SaveStates::ADSRInfo>() = s_chan[i].ADSR;
         channel.get<SaveStates::ADSRInfoEx>() = s_chan[i].ADSRX;
-        auto storePtr = [=](uint8_t *ptr, Protobuf::Int32 &val) { val.value = ptr ? ptr - spuMemC : -1; };
+        auto storePtr = [=, this](uint8_t *ptr, Protobuf::Int32 &val) { val.value = ptr ? ptr - spuMemC : -1; };
         storePtr(s_chan[i].pStart, data.get<Chan::StartPtr>());
         storePtr(s_chan[i].pCurr, data.get<Chan::CurrPtr>());
         storePtr(s_chan[i].pLoop, data.get<Chan::LoopPtr>());
@@ -124,7 +124,7 @@ void PCSX::SPU::impl::load(const SaveStates::SPU &spu) {
         s_chan[i].data = data;
         s_chan[i].ADSR = channel.get<SaveStates::ADSRInfo>();
         s_chan[i].ADSRX = channel.get<SaveStates::ADSRInfoEx>();
-        auto restorePtr = [=](uint8_t *&ptr, const Protobuf::Int32 &val) {
+        auto restorePtr = [=, this](uint8_t *&ptr, const Protobuf::Int32 &val) {
             ptr = val.value == -1 ? nullptr : val.value + spuMemC;
         };
         restorePtr(s_chan[i].pStart, data.get<Chan::StartPtr>());

--- a/src/spu/freeze.cc
+++ b/src/spu/freeze.cc
@@ -87,7 +87,7 @@ void PCSX::SPU::impl::save(SaveStates::SPU &spu) {
         data = s_chan[i].data;
         channel.get<SaveStates::ADSRInfo>() = s_chan[i].ADSR;
         channel.get<SaveStates::ADSRInfoEx>() = s_chan[i].ADSRX;
-        auto storePtr = [=, this](uint8_t *ptr, Protobuf::Int32 &val) { val.value = ptr ? ptr - spuMemC : -1; };
+        auto storePtr = [this](uint8_t *ptr, Protobuf::Int32 &val) { val.value = ptr ? ptr - spuMemC : -1; };
         storePtr(s_chan[i].pStart, data.get<Chan::StartPtr>());
         storePtr(s_chan[i].pCurr, data.get<Chan::CurrPtr>());
         storePtr(s_chan[i].pLoop, data.get<Chan::LoopPtr>());
@@ -124,7 +124,7 @@ void PCSX::SPU::impl::load(const SaveStates::SPU &spu) {
         s_chan[i].data = data;
         s_chan[i].ADSR = channel.get<SaveStates::ADSRInfo>();
         s_chan[i].ADSRX = channel.get<SaveStates::ADSRInfoEx>();
-        auto restorePtr = [=, this](uint8_t *&ptr, const Protobuf::Int32 &val) {
+        auto restorePtr = [this](uint8_t *&ptr, const Protobuf::Int32 &val) {
             ptr = val.value == -1 ? nullptr : val.value + spuMemC;
         };
         restorePtr(s_chan[i].pStart, data.get<Chan::StartPtr>());


### PR DESCRIPTION
```
src/spu/freeze.cc: In lambda function:
src/spu/freeze.cc:90:25: warning: implicit capture of ‘this’ via ‘[=]’ is deprecated in C++20 [-Wdeprecated]
   90 |         auto storePtr = [=](uint8_t *ptr, Protobuf::Int32 &val) { val.value = ptr ? ptr - spuMemC : -1; };
      |                         ^
src/spu/freeze.cc:90:25: note: add explicit ‘this’ or ‘*this’ capture
src/spu/freeze.cc: In lambda function:
src/spu/freeze.cc:127:27: warning: implicit capture of ‘this’ via ‘[=]’ is deprecated in C++20 [-Wdeprecated]
  127 |         auto restorePtr = [=](uint8_t *&ptr, const Protobuf::Int32 &val) {
      |                           ^
src/spu/freeze.cc:127:27: note: add explicit ‘this’ or ‘*this’ capture
```