### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/gui/gui.cc
+++ b/src/gui/gui.cc
@@ -314,7 +314,7 @@ void PCSX::GUI::endFrame() {
     bool changed = false;
 
     if (m_fullscreenRender) {
-        ImTextureID texture = ImTextureID(m_offscreenTextures[m_currentTexture]);
+        ImTextureID texture = reinterpret_cast<ImTextureID*>(&m_offscreenTextures[m_currentTexture]);
         auto basePos = ImGui::GetMainViewport()->Pos;
         ImGui::SetNextWindowPos(
             ImVec2((w - m_renderSize.x) / 2.0f + basePos.x, (h - m_renderSize.y) / 2.0f + basePos.y));
@@ -542,7 +542,7 @@ void PCSX::GUI::endFrame() {
                 ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoCollapse)) {
             ImVec2 textureSize = ImGui::GetContentRegionAvail();
             normalizeDimensions(textureSize, m_renderRatio);
-            ImGui::Image((ImTextureID)m_offscreenTextures[m_currentTexture], textureSize, ImVec2(0, 0), ImVec2(1, 1));
+            ImGui::Image(reinterpret_cast<ImTextureID*>(&m_offscreenTextures[m_currentTexture]), textureSize, ImVec2(0, 0), ImVec2(1, 1));
         }
         ImGui::End();
         if (!outputShown) m_fullscreenRender = true;

--- a/src/gui/widgets/vram-viewer.cc
+++ b/src/gui/widgets/vram-viewer.cc
@@ -337,7 +337,7 @@ void PCSX::Widgets::VRAMViewer::drawVRAM(unsigned int textureID) {
     ImVec2 dimensions = m_cornerBR - m_cornerTL;
     ImVec2 texTL = ImVec2(0.0f, 0.0f) - m_cornerTL / dimensions;
     ImVec2 texBR = ImVec2(1.0f, 1.0f) - (m_cornerBR - m_resolution) / dimensions;
-    ImGui::Image((ImTextureID)textureID, m_resolution, texTL, texBR);
+    ImGui::Image(reinterpret_cast<ImTextureID*>(&textureID), m_resolution, texTL, texBR);
     if (m_clutDestination && m_selectingClut) {
         m_clutDestination->m_clut = m_mouseUV;
     }


### PR DESCRIPTION
```
src/gui/gui.cc: In member function ‘void PCSX::GUI::endFrame()’:
src/gui/gui.cc:317:80: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
  317 |         ImTextureID texture = ImTextureID(m_offscreenTextures[m_currentTexture]);
      |                                                                                ^
src/gui/gui.cc:545:75: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
  545 |             ImGui::Image((ImTextureID)m_offscreenTextures[m_currentTexture], textureSize, ImVec2(0, 0), ImVec2(1, 1));
      |                                                                           ^
...
src/gui/widgets/vram-viewer.cc: In member function ‘void PCSX::Widgets::VRAMViewer::drawVRAM(unsigned int)’:
src/gui/widgets/vram-viewer.cc:340:31: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
  340 |     ImGui::Image((ImTextureID)textureID, m_resolution, texTL, texBR);
      |                               ^~~~~~~~~
```