### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/spu/debug.cc
+++ b/src/spu/debug.cc
@@ -136,7 +136,7 @@ void PCSX::SPU::impl::debug() {
             {
                 ImGui::Text("Start pos:\nCurr pos:\nLoop pos:\n\nRight vol:\nLeft vol:\n\nAct freq:\nUsed freq:");
                 ImGui::SameLine();
-                ImGui::Text("%i\n%i\n%i\n\n%6i  %04x\n%6i  %04x\n\n%i\n%i", ch.pStart - spuMemC, ch.pCurr - spuMemC,
+                ImGui::Text("%li\n%li\n%li\n\n%6i  %04x\n%6i  %04x\n\n%i\n%i", ch.pStart - spuMemC, ch.pCurr - spuMemC,
                             ch.pLoop - spuMemC, ch.data.get<Chan::RightVolume>().value,
                             ch.data.get<Chan::RightVolRaw>().value, ch.data.get<Chan::LeftVolume>().value,
                             ch.data.get<Chan::LeftVolRaw>().value, ch.data.get<Chan::ActFreq>().value,
@@ -158,7 +158,7 @@ void PCSX::SPU::impl::debug() {
                 ImGui::Text("Spu states");
                 ImGui::Text("Irq addr:\nCtrl:\nStat:\nSpu mem:");
                 ImGui::SameLine();
-                ImGui::Text("%i\n%04x\n%04x\n%i", pSpuIrq ? -1 : (unsigned long)pSpuIrq - (unsigned long)spuMemC,
+                ImGui::Text("%li\n%04x\n%04x\n%i", pSpuIrq ? -1 : (unsigned long)pSpuIrq - (unsigned long)spuMemC,
                             spuCtrl, spuStat, spuAddr);
             }
             ImGui::EndChild();


### PR DESCRIPTION
```
src/spu/debug.cc: In member function ‘virtual void PCSX::SPU::impl::debug()’:
src/spu/debug.cc:139:31: warning: format ‘%i’ expects argument of type ‘int’, but argument 2 has type ‘long int’ [-Wformat=]
  139 |                 ImGui::Text("%i\n%i\n%i\n\n%6i  %04x\n%6i  %04x\n\n%i\n%i", ch.pStart - spuMemC, ch.pCurr - spuMemC,
      |                              ~^                                             ~~~~~~~~~~~~~~~~~~~
      |                               |                                                       |
      |                               int                                                     long int
      |                              %li
src/spu/debug.cc:139:35: warning: format ‘%i’ expects argument of type ‘int’, but argument 3 has type ‘long int’ [-Wformat=]
  139 |                 ImGui::Text("%i\n%i\n%i\n\n%6i  %04x\n%6i  %04x\n\n%i\n%i", ch.pStart - spuMemC, ch.pCurr - spuMemC,
      |                                  ~^                                                              ~~~~~~~~~~~~~~~~~~
      |                                   |                                                                       |
      |                                   int                                                                     long int
      |                                  %li
src/spu/debug.cc:139:39: warning: format ‘%i’ expects argument of type ‘int’, but argument 4 has type ‘long int’ [-Wformat=]
  139 |                 ImGui::Text("%i\n%i\n%i\n\n%6i  %04x\n%6i  %04x\n\n%i\n%i", ch.pStart - spuMemC, ch.pCurr - spuMemC,
      |                                      ~^
      |                                       |
      |                                       int
      |                                      %li
  140 |                             ch.pLoop - spuMemC, ch.data.get<Chan::RightVolume>().value,
      |                             ~~~~~~~~~~~~~~~~~~
      |                                      |
      |                                      long int
src/spu/debug.cc:161:31: warning: format ‘%i’ expects argument of type ‘int’, but argument 2 has type ‘long unsigned int’ [-Wformat=]
  161 |                 ImGui::Text("%i\n%04x\n%04x\n%i", pSpuIrq ? -1 : (unsigned long)pSpuIrq - (unsigned long)spuMemC,
      |                              ~^                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                               |                           |
      |                               int                         long unsigned int
      |                              %li
```