### PR TITLE
Openbios event refactor

### DIFF
--- a/src/mips/.gitignore
+++ b/src/mips/.gitignore
@@ -1,0 +1,7 @@
+# Clion
+.idea/
+cmake-build-*/
+
+*.bin
+*.elf
+*.map

--- a/src/mips/.gitignore
+++ b/src/mips/.gitignore
@@ -5,3 +5,5 @@ cmake-build-*/
 *.bin
 *.elf
 *.map
+*.cpe
+*.ps-exe

--- a/src/mips/common.mk
+++ b/src/mips/common.mk
@@ -8,7 +8,7 @@ LDSCRIPT ?= ../$(TYPE).ld
 ARCHFLAGS = -march=mips1 -mabi=32 -EL -fno-pic -mno-shared -mno-abicalls -mfp32
 ARCHFLAGS += -fno-stack-protector -nostdlib -ffreestanding
 CPPFLAGS += -mno-gpopt -fomit-frame-pointer -ffunction-sections
-CPPFLAGS += -fno-builtin -fno-strict-aliasing
+CPPFLAGS += -fno-builtin -fno-strict-aliasing -Wno-attributes
 CPPFLAGS += $(ARCHFLAGS)
 CPPFLAGS += -I..
 

--- a/src/mips/common/kernel/events.h
+++ b/src/mips/common/kernel/events.h
@@ -25,13 +25,29 @@ SOFTWARE.
 */
 
 #pragma once
-#include "common/kernel/events.h"
 
-int initEvents(int count);
-uint32_t openEvent(uint32_t class, uint32_t spec, uint32_t mode, void (*handler)());
-void deliverEvent(uint32_t class, uint32_t spec);
-void undeliverEvent(uint32_t class, uint32_t spec);
-int testEvent(uint32_t event);
-int enableEvent(uint32_t event);
-int closeEvent(uint32_t event);
-int waitEvent(uint32_t event);
+enum event_class {
+    EVENT_VBLANK     = 0xf0000001, // IRQ0
+    EVENT_GPU        = 0xf0000002, // IRQ1
+    EVENT_CDROM      = 0xf0000003, // IRQ2
+    EVENT_DMA        = 0xf0000004, // IRQ3
+    EVENT_RTC0       = 0xf0000005, // IRQ4 - Timer 0
+    EVENT_RTC1       = 0xf0000006, // IRQ5 - Timer 1 or 2
+    //  0xf0000007 - unused, should be Timer 2
+    EVENT_CONTROLLER = 0xf0000008, // IRQ7
+    EVENT_SPU        = 0xf0000009, // IRQ9
+    EVENT_PIO        = 0xf000000A, // IRQ10
+    EVENT_SIO        = 0xf000000B, // IRQ8
+};
+
+enum event_mode {
+    EVENT_MODE_CALLBACK    = 0x1000,
+    EVENT_MODE_NO_CALLBACK = 0x2000,
+};
+
+enum event_flag {
+    EVENT_FLAG_FREE       = 0x0000,
+    EVENT_FLAG_DISABLED   = 0x1000,
+    EVENT_FLAG_ENABLED    = 0x2000,
+    EVENT_FLAG_PENDING    = 0x4000,
+};

--- a/src/mips/openbios/build.sh
+++ b/src/mips/openbios/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+CURRENT_PATH=$(PWD)
+PROJECT_PATH=$(realpath "$CURRENT_PATH"/../../..)
+CURRENT_RELATIVE_PATH=$(realpath --relative-to="$PROJECT_PATH" "$CURRENT_PATH")
+
+docker run -it --rm -v "$PROJECT_PATH:/project" grumpycoders/pcsx-redux-build:latest make -C "$CURRENT_RELATIVE_PATH" deepclean all -j4
+

--- a/src/mips/openbios/cdrom/cdrom.c
+++ b/src/mips/openbios/cdrom/cdrom.c
@@ -36,11 +36,11 @@ SOFTWARE.
 
 void initializeCDRomHandlersAndEvents() {
     syscall_enqueueCDRomHandlers();
-    g_cdEventACK = syscall_openEvent(0xf0000003, 0x0010, 0x2000, NULL);
-    g_cdEventDNE = syscall_openEvent(0xf0000003, 0x0020, 0x2000, NULL);
-    g_cdEventRDY = syscall_openEvent(0xf0000003, 0x0040, 0x2000, NULL);
-    g_cdEventEND = syscall_openEvent(0xf0000003, 0x0080, 0x2000, NULL);
-    g_cdEventERR = syscall_openEvent(0xf0000003, 0x8000, 0x2000, NULL);
+    g_cdEventACK = syscall_openEvent(EVENT_CDROM, 0x0010, EVENT_MODE_NO_CALLBACK, NULL);
+    g_cdEventDNE = syscall_openEvent(EVENT_CDROM, 0x0020, EVENT_MODE_NO_CALLBACK, NULL);
+    g_cdEventRDY = syscall_openEvent(EVENT_CDROM, 0x0040, EVENT_MODE_NO_CALLBACK, NULL);
+    g_cdEventEND = syscall_openEvent(EVENT_CDROM, 0x0080, EVENT_MODE_NO_CALLBACK, NULL);
+    g_cdEventERR = syscall_openEvent(EVENT_CDROM, 0x8000, EVENT_MODE_NO_CALLBACK, NULL);
     syscall_enableEvent(g_cdEventACK);
     syscall_enableEvent(g_cdEventDNE);
     syscall_enableEvent(g_cdEventRDY);

--- a/src/mips/openbios/cdrom/events.c
+++ b/src/mips/openbios/cdrom/events.c
@@ -35,20 +35,20 @@ uint32_t g_cdEventERR; /* 0x8000 */
 
 // Yes, these undeliver some events that never got created in the first place.
 void __attribute__((section(".ramtext"))) cdromUndeliverAllExceptAckAndRdy() {
-    syscall_undeliverEvent(0xf0000003, 0x20);
-    syscall_undeliverEvent(0xf0000003, 0x80);
-    syscall_undeliverEvent(0xf0000003, 0x8000);
-    syscall_undeliverEvent(0xf0000003, 0x100); // never created
-    syscall_undeliverEvent(0xf0000003, 0x200); // never created
+    syscall_undeliverEvent(EVENT_CDROM, 0x20);
+    syscall_undeliverEvent(EVENT_CDROM, 0x80);
+    syscall_undeliverEvent(EVENT_CDROM, 0x8000);
+    syscall_undeliverEvent(EVENT_CDROM, 0x100); // never created
+    syscall_undeliverEvent(EVENT_CDROM, 0x200); // never created
 }
 
 void __attribute__((section(".ramtext")))  cdromUndeliverAll() {
-    syscall_undeliverEvent(0xf0000003, 0x40);
-    syscall_undeliverEvent(0xf0000003, 0x10);
-    syscall_undeliverEvent(0xf0000003, 0x20);
-    syscall_undeliverEvent(0xf0000003, 0x80);
-    syscall_undeliverEvent(0xf0000003, 0x8000);
-    syscall_undeliverEvent(0xf0000003, 0x100); // never created
-    syscall_undeliverEvent(0xf0000003, 0x200); // never created
+    syscall_undeliverEvent(EVENT_CDROM, 0x40);
+    syscall_undeliverEvent(EVENT_CDROM, 0x10);
+    syscall_undeliverEvent(EVENT_CDROM, 0x20);
+    syscall_undeliverEvent(EVENT_CDROM, 0x80);
+    syscall_undeliverEvent(EVENT_CDROM, 0x8000);
+    syscall_undeliverEvent(EVENT_CDROM, 0x100); // never created
+    syscall_undeliverEvent(EVENT_CDROM, 0x200); // never created
 }
 

--- a/src/mips/openbios/cdrom/events.h
+++ b/src/mips/openbios/cdrom/events.h
@@ -27,6 +27,7 @@ SOFTWARE.
 #pragma once
 
 #include "common/compiler/stdint.h"
+#include "openbios/kernel/events.h"
 
 extern uint32_t g_cdEventACK;
 extern uint32_t g_cdEventDNE;

--- a/src/mips/openbios/cdrom/statemachine.c
+++ b/src/mips/openbios/cdrom/statemachine.c
@@ -191,7 +191,7 @@ static void __attribute__((section(".ramtext"))) audioResponse(uint8_t status) {
     s_audioResp[5] = CDROM_REG1;
     s_audioResp[6] = CDROM_REG1;
     s_audioResp[7] = CDROM_REG1;
-    syscall_deliverEvent(0xf0000003, 0x40);
+    syscall_deliverEvent(EVENT_CDROM, 0x40);
 }
 
 static void __attribute__((section(".ramtext"))) dataReady() {
@@ -201,7 +201,7 @@ static void __attribute__((section(".ramtext"))) dataReady() {
             initiateDMA();
             return;
         case 0xe6: case 0xeb:
-            syscall_deliverEvent(0xf0000003, 0x40);
+            syscall_deliverEvent(EVENT_CDROM, 0x40);
             return;
     }
 
@@ -210,13 +210,13 @@ static void __attribute__((section(".ramtext"))) dataReady() {
             initiateDMA();
             break;
         case 0xe6: case 0xeb:
-            syscall_deliverEvent(0xf0000003, 0x40);
+            syscall_deliverEvent(EVENT_CDROM, 0x40);
             break;
         case 3: case 4:  case 5:
             audioResponse(status);
             break;
         default:
-            syscall_deliverEvent(0xf0000003, 0x200);
+            syscall_deliverEvent(EVENT_CDROM, 0x200);
             break;
 
     }
@@ -272,7 +272,7 @@ static void __attribute__((section(".ramtext"))) complete() {
                     break;
             }
             s_currentState = IDLE;
-            syscall_deliverEvent(0xf0000003, 0x0020);
+            syscall_deliverEvent(EVENT_CDROM, 0x0020);
             break;
         case 0x1a: { // getID?
             uint8_t * const ptr = s_idResponsePtr;
@@ -281,20 +281,20 @@ static void __attribute__((section(".ramtext"))) complete() {
             ptr[2] = CDROM_REG1;
             ptr[3] = CDROM_REG1;
             s_currentState = IDLE;
-            syscall_deliverEvent(0xf0000003, 0x0020);
+            syscall_deliverEvent(EVENT_CDROM, 0x0020);
             break;
         }
         case GOT_ERROR_AND_REINIT:
             s_gotInt5 = 0;
             s_currentState = IDLE;
-            syscall_deliverEvent(0xf0000003, 0x8000);
+            syscall_deliverEvent(EVENT_CDROM, 0x8000);
             break;
         case IDLE:
-            syscall_deliverEvent(0xf0000003, 0x0200);
+            syscall_deliverEvent(EVENT_CDROM, 0x0200);
             break;
         default:
             s_currentState = IDLE;
-            syscall_deliverEvent(0xf0000003, 0x0020);
+            syscall_deliverEvent(EVENT_CDROM, 0x0020);
             break;
     }
 }
@@ -319,7 +319,7 @@ static void __attribute__((section(".ramtext"))) getLocLAck() {
         s_currentState = s_preemptedState;
         s_preemptedState = IDLE;
     }
-    syscall_deliverEvent(0xf0000003, 0x0020);
+    syscall_deliverEvent(EVENT_CDROM, 0x0020);
 }
 
 static void __attribute__((section(".ramtext"))) getLocPAck() {
@@ -358,24 +358,24 @@ static void __attribute__((section(".ramtext"))) testAck(uint8_t status) {
     }
 
     s_currentState = IDLE;
-    syscall_deliverEvent(0xf0000003, 0x0020);
+    syscall_deliverEvent(EVENT_CDROM, 0x0020);
 }
 
 static void __attribute__((section(".ramtext"))) ack() {
     s_currentState = IDLE;
-    syscall_deliverEvent(0xf0000003, 0x0020);
+    syscall_deliverEvent(EVENT_CDROM, 0x0020);
 }
 
 static void __attribute__((section(".ramtext"))) getStatusAck(uint8_t status) {
     *s_getStatusResponsePtr = status;
     s_currentState = IDLE;
-    syscall_deliverEvent(0xf0000003, 0x0020);
+    syscall_deliverEvent(EVENT_CDROM, 0x0020);
 }
 
 static void __attribute__((section(".ramtext"))) demuteAck(void) {
     s_currentState = s_preemptedState;
     s_preemptedState = IDLE;
-    syscall_deliverEvent(0xf0000003, 0x0020);
+    syscall_deliverEvent(EVENT_CDROM, 0x0020);
 }
 
 static uint8_t * s_tracksInformationPtr;
@@ -390,7 +390,7 @@ static void __attribute__((section(".ramtext"))) getTDack()  {
 
     if (trackNum > s_numberOfTracks) {
         s_currentState = IDLE;
-        syscall_deliverEvent(0xf0000003, 0x0020);
+        syscall_deliverEvent(EVENT_CDROM, 0x0020);
         return;
     }
 
@@ -414,7 +414,7 @@ static void __attribute__((section(".ramtext"))) getParamAck() {
     CDROM_REG1;
     CDROM_REG1;
     s_currentState = IDLE;
-    syscall_deliverEvent(0xf0000003, 0x0020);
+    syscall_deliverEvent(EVENT_CDROM, 0x0020);
 }
 
 static uint8_t s_firstTrack;
@@ -443,7 +443,7 @@ static void __attribute__((section(".ramtext"))) getTNack(void) {
 static void __attribute__((section(".ramtext"))) unlockAck() {
     s_currentState = s_preemptedState;
     s_preemptedState = IDLE;
-    syscall_deliverEvent(0xf0000003, 0x0020);
+    syscall_deliverEvent(EVENT_CDROM, 0x0020);
 }
 
 static void __attribute__((section(".ramtext"))) issueSeekAfterSetLoc(int P) {
@@ -502,7 +502,7 @@ static void __attribute__((section(".ramtext"))) acknowledge() {
             break;
         case 3: case 4: case 5:
             s_gotInt3 = 1;
-            syscall_deliverEvent(0xf0000003, 0x0020);
+            syscall_deliverEvent(EVENT_CDROM, 0x0020);
             break;
         case GETSTATUS:
             getStatusAck(status);
@@ -539,14 +539,14 @@ static void __attribute__((section(".ramtext"))) acknowledge() {
             chainGetTNack();
             break;
         case IDLE:
-            syscall_deliverEvent(0xf0000003, 0x0200);
+            syscall_deliverEvent(EVENT_CDROM, 0x0200);
             break;
     }
 }
 
 static void __attribute__((section(".ramtext"))) end() {
     if ((s_preemptedState == READN) || (s_preemptedState == READS) || (s_currentState == READN) || (s_currentState == READS)) {
-        if (s_dmaCounter > 0) syscall_deliverEvent(0xf0000003, 0x0080);
+        if (s_dmaCounter > 0) syscall_deliverEvent(EVENT_CDROM, 0x0080);
         if ((s_currentState == READN) || (s_currentState == READS)) {
             s_currentState = IDLE;
         } else {
@@ -564,11 +564,11 @@ static void __attribute__((section(".ramtext"))) end() {
 
     switch (s_currentState) {
         case 3: case 4: case 5:
-            syscall_deliverEvent(0xf0000003, 0x0080);
+            syscall_deliverEvent(EVENT_CDROM, 0x0080);
             s_currentState = IDLE;
             break;
         default:
-            syscall_deliverEvent(0xf0000003, 0x0200);
+            syscall_deliverEvent(EVENT_CDROM, 0x0200);
             break;
     }
 }
@@ -587,7 +587,7 @@ static void __attribute__((section(".ramtext"))) discError() {
             ptr[3] = CDROM_REG1;
             s_preemptedState = IDLE;
             s_currentState = IDLE;
-            syscall_deliverEvent(0xf0000003, 0x8000);
+            syscall_deliverEvent(EVENT_CDROM, 0x8000);
             break;
         }
         case INITIALIZING:
@@ -605,7 +605,7 @@ static void __attribute__((section(".ramtext"))) discError() {
                 s_gotInt5 = 0;
                 s_preemptedState = IDLE;
                 s_currentState = IDLE;
-                syscall_deliverEvent(0xf0000003, 0x8000);
+                syscall_deliverEvent(EVENT_CDROM, 0x8000);
             }
             break;
     }
@@ -674,7 +674,7 @@ int __attribute__((section(".ramtext"))) cdromDMAVerifier() {
     dicr |= 0x88000000;
     DICR = dicr;
     if (!(--s_dmaCounter)) {
-        syscall_deliverEvent(0xf0000003, 0x0010);
+        syscall_deliverEvent(EVENT_CDROM, 0x0010);
     }
     s_dmaStuff = 0;
     return 1;

--- a/src/mips/openbios/handlers/irq.c
+++ b/src/mips/openbios/handlers/irq.c
@@ -42,17 +42,17 @@ static __attribute__((section(".ramtext"))) int IRQVerifier(void) {
     // they can't be cached by the compiler, if this is what the
     // original author was thinking.
     uint32_t mask = IMASK & IREG;
-    if ((mask & 0x004) != 0) deliverEvent(0xf0000003, 0x1000);
-    if ((mask & 0x200) != 0) deliverEvent(0xf0000009, 0x1000);
-    if ((mask & 0x002) != 0) deliverEvent(0xf0000002, 0x1000);
-    if ((mask & 0x400) != 0) deliverEvent(0xf000000a, 0x1000);
-    if ((mask & 0x100) != 0) deliverEvent(0xf000000b, 0x1000);
-    if ((mask & 0x001) != 0) deliverEvent(0xf0000001, 0x1000);
-    if ((mask & 0x010) != 0) deliverEvent(0xf0000005, 0x1000);
-    if ((mask & 0x020) != 0) deliverEvent(0xf0000006, 0x1000); // Yes that's a copy-paste mistake from the BIOS code directly.
-    if ((mask & 0x040) != 0) deliverEvent(0xf0000006, 0x1000); // Keeping it this way to avoid breaking stuff.
-    if ((mask & 0x080) != 0) deliverEvent(0xf0000008, 0x1000);
-    if ((mask & 0x008) != 0) deliverEvent(0xf0000004, 0x1000);
+    if ((mask & 0x004) != 0) deliverEvent(EVENT_CDROM, 0x1000);
+    if ((mask & 0x200) != 0) deliverEvent(EVENT_SPU, 0x1000);
+    if ((mask & 0x002) != 0) deliverEvent(EVENT_GPU, 0x1000);
+    if ((mask & 0x400) != 0) deliverEvent(EVENT_PIO, 0x1000);
+    if ((mask & 0x100) != 0) deliverEvent(EVENT_SIO, 0x1000);
+    if ((mask & 0x001) != 0) deliverEvent(EVENT_VBLANK, 0x1000);
+    if ((mask & 0x010) != 0) deliverEvent(EVENT_RTC0, 0x1000);
+    if ((mask & 0x020) != 0) deliverEvent(EVENT_RTC1, 0x1000); // Yes that's a copy-paste mistake from the BIOS code directly.
+    if ((mask & 0x040) != 0) deliverEvent(EVENT_RTC1, 0x1000); // Keeping it this way to avoid breaking stuff.
+    if ((mask & 0x080) != 0) deliverEvent(EVENT_CONTROLLER, 0x1000);
+    if ((mask & 0x008) != 0) deliverEvent(EVENT_DMA, 0x1000);
     uint32_t ackMask = 0;
     int * ptr = s_IRQsAutoAck;
     for (int IRQ = 0; IRQ < 11; IRQ++, ptr++) {

--- a/src/mips/openbios/kernel/events.h
+++ b/src/mips/openbios/kernel/events.h
@@ -26,6 +26,32 @@ SOFTWARE.
 
 #pragma once
 
+enum event_class {
+    EVENT_VBLANK     = 0xf0000001, // IRQ0
+    EVENT_GPU        = 0xf0000002, // IRQ1
+    EVENT_CDROM      = 0xf0000003, // IRQ2
+    EVENT_DMA        = 0xf0000004, // IRQ3
+    EVENT_RTC0       = 0xf0000005, // IRQ4 - Timer 0
+    EVENT_RTC1       = 0xf0000006, // IRQ5 - Timer 1 or 2
+    //  0xf0000007 - unused, should be Timer 2
+    EVENT_CONTROLLER = 0xf0000008, // IRQ7
+    EVENT_SPU        = 0xf0000009, // IRQ9
+    EVENT_PIO        = 0xf000000A, // IRQ10
+    EVENT_SIO        = 0xf000000B, // IRQ8
+};
+
+enum event_mode {
+    EVENT_MODE_CALLBACK    = 0x1000,
+    EVENT_MODE_NO_CALLBACK = 0x2000,
+};
+
+enum event_flag {
+    EVENT_FLAG_FREE       = 0x0000,
+    EVENT_FLAG_DISABLED   = 0x1000,
+    EVENT_FLAG_ENABLED    = 0x2000,
+    EVENT_FLAG_PENDING    = 0x4000,
+};
+
 int initEvents(int count);
 uint32_t openEvent(uint32_t class, uint32_t spec, uint32_t mode, void (*handler)());
 void deliverEvent(uint32_t class, uint32_t spec);


### PR DESCRIPTION
- Bash build script for macOS/Linux.
- Suppressed `warning: always_inline function might not be inlinable [-Wattributes]` warning
- Refactored events to use constants for classes, modes and flags (no event spec for now)
- **BUGFIX**: `deliverEvent` was doing an assignment instead of comparison which caused to destroy event if it wasn't fired immediately (no event was delivered since the callback is null)
```c
// was
else if ((ptr->mode = 0x1000) && ptr->handler) ptr->handler();
// changed to
else if (ptr->mode == EVENT_MODE_CALLBACK && ptr->handler)
```
After this fix I was able to boot WipeOut using openbios.