### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/core/cdriso.cc
+++ b/src/core/cdriso.cc
@@ -1292,7 +1292,7 @@ int PCSX::CDRiso::LoadSBI(const char *filename) {
         buffer[14] = 'i';
         buffer[15] = '\0';
 
-        sprintf(sbifile, "%s%s", PCSX::g_emulator->settings.get<Emulator::SettingPpfDir>().string().c_str(), buffer);
+        sprintf(sbifile, "%hhn%s", PCSX::g_emulator->settings.get<Emulator::SettingPpfDir>().string().c_str(), buffer);
         filename = sbifile;
     }
 

--- a/src/core/misc.cc
+++ b/src/core/misc.cc
@@ -308,9 +308,9 @@ bool CheckCdrom() {
     if (PCSX::g_emulator->config().PerGameMcd) {
         char mcd1path[MAXPATHLEN] = {'\0'};
         char mcd2path[MAXPATHLEN] = {'\0'};
-        sprintf(mcd1path, "memcards/games/%s-%02d.mcd",
+        sprintf(mcd1path, "memcards/games/%hhn-%02d.mcd",
                 PCSX::g_emulator->settings.get<PCSX::Emulator::SettingPsxExe>().string().c_str(), 1);
-        sprintf(mcd2path, "memcards/games/%s-%02d.mcd",
+        sprintf(mcd2path, "memcards/games/%hhn-%02d.mcd",
                 PCSX::g_emulator->settings.get<PCSX::Emulator::SettingPsxExe>().string().c_str(), 2);
         PCSX::g_emulator->settings.get<PCSX::Emulator::SettingMcd1>() = mcd1path;
         PCSX::g_emulator->settings.get<PCSX::Emulator::SettingMcd2>() = mcd2path;
@@ -353,7 +353,7 @@ static void LoadLibPS() {
     FILE *f;
 
     // Load Net Yaroze runtime library (if exists)
-    sprintf(buf, "%s/libps.exe",
+    sprintf(buf, "%hhn/libps.exe",
             PCSX::g_emulator->settings.get<PCSX::Emulator::SettingBios>().value.parent_path().u8string().c_str());
     f = fopen(buf, "rb");
 

--- a/src/core/misc.cc
+++ b/src/core/misc.cc
@@ -29,6 +29,7 @@
 #include "core/misc.h"
 #include "core/ppf.h"
 #include "core/psxemulator.h"
+#include "fmt/format.h"
 
 #include "spu/interface.h"
 
@@ -308,9 +309,13 @@ bool CheckCdrom() {
     if (PCSX::g_emulator->config().PerGameMcd) {
         char mcd1path[MAXPATHLEN] = {'\0'};
         char mcd2path[MAXPATHLEN] = {'\0'};
-        sprintf(mcd1path, "memcards/games/%hhn-%02d.mcd",
+        /*sprintf(mcd1path, "memcards/games/%hhn-%02d.mcd",
                 PCSX::g_emulator->settings.get<PCSX::Emulator::SettingPsxExe>().string().c_str(), 1);
         sprintf(mcd2path, "memcards/games/%hhn-%02d.mcd",
+                PCSX::g_emulator->settings.get<PCSX::Emulator::SettingPsxExe>().string().c_str(), 2);*/
+        std::string label1 = fmt::format(mcd1path, "memcards/games/{:08x}-{:02d}.mcd",
+                PCSX::g_emulator->settings.get<PCSX::Emulator::SettingPsxExe>().string().c_str(), 1);
+        std::string label2 = fmt::format(mcd2path, "memcards/games/{:08x}-{:02d}.mcd",
                 PCSX::g_emulator->settings.get<PCSX::Emulator::SettingPsxExe>().string().c_str(), 2);
         PCSX::g_emulator->settings.get<PCSX::Emulator::SettingMcd1>() = mcd1path;
         PCSX::g_emulator->settings.get<PCSX::Emulator::SettingMcd2>() = mcd2path;


### PR DESCRIPTION
```
src/core/misc.cc: In function ‘bool CheckCdrom()’:
src/core/misc.cc:311:44: warning: format ‘%s’ expects argument of type ‘char*’, but argument 3 has type ‘const char8_t*’ [-Wformat=]
  311 |         sprintf(mcd1path, "memcards/games/%s-%02d.mcd",
      |                                           ~^
      |                                            |
      |                                            char*
      |                                           %hhn
  312 |                 PCSX::g_emulator->settings.get<PCSX::Emulator::SettingPsxExe>().string().c_str(), 1);
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                                               |
      |                                                                                               const char8_t*
src/core/misc.cc:313:44: warning: format ‘%s’ expects argument of type ‘char*’, but argument 3 has type ‘const char8_t*’ [-Wformat=]
  313 |         sprintf(mcd2path, "memcards/games/%s-%02d.mcd",
      |                                           ~^
      |                                            |
      |                                            char*
      |                                           %hhn
  314 |                 PCSX::g_emulator->settings.get<PCSX::Emulator::SettingPsxExe>().string().c_str(), 2);
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                                               |
      |                                                                                               const char8_t*
src/core/misc.cc: In function ‘void LoadLibPS()’:
src/core/misc.cc:356:20: warning: format ‘%s’ expects argument of type ‘char*’, but argument 3 has type ‘const char8_t*’ [-Wformat=]
  356 |     sprintf(buf, "%s/libps.exe",
      |                   ~^
      |                    |
      |                    char*
      |                   %hhn
  357 |             PCSX::g_emulator->settings.get<PCSX::Emulator::SettingBios>().value.parent_path().u8string().c_str());
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                                                               |
      |                                                                                                               const char8_t*
...
src/core/cdriso.cc: In member function ‘int PCSX::CDRiso::LoadSBI(const char*)’:
src/core/cdriso.cc:1295:28: warning: format ‘%s’ expects argument of type ‘char*’, but argument 3 has type ‘const char8_t*’ [-Wformat=]
 1295 |         sprintf(sbifile, "%s%s", PCSX::g_emulator->settings.get<Emulator::SettingPpfDir>().string().c_str(), buffer);
      |                           ~^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                            |                                                                             |
      |                            char*                                                                         const char8_t*
      |                           %hhn
```