### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/gui/gui.cc
+++ b/src/gui/gui.cc
@@ -889,7 +889,7 @@ void PCSX::GUI::about() {
             checkGL();
             ImGui::TextWrapped("%s: %s", str, value);
         };
-        ImGui::Text(_("OpenGL information"));
+        ImGui::TextUnformatted(_("OpenGL information"));
         someString(_("vendor"), GL_VENDOR);
         someString(_("renderer"), GL_RENDERER);
         someString(_("version"), GL_VERSION);
@@ -897,7 +897,7 @@ void PCSX::GUI::about() {
         GLint n, i;
         glGetIntegerv(GL_NUM_EXTENSIONS, &n);
         checkGL();
-        ImGui::Text(_("extensions:"));
+        ImGui::TextUnformatted(_("extensions:"));
         ImGui::BeginChild("GLextensions", ImVec2(0, 0), true);
         for (i = 0; i < n; i++) {
             const char* extension = (const char*)glGetStringi(GL_EXTENSIONS, i);

--- a/src/gui/widgets/assembly.cc
+++ b/src/gui/widgets/assembly.cc
@@ -138,7 +138,7 @@ void PCSX::Widgets::Assembly::GPR(uint8_t reg) {
     sameLine();
     ImGui::Text(" $");
     sameLine();
-    ImGui::Text(s_disRNameGPR[reg]);
+    ImGui::TextUnformatted(s_disRNameGPR[reg]);
     if (ImGui::IsItemHovered()) {
         ImGui::BeginTooltip();
         ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
@@ -152,7 +152,7 @@ void PCSX::Widgets::Assembly::CP0(uint8_t reg) {
     sameLine();
     ImGui::Text(" $");
     sameLine();
-    ImGui::Text(s_disRNameCP0[reg]);
+    ImGui::TextUnformatted(s_disRNameCP0[reg]);
     if (ImGui::IsItemHovered()) {
         ImGui::BeginTooltip();
         ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
@@ -166,7 +166,7 @@ void PCSX::Widgets::Assembly::CP2C(uint8_t reg) {
     sameLine();
     ImGui::Text(" $");
     sameLine();
-    ImGui::Text(s_disRNameCP2C[reg]);
+    ImGui::TextUnformatted(s_disRNameCP2C[reg]);
     if (ImGui::IsItemHovered()) {
         ImGui::BeginTooltip();
         ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
@@ -180,7 +180,7 @@ void PCSX::Widgets::Assembly::CP2D(uint8_t reg) {
     sameLine();
     ImGui::Text(" $");
     sameLine();
-    ImGui::Text(s_disRNameCP2D[reg]);
+    ImGui::TextUnformatted(s_disRNameCP2D[reg]);
     if (ImGui::IsItemHovered()) {
         ImGui::BeginTooltip();
         ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
@@ -263,7 +263,7 @@ void PCSX::Widgets::Assembly::Target(uint32_t value) {
     comma();
     sameLine();
     char label[21];
-    ImGui::Text("");
+    ImGui::TextUnformatted("");
     ImGui::SameLine();
     if (m_displayArrowForJumps) m_arrows.push_back({m_currentAddr, value});
     std::snprintf(label, sizeof(label), "0x%8.8x##%8.8x", value, m_currentAddr);
@@ -341,7 +341,7 @@ void PCSX::Widgets::Assembly::OfB(int16_t offset, uint8_t reg, int size) {
         std::snprintf(label, sizeof(label), "0x%4.4x($%s)##%08x", offset, s_disRNameGPR[reg], m_currentAddr);
     }
     uint32_t addr = m_registers->GPR.r[reg] + offset;
-    ImGui::Text("");
+    ImGui::TextUnformatted("");
     ImGui::SameLine();
     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
     if (ImGui::Button(label)) jumpToMemory(addr, size);
@@ -368,7 +368,7 @@ void PCSX::Widgets::Assembly::BranchDest(uint32_t value) {
     comma();
     sameLine();
     char label[21];
-    ImGui::Text("");
+    ImGui::TextUnformatted("");
     ImGui::SameLine();
     m_arrows.push_back({m_currentAddr, value});
     std::snprintf(label, sizeof(label), "0x%8.8x##%8.8x", value, m_currentAddr);
@@ -398,7 +398,7 @@ void PCSX::Widgets::Assembly::Offset(uint32_t addr, int size) {
     std::string longLabel = label;
     auto symbols = findSymbol(addr);
     if (symbols.size() != 0) longLabel = *symbols.begin() + " ;" + label;
-    ImGui::Text("");
+    ImGui::TextUnformatted("");
     ImGui::SameLine();
     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
     if (ImGui::Button(longLabel.c_str())) jumpToMemory(addr, size);
@@ -455,7 +455,7 @@ void PCSX::Widgets::Assembly::draw(psxRegisters* registers, Memory* memory, Dwar
             if (ImGui::IsItemHovered()) {
                 ImGui::BeginTooltip();
                 ImGui::PushTextWrapPos(glyphWidth * 35.0f);
-                ImGui::TextWrapped(
+                ImGui::TextUnformatted(
                     _("When two instructions are detected to be a single pseudo-instruction, combine them into the "
                       "actual pseudo-instruction."));
                 ImGui::PopTextWrapPos();
@@ -465,7 +465,7 @@ void PCSX::Widgets::Assembly::draw(psxRegisters* registers, Memory* memory, Dwar
             if (ImGui::IsItemHovered()) {
                 ImGui::BeginTooltip();
                 ImGui::PushTextWrapPos(glyphWidth * 35.0f);
-                ImGui::TextWrapped(
+                ImGui::TextUnformatted(
                     _("When combining two instructions into a single pseudo-instruction, add a placeholder for the "
                       "second one."));
                 ImGui::PopTextWrapPos();
@@ -475,7 +475,7 @@ void PCSX::Widgets::Assembly::draw(psxRegisters* registers, Memory* memory, Dwar
             if (ImGui::IsItemHovered()) {
                 ImGui::BeginTooltip();
                 ImGui::PushTextWrapPos(glyphWidth * 35.0f);
-                ImGui::TextWrapped(
+                ImGui::TextUnformatted(
                     _("Add a small visible notch to indicate instructions that are on the delay slot of a branch."));
                 ImGui::PopTextWrapPos();
                 ImGui::EndTooltip();
@@ -484,7 +484,7 @@ void PCSX::Widgets::Assembly::draw(psxRegisters* registers, Memory* memory, Dwar
             if (ImGui::IsItemHovered()) {
                 ImGui::BeginTooltip();
                 ImGui::PushTextWrapPos(glyphWidth * 35.0f);
-                ImGui::TextWrapped(_("Display arrows for jumps. This might crowd the display a bit too much."));
+                ImGui::TextUnformatted(_("Display arrows for jumps. This might crowd the display a bit too much."));
                 ImGui::PopTextWrapPos();
                 ImGui::EndTooltip();
             }
@@ -637,7 +637,7 @@ void PCSX::Widgets::Assembly::draw(psxRegisters* registers, Memory* memory, Dwar
                 }
 
                 for (int i = 0; i < m_numColumns * ImGui::GetWindowDpiScale(); i++) {
-                    ImGui::Text("");
+                    ImGui::TextUnformatted("");
                     ImGui::SameLine();
                 }
 
@@ -930,7 +930,7 @@ void PCSX::Widgets::Assembly::draw(psxRegisters* registers, Memory* memory, Dwar
                         dwarf->m_pc = fmt::format("{:08x}", symbol.second);
                     }
                     ImGui::SameLine();
-                    ImGui::Text(label.c_str());
+                    ImGui::TextUnformatted(label.c_str());
                 }
             }
             ImGui::EndChild();

--- a/src/gui/widgets/breakpoints.cc
+++ b/src/gui/widgets/breakpoints.cc
@@ -56,7 +56,7 @@ void PCSX::Widgets::Breakpoints::draw(const char* title) {
     ImGui::SameLine();
     ImGui::Checkbox(_("Break on word write map"), &debugger->m_breakmp_w32);
     ImGui::Separator();
-    ImGui::Text(_("Breakpoints"));
+    ImGui::TextUnformatted(_("Breakpoints"));
     if (ImGui::Button(_("Show all breakpoints"))) {
         m_filterE = m_filterR1 = m_filterR2 = m_filterR4 = m_filterW1 = m_filterW2 = m_filterW4 = true;
     }

--- a/src/gui/widgets/dwarf.cc
+++ b/src/gui/widgets/dwarf.cc
@@ -88,7 +88,7 @@ void dumpTree(const dwarf::die& node, const PCSX::Elf& elf) {
                 if (ImGui::TreeNode(attribute.c_str())) {
                     auto strs = expr.to_strings();
                     for (auto& s : strs) {
-                        ImGui::Text(s.c_str());
+                        ImGui::TextUnformatted(s.c_str());
                     }
                     ImGui::TreePop();
                 }
@@ -96,7 +96,7 @@ void dumpTree(const dwarf::die& node, const PCSX::Elf& elf) {
             }
             default: {
                 std::string attribute = fmt::format("{:30} {}", to_string(attr.first), to_string(attr.second));
-                ImGui::Text(attribute.c_str());
+                ImGui::TextUnformatted(attribute.c_str());
                 break;
             }
         }
@@ -148,7 +148,7 @@ void PCSX::Widgets::Dwarf::draw(const char* title) {
             }
             case BY_PC: {
                 auto [entry, stack] = e.findByAddress(strtoul(m_pc.c_str(), nullptr, 16));
-                if (entry.valid()) ImGui::Text(entry.get_description().c_str());
+                if (entry.valid()) ImGui::TextUnformatted(entry.get_description().c_str());
                 for (auto& d : stack) {
                     dumpTree(d, e);
                 }

--- a/src/gui/widgets/filedialog.cc
+++ b/src/gui/widgets/filedialog.cc
@@ -179,7 +179,7 @@ bool PCSX::Widgets::FileDialog::draw() {
 
         if (ImGui::Button(_("Home"))) goHome = true;
         ImGui::SameLine();
-        ImGui::Text(reinterpret_cast<const char*>(m_currentPath.u8string().c_str()));
+        ImGui::TextUnformatted(reinterpret_cast<const char*>(m_currentPath.u8string().c_str()));
         {
             ImGui::BeginChild("Directories", ImVec2(250, 350), true, ImGuiWindowFlags_HorizontalScrollbar);
             if (ImGui::TreeNode(_("Roots"))) {
@@ -304,11 +304,11 @@ bool PCSX::Widgets::FileDialog::draw() {
                     }
                 }
                 ImGui::SameLine();
-                ImGui::Text(reinterpret_cast<const char*>(p.filename.c_str()));
+                ImGui::TextUnformatted(reinterpret_cast<const char*>(p.filename.c_str()));
                 ImGui::NextColumn();
-                ImGui::Text(std::to_string(p.size).c_str());
+                ImGui::TextUnformatted(std::to_string(p.size).c_str());
                 ImGui::NextColumn();
-                ImGui::Text(p.dateTime.c_str());
+                ImGui::TextUnformatted(p.dateTime.c_str());
                 ImGui::NextColumn();
 
                 if (p.selected) selected = &p;
@@ -319,7 +319,7 @@ bool PCSX::Widgets::FileDialog::draw() {
         PCSX::u8string selectedStr;
         bool gotSelected = selected;
         if (m_flags & NewFile) {
-            ImGui::Text(reinterpret_cast<const char*>(m_currentPath.u8string().c_str()));
+            ImGui::TextUnformatted(reinterpret_cast<const char*>(m_currentPath.u8string().c_str()));
             ImGui::SameLine();
             std::string label = std::string("##") + m_title() + "Filename";
             InputText(label.c_str(), &m_newFile);
@@ -327,7 +327,7 @@ bool PCSX::Widgets::FileDialog::draw() {
             gotSelected = !m_newFile.empty();
         } else {
             selectedStr = (m_currentPath / std::filesystem::path(selected ? selected->filename : MAKEU8(u8"..."))).u8string();
-            ImGui::Text(reinterpret_cast<const char*>(selectedStr.c_str()));
+            ImGui::TextUnformatted(reinterpret_cast<const char*>(selectedStr.c_str()));
         }
         if (!gotSelected) {
             const ImVec4 lolight = ImGui::GetStyle().Colors[ImGuiCol_TextDisabled];


### PR DESCRIPTION
```
src/gui/gui.cc: In member function ‘void PCSX::GUI::about()’:
src/gui/gui.cc:892:44: warning: format not a string literal and no format arguments [-Wformat-security]
  892 |         ImGui::Text(_("OpenGL information"));
      |                                            ^
src/gui/gui.cc:900:37: warning: format not a string literal and no format arguments [-Wformat-security]
  900 |         ImGui::Text(_("extensions:"));
      |                                     ^
...
src/gui/widgets/breakpoints.cc: In member function ‘void PCSX::Widgets::Breakpoints::draw(const char*)’:
src/gui/widgets/breakpoints.cc:59:33: warning: format not a string literal and no format arguments [-Wformat-security]
   59 |     ImGui::Text(_("Breakpoints"));
      |                                 ^
...
src/gui/widgets/dwarf.cc: In function ‘void {anonymous}::dumpTree(const dwarf::die&, const PCSX::Elf&)’:
src/gui/widgets/dwarf.cc:91:46: warning: format not a string literal and no format arguments [-Wformat-security]
   91 |                         ImGui::Text(s.c_str());
      |                                              ^
src/gui/widgets/dwarf.cc:99:46: warning: format not a string literal and no format arguments [-Wformat-security]
   99 |                 ImGui::Text(attribute.c_str());
      |                                              ^
...
src/gui/widgets/assembly.cc: In member function ‘virtual void PCSX::Widgets::Assembly::GPR(uint8_t)’:
src/gui/widgets/assembly.cc:141:35: warning: format not a string literal and no format arguments [-Wformat-security]
  141 |     ImGui::Text(s_disRNameGPR[reg]);
      |                                   ^
src/gui/widgets/assembly.cc: In member function ‘virtual void PCSX::Widgets::Assembly::CP0(uint8_t)’:
src/gui/widgets/assembly.cc:155:35: warning: format not a string literal and no format arguments [-Wformat-security]
  155 |     ImGui::Text(s_disRNameCP0[reg]);
      |                                   ^
src/gui/widgets/assembly.cc: In member function ‘virtual void PCSX::Widgets::Assembly::CP2C(uint8_t)’:
src/gui/widgets/assembly.cc:169:36: warning: format not a string literal and no format arguments [-Wformat-security]
  169 |     ImGui::Text(s_disRNameCP2C[reg]);
      |                                    ^
src/gui/widgets/assembly.cc: In member function ‘virtual void PCSX::Widgets::Assembly::CP2D(uint8_t)’:
src/gui/widgets/assembly.cc:183:36: warning: format not a string literal and no format arguments [-Wformat-security]
  183 |     ImGui::Text(s_disRNameCP2D[reg]);
      |                                    ^
src/gui/widgets/assembly.cc: In member function ‘virtual void PCSX::Widgets::Assembly::Target(uint32_t)’:
src/gui/widgets/assembly.cc:266:17: warning: zero-length gnu_printf format string [-Wformat-zero-length]
  266 |     ImGui::Text("");
      |                 ^~
src/gui/widgets/assembly.cc: In member function ‘virtual void PCSX::Widgets::Assembly::OfB(int16_t, uint8_t, int)’:
src/gui/widgets/assembly.cc:344:17: warning: zero-length gnu_printf format string [-Wformat-zero-length]
  344 |     ImGui::Text("");
      |                 ^~
src/gui/widgets/assembly.cc: In member function ‘virtual void PCSX::Widgets::Assembly::BranchDest(uint32_t)’:
src/gui/widgets/assembly.cc:371:17: warning: zero-length gnu_printf format string [-Wformat-zero-length]
  371 |     ImGui::Text("");
      |                 ^~
src/gui/widgets/assembly.cc: In member function ‘virtual void PCSX::Widgets::Assembly::Offset(uint32_t, int)’:
src/gui/widgets/assembly.cc:401:17: warning: zero-length gnu_printf format string [-Wformat-zero-length]
  401 |     ImGui::Text("");
      |                 ^~
src/gui/widgets/assembly.cc: In member function ‘void PCSX::Widgets::Assembly::draw(PCSX::psxRegisters*, PCSX::Memory*, PCSX::Widgets::Dwarf*, const char*)’:
src/gui/widgets/assembly.cc:460:52: warning: format not a string literal and no format arguments [-Wformat-security]
  460 |                       "actual pseudo-instruction."));
      |                                                    ^
src/gui/widgets/assembly.cc:470:37: warning: format not a string literal and no format arguments [-Wformat-security]
  470 |                       "second one."));
      |                                     ^
src/gui/widgets/assembly.cc:479:116: warning: format not a string literal and no format arguments [-Wformat-security]
  479 |                     _("Add a small visible notch to indicate instructions that are on the delay slot of a branch."));
      |                                                                                                                    ^
src/gui/widgets/assembly.cc:487:111: warning: format not a string literal and no format arguments [-Wformat-security]
  487 |                 ImGui::TextWrapped(_("Display arrows for jumps. This might crowd the display a bit too much."));
      |                                                                                                               ^
src/gui/widgets/assembly.cc: In lambda function:
src/gui/widgets/assembly.cc:640:33: warning: zero-length gnu_printf format string [-Wformat-zero-length]
  640 |                     ImGui::Text("");
      |                                 ^~
src/gui/widgets/assembly.cc: In member function ‘void PCSX::Widgets::Assembly::draw(PCSX::psxRegisters*, PCSX::Memory*, PCSX::Widgets::Dwarf*, const char*)’:
src/gui/widgets/assembly.cc:933:46: warning: format not a string literal and no format arguments [-Wformat-security]
  933 |                     ImGui::Text(label.c_str());
      |                                              ^
...
src/gui/widgets/filedialog.cc: In member function ‘bool PCSX::Widgets::FileDialog::draw()’:
src/gui/widgets/filedialog.cc:182:84: warning: format not a string literal and no format arguments [-Wformat-security]
  182 |         ImGui::Text(reinterpret_cast<const char*>(m_currentPath.u8string().c_str()));
      |                                                                                    ^
src/gui/widgets/filedialog.cc:307:78: warning: format not a string literal and no format arguments [-Wformat-security]
  307 |                 ImGui::Text(reinterpret_cast<const char*>(p.filename.c_str()));
      |                                                                              ^
src/gui/widgets/filedialog.cc:309:59: warning: format not a string literal and no format arguments [-Wformat-security]
  309 |                 ImGui::Text(std::to_string(p.size).c_str());
      |                                                           ^
src/gui/widgets/filedialog.cc:311:47: warning: format not a string literal and no format arguments [-Wformat-security]
  311 |                 ImGui::Text(p.dateTime.c_str());
      |                                               ^
src/gui/widgets/filedialog.cc:322:88: warning: format not a string literal and no format arguments [-Wformat-security]
  322 |             ImGui::Text(reinterpret_cast<const char*>(m_currentPath.u8string().c_str()));
      |                                                                                        ^
src/gui/widgets/filedialog.cc:330:75: warning: format not a string literal and no format arguments [-Wformat-security]
  330 |             ImGui::Text(reinterpret_cast<const char*>(selectedStr.c_str()));
      |                                                                           ^
```