### PR TITLE
remove layout(origin_upper_left)

### DIFF
--- a/src/gui/widgets/vram-viewer.cc
+++ b/src/gui/widgets/vram-viewer.cc
@@ -62,8 +62,7 @@ uniform vec2 u_cornerBR;
 uniform int u_24shift;
 in vec2 fragUV;
 out vec4 outColor;
-layout(origin_upper_left) in vec4 gl_FragCoord;
-
+//layout(origin_upper_left) in vec4 gl_FragCoord; // causes my machine to crash on failed assert due to Invalid layout qualifier "origin_upper_left" and seems unnecessary
 uniform bool u_magnify;
 uniform float u_magnifyRadius;
 uniform float u_magnifyAmount;


### PR DESCRIPTION
fixes failed assert due to Invalid layout qualifier "origin_upper_left" and seems unnecessary (AMD A10 CPU with integrated R7 GPU)