### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/core/misc.cc
+++ b/src/core/misc.cc
@@ -359,7 +359,8 @@ static void LoadLibPS() {
 
     if (f != NULL) {
         fseek(f, 0x800, SEEK_SET);
-        fread(PCSX::g_emulator->m_psxMem->g_psxM + 0x10000, 0x61000, 1, f);
+        if (fread(PCSX::g_emulator->m_psxMem->g_psxM + 0x10000, 0x61000, 1, f) != 1)
+            printf("File read error.");
         fclose(f);
     }
 }
@@ -389,9 +390,11 @@ int Load(const char *ExePath) {
         type = PSXGetFileType(tmpFile);
         switch (type) {
             case PSX_EXE:
-                fread(&tmpHead, sizeof(EXE_HEADER), 1, tmpFile);
+                if (fread(&tmpHead, sizeof(EXE_HEADER), 1, tmpFile) != 1)
+                    printf("File read error.");
                 fseek(tmpFile, 0x800, SEEK_SET);
-                fread(PSXM(SWAP_LE32(tmpHead.t_addr)), SWAP_LE32(tmpHead.t_size), 1, tmpFile);
+                if (fread(PSXM(SWAP_LE32(tmpHead.t_addr)), SWAP_LE32(tmpHead.t_size), 1, tmpFile) != 1)
+                    printf("File read error.");
                 fclose(tmpFile);
                 PCSX::g_emulator->m_psxCpu->m_psxRegs.pc = SWAP_LE32(tmpHead.pc0);
                 PCSX::g_emulator->m_psxCpu->m_psxRegs.GPR.n.gp = SWAP_LE32(tmpHead.gp0);
@@ -404,20 +407,25 @@ int Load(const char *ExePath) {
             case CPE_EXE:
                 fseek(tmpFile, 6, SEEK_SET); /* Something tells me we should go to 4 and read the "08 00" here... */
                 do {
-                    fread(&opcode, 1, 1, tmpFile);
+                    if (fread(&opcode, 1, 1, tmpFile) != 1)
+                        printf("File read error.");
                     switch (opcode) {
                         case 1: /* Section loading */
-                            fread(&section_address, 4, 1, tmpFile);
-                            fread(&section_size, 4, 1, tmpFile);
+                            if (fread(&section_address, 4, 1, tmpFile) != 1)
+                                printf("File read error.");
+                            if (fread(&section_size, 4, 1, tmpFile) != 1)
+                                printf("File read error.");
                             section_address = SWAP_LEu32(section_address);
                             section_size = SWAP_LEu32(section_size);
                             EMU_LOG("Loading %08X bytes from %08X to %08X\n", section_size, ftell(tmpFile),
                                     section_address);
-                            fread(PSXM(section_address), section_size, 1, tmpFile);
+                            if (fread(PSXM(section_address), section_size, 1, tmpFile) != 1)
+                                printf("File read error.");
                             break;
                         case 3:                          /* register loading (PC only?) */
                             fseek(tmpFile, 2, SEEK_CUR); /* unknown field */
-                            fread(&PCSX::g_emulator->m_psxCpu->m_psxRegs.pc, 4, 1, tmpFile);
+                            if (fread(&PCSX::g_emulator->m_psxCpu->m_psxRegs.pc, 4, 1, tmpFile) != 1)
+                                printf("File read error.");
                             PCSX::g_emulator->m_psxCpu->m_psxRegs.pc =
                                 SWAP_LEu32(PCSX::g_emulator->m_psxCpu->m_psxRegs.pc);
                             break;
@@ -433,19 +441,23 @@ int Load(const char *ExePath) {
                 break;
 
             case COFF_EXE:
-                fread(&coffHead, sizeof(coffHead), 1, tmpFile);
-                fread(&optHead, sizeof(optHead), 1, tmpFile);
+                if (fread(&coffHead, sizeof(coffHead), 1, tmpFile) != 1)
+                    printf("File read error.");
+                if (fread(&optHead, sizeof(optHead), 1, tmpFile) != 1)
+                    printf("File read error.");
 
                 PCSX::g_emulator->m_psxCpu->m_psxRegs.pc = SWAP_LE32(optHead.entry);
                 PCSX::g_emulator->m_psxCpu->m_psxRegs.GPR.n.sp = 0x801fff00;
 
                 for (i = 0; i < SWAP_LE16(coffHead.f_nscns); i++) {
                     fseek(tmpFile, sizeof(FILHDR) + SWAP_LE16(coffHead.f_opthdr) + sizeof(section) * i, SEEK_SET);
-                    fread(&section, sizeof(section), 1, tmpFile);
+                    if (fread(&section, sizeof(section), 1, tmpFile) != 1)
+                        printf("File read error.");
 
                     if (section.s_scnptr != 0) {
                         fseek(tmpFile, SWAP_LE32(section.s_scnptr), SEEK_SET);
-                        fread(PSXM(SWAP_LE32(section.s_paddr)), SWAP_LE32(section.s_size), 1, tmpFile);
+                        if (fread(PSXM(SWAP_LE32(section.s_paddr)), SWAP_LE32(section.s_size), 1, tmpFile) != 1)
+                            printf("File read error.");
                     } else {
                         psxmaddr = PSXM(SWAP_LE32(section.s_paddr));
                         assert(psxmaddr != NULL);

--- a/src/core/ppf.cc
+++ b/src/core/ppf.cc
@@ -206,7 +206,9 @@ void PCSX::PPF::BuildPPFCache() {
     if (ppffile == NULL) return;
 
     memset(buffer, 0, 5);
-    fread(buffer, 3, 1, ppffile);
+    if (fread(buffer, 3, 1, ppffile) != 1) {
+        printf("File read error.");
+    }
 
     if (strcmp(buffer, "PPF") != 0) {
         PCSX::g_system->printf(_("Invalid PPF patch: %s.\n"), szPPF);
@@ -229,12 +231,16 @@ void PCSX::PPF::BuildPPFCache() {
             fseek(ppffile, -8, SEEK_END);
 
             memset(buffer, 0, 5);
-            fread(buffer, 4, 1, ppffile);
+            if (fread(buffer, 4, 1, ppffile) != 1) {
+                printf("File read error.");
+            }
 
             if (strcmp(".DIZ", buffer) != 0) {
                 dizyn = 0;
             } else {
-                fread(&dizlen, 4, 1, ppffile);
+                if (fread(&dizlen, 4, 1, ppffile) != 1) {
+                    printf("File read error.");
+                }
                 dizlen = SWAP_LE32(dizlen);
                 dizyn = 1;
             }
@@ -260,12 +266,16 @@ void PCSX::PPF::BuildPPFCache() {
 
             fseek(ppffile, -6, SEEK_END);
             memset(buffer, 0, 5);
-            fread(buffer, 4, 1, ppffile);
+            if (fread(buffer, 4, 1, ppffile) != 1) {
+                printf("File read error.");
+            }
             dizlen = 0;
 
             if (strcmp(".DIZ", buffer) == 0) {
                 fseek(ppffile, -2, SEEK_END);
-                fread(&dizlen, 2, 1, ppffile);
+                if (fread(&dizlen, 2, 1, ppffile) != 1) {
+                    printf("File read error.");
+                }
                 dizlen = SWAP_LE32(dizlen);
                 dizlen += 36;
             }
@@ -292,13 +302,21 @@ void PCSX::PPF::BuildPPFCache() {
     // now do the data reading
     do {
         fseek(ppffile, seekpos, SEEK_SET);
-        fread(&pos, 4, 1, ppffile);
+        if (fread(&pos, 4, 1, ppffile) != 1) {
+            printf("File read error.");
+        }
         pos = SWAP_LE32(pos);
 
-        if (method == 2) fread(buffer, 4, 1, ppffile);  // skip 4 bytes on ppf3 (no int64 support here)
+        if (method == 2) {
+            if (fread(buffer, 4, 1, ppffile) != 1) {  // skip 4 bytes on ppf3 (no int64 support here)
+                printf("File read error.");
+            }
+        }
 
         anz = fgetc(ppffile);
-        fread(ppfmem, anz, 1, ppffile);
+        if (fread(ppfmem, anz, 1, ppffile) != 1) {
+            printf("File read error.");
+        }
 
         ladr = pos / PCSX::CDRom::CD_FRAMESIZE_RAW;
         off = pos % PCSX::CDRom::CD_FRAMESIZE_RAW;

--- a/src/core/ppf.cc
+++ b/src/core/ppf.cc
@@ -207,7 +207,7 @@ void PCSX::PPF::BuildPPFCache() {
 
     memset(buffer, 0, 5);
     if (fread(buffer, 3, 1, ppffile) != 1) {
-        printf("File read error.");
+        throw("File read error.");
     }
 
     if (strcmp(buffer, "PPF") != 0) {
@@ -232,14 +232,14 @@ void PCSX::PPF::BuildPPFCache() {
 
             memset(buffer, 0, 5);
             if (fread(buffer, 4, 1, ppffile) != 1) {
-                printf("File read error.");
+                throw("File read error.");
             }
 
             if (strcmp(".DIZ", buffer) != 0) {
                 dizyn = 0;
             } else {
                 if (fread(&dizlen, 4, 1, ppffile) != 1) {
-                    printf("File read error.");
+                    throw("File read error.");
                 }
                 dizlen = SWAP_LE32(dizlen);
                 dizyn = 1;
@@ -267,14 +267,14 @@ void PCSX::PPF::BuildPPFCache() {
             fseek(ppffile, -6, SEEK_END);
             memset(buffer, 0, 5);
             if (fread(buffer, 4, 1, ppffile) != 1) {
-                printf("File read error.");
+                throw("File read error.");
             }
             dizlen = 0;
 
             if (strcmp(".DIZ", buffer) == 0) {
                 fseek(ppffile, -2, SEEK_END);
                 if (fread(&dizlen, 2, 1, ppffile) != 1) {
-                    printf("File read error.");
+                    throw("File read error.");
                 }
                 dizlen = SWAP_LE32(dizlen);
                 dizlen += 36;
@@ -303,19 +303,19 @@ void PCSX::PPF::BuildPPFCache() {
     do {
         fseek(ppffile, seekpos, SEEK_SET);
         if (fread(&pos, 4, 1, ppffile) != 1) {
-            printf("File read error.");
+            throw("File read error.");
         }
         pos = SWAP_LE32(pos);
 
         if (method == 2) {
             if (fread(buffer, 4, 1, ppffile) != 1) {  // skip 4 bytes on ppf3 (no int64 support here)
-                printf("File read error.");
+                throw("File read error.");
             }
         }
 
         anz = fgetc(ppffile);
         if (fread(ppfmem, anz, 1, ppffile) != 1) {
-            printf("File read error.");
+            throw("File read error.");
         }
 
         ladr = pos / PCSX::CDRom::CD_FRAMESIZE_RAW;

--- a/src/core/sio.cc
+++ b/src/core/sio.cc
@@ -423,7 +423,9 @@ void PCSX::SIO::LoadMcd(int mcd, const PCSX::u8string str) {
                 else if (buf.st_size == MCD_SIZE + 3904)
                     fseek(f, 3904, SEEK_SET);
             }
-            fread(data, 1, MCD_SIZE, f);
+            if (fread(data, 1, MCD_SIZE, f) != MCD_SIZE) {
+                printf("File read error.");
+            }
             fclose(f);
         } else
             PCSX::g_system->message(_("Memory card %s failed to load!\n"), fname);
@@ -436,7 +438,9 @@ void PCSX::SIO::LoadMcd(int mcd, const PCSX::u8string str) {
             else if (buf.st_size == MCD_SIZE + 3904)
                 fseek(f, 3904, SEEK_SET);
         }
-        fread(data, 1, MCD_SIZE, f);
+        if (fread(data, 1, MCD_SIZE, f) != MCD_SIZE) {
+            printf("File read error.");
+        }
         fclose(f);
     }
 }

--- a/src/core/sio.cc
+++ b/src/core/sio.cc
@@ -424,7 +424,7 @@ void PCSX::SIO::LoadMcd(int mcd, const PCSX::u8string str) {
                     fseek(f, 3904, SEEK_SET);
             }
             if (fread(data, 1, MCD_SIZE, f) != MCD_SIZE) {
-                printf("File read error.");
+                throw("File read error.");
             }
             fclose(f);
         } else
@@ -439,7 +439,7 @@ void PCSX::SIO::LoadMcd(int mcd, const PCSX::u8string str) {
                 fseek(f, 3904, SEEK_SET);
         }
         if (fread(data, 1, MCD_SIZE, f) != MCD_SIZE) {
-            printf("File read error.");
+            throw("File read error.");
         }
         fclose(f);
     }


### PR DESCRIPTION
```
src/core/ppf.cc:209:10: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
  209 |     fread(buffer, 3, 1, ppffile);
      |     ~~~~~^~~~~~~~~~~~~~~~~~~~~~~
src/core/ppf.cc:232:18: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
  232 |             fread(buffer, 4, 1, ppffile);
      |             ~~~~~^~~~~~~~~~~~~~~~~~~~~~~
src/core/ppf.cc:237:22: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
  237 |                 fread(&dizlen, 4, 1, ppffile);
      |                 ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
src/core/ppf.cc:263:18: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
  263 |             fread(buffer, 4, 1, ppffile);
      |             ~~~~~^~~~~~~~~~~~~~~~~~~~~~~
src/core/ppf.cc:268:22: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
  268 |                 fread(&dizlen, 2, 1, ppffile);
      |                 ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
src/core/ppf.cc:295:14: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
  295 |         fread(&pos, 4, 1, ppffile);
      |         ~~~~~^~~~~~~~~~~~~~~~~~~~~
src/core/ppf.cc:298:31: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
  298 |         if (method == 2) fread(buffer, 4, 1, ppffile);  // skip 4 bytes on ppf3 (no int64 support here)
      |                          ~~~~~^~~~~~~~~~~~~~~~~~~~~~~
src/core/ppf.cc:301:14: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
  301 |         fread(ppfmem, anz, 1, ppffile);
      |         ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
...
src/core/misc.cc: In function ‘int Load(const char*)’:
src/core/misc.cc:392:22: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
  392 |                 fread(&tmpHead, sizeof(EXE_HEADER), 1, tmpFile);
      |                 ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/core/misc.cc:394:22: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
  394 |                 fread(PSXM(SWAP_LE32(tmpHead.t_addr)), SWAP_LE32(tmpHead.t_size), 1, tmpFile);
      |                 ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/core/misc.cc:407:26: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
  407 |                     fread(&opcode, 1, 1, tmpFile);
      |                     ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
src/core/misc.cc:410:34: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
  410 |                             fread(&section_address, 4, 1, tmpFile);
      |                             ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/core/misc.cc:411:34: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
  411 |                             fread(&section_size, 4, 1, tmpFile);
      |                             ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/core/misc.cc:416:34: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
  416 |                             fread(PSXM(section_address), section_size, 1, tmpFile);
      |                             ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/core/misc.cc:420:34: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
  420 |                             fread(&PCSX::g_emulator->m_psxCpu->m_psxRegs.pc, 4, 1, tmpFile);
      |                             ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/core/misc.cc:436:22: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
  436 |                 fread(&coffHead, sizeof(coffHead), 1, tmpFile);
      |                 ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/core/misc.cc:437:22: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
  437 |                 fread(&optHead, sizeof(optHead), 1, tmpFile);
      |                 ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/core/misc.cc:444:26: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
  444 |                     fread(&section, sizeof(section), 1, tmpFile);
      |                     ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/core/misc.cc:448:30: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
  448 |                         fread(PSXM(SWAP_LE32(section.s_paddr)), SWAP_LE32(section.s_size), 1, tmpFile);
      |                         ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/core/misc.cc: In function ‘void LoadLibPS()’:
src/core/misc.cc:362:14: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
  362 |         fread(PCSX::g_emulator->m_psxMem->g_psxM + 0x10000, 0x61000, 1, f);
      |         ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
...
src/core/sio.cc: In member function ‘void PCSX::SIO::LoadMcd(int, PCSX::u8string)’:
src/core/sio.cc:426:18: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
  426 |             fread(data, 1, MCD_SIZE, f);
      |             ~~~~~^~~~~~~~~~~~~~~~~~~~~~
src/core/sio.cc:439:14: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
  439 |         fread(data, 1, MCD_SIZE, f);
      |         ~~~~~^~~~~~~~~~~~~~~~~~~~~~
```