### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/gpu/soft/gpu.cc
+++ b/src/gpu/soft/gpu.cc
@@ -312,7 +312,7 @@ extern "C" void softGPUmakeSnapshot(void)  // snapshot of whole vram
 #ifdef _WIN32
         sprintf(filename, "SNAP\\PEOPSSOFT%03d.bmp", snapshotnr);
 #else
-        sprintf(filename, "%s/peopssoft%03ld.bmp", getenv("HOME"), snapshotnr);
+        sprintf(filename, "%s/peopssoft%03d.bmp", getenv("HOME"), snapshotnr);
 #endif
 
         bmpfile = fopen(filename, "rb");

--- a/src/gui/widgets/dwarf.cc
+++ b/src/gui/widgets/dwarf.cc
@@ -176,7 +176,7 @@ void PCSX::Widgets::Dwarf::draw(const char* title) {
                         for (auto& e : m) {
                             auto& l = e.second;
                             ImGui::Text(
-                                ":%5i/%3i [%08x] idx: %i, stmt: %i, basic: %i, endseq: %i, prlgend: %i, eplgend: %i, "
+                                ":%5i/%3i [%08lx] idx: %i, stmt: %i, basic: %i, endseq: %i, prlgend: %i, eplgend: %i, "
                                 "discr: %i",
                                 l.line, l.column, l.address, l.op_index, l.is_stmt, l.basic_block, l.end_sequence,
                                 l.prologue_end, l.epilogue_begin, l.discriminator);


### PR DESCRIPTION
```
src/gui/widgets/dwarf.cc:179:47: warning: format ‘%x’ expects argument of type ‘unsigned int’, but argument 4 has type ‘dwarf::taddr’ {aka ‘long unsigned int’} [-Wformat=]
  179 |                                 ":%5i/%3i [%08x] idx: %i, stmt: %i, basic: %i, endseq: %i, prlgend: %i, eplgend: %i, "
      |                                            ~~~^
      |                                               |
      |                                               unsigned int
      |                                            %08lx
  180 |                                 "discr: %i",
  181 |                                 l.line, l.column, l.address, l.op_index, l.is_stmt, l.basic_block, l.end_sequence,
      |                                                   ~~~~~~~~~
      |                                                     |
      |                                                     dwarf::taddr {aka long unsigned int}
...
src/gpu/soft/gpu.cc: In function ‘void softGPUmakeSnapshot()’:
src/gpu/soft/gpu.cc:315:44: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 4 has type ‘uint32_t’ {aka ‘unsigned int’} [-Wformat=]
  315 |         sprintf(filename, "%s/peopssoft%03ld.bmp", getenv("HOME"), snapshotnr);
      |                                        ~~~~^                       ~~~~~~~~~~
      |                                            |                       |
      |                                            long int                uint32_t {aka unsigned int}
      |                                        %03d
```