### PR TITLE
Threads

### DIFF
--- a/src/mips/common/hardware/irq.h
+++ b/src/mips/common/hardware/irq.h
@@ -39,5 +39,5 @@ enum IRQ {
     IRQ_CONTROLLER = 1 << 7,
     IRQ_SIO        = 1 << 8,
     IRQ_SPU        = 1 << 9,
-    IRQ_LIGHTGUN   = 1 << 10,
+    IRQ_PIO        = 1 << 10,
 };

--- a/src/mips/common/hardware/irq.h
+++ b/src/mips/common/hardware/irq.h
@@ -1,0 +1,43 @@
+/*
+
+MIT License
+
+Copyright (c) 2019 PCSX-Redux authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+#pragma once
+
+#include "common/compiler/stdint.h"
+
+enum IRQ {
+    IRQ_VBLANK     = 1 << 0,
+    IRQ_GPU        = 1 << 1,
+    IRQ_CDROM      = 1 << 2,
+    IRQ_DMA        = 1 << 3,
+    IRQ_TIMER0     = 1 << 4,
+    IRQ_TIMER1     = 1 << 5,
+    IRQ_TIMER2     = 1 << 6,
+    IRQ_CONTROLLER = 1 << 7,
+    IRQ_SIO        = 1 << 8,
+    IRQ_SPU        = 1 << 9,
+    IRQ_LIGHTGUN   = 1 << 10,
+};

--- a/src/mips/common/syscalls/syscalls.h
+++ b/src/mips/common/syscalls/syscalls.h
@@ -168,10 +168,10 @@ static __attribute__((always_inline)) void syscall_kfree(void * ptr) {
     return ((void(*)(void *))0xb0)(ptr);
 }
 
-static __attribute__((always_inline)) void syscall_deliverEvent(uint32_t class, uint32_t mode) {
+static __attribute__((always_inline)) void syscall_deliverEvent(uint32_t class, uint32_t spec) {
     register volatile int n asm("t1") = 0x07;
     __asm__ volatile("" : "=r"(n) : "r"(n));
-    ((void(*)(uint32_t, uint32_t))0xb0)(class, mode);
+    ((void(*)(uint32_t, uint32_t))0xb0)(class, spec);
 }
 
 static __attribute__((always_inline)) uint32_t syscall_openEvent(uint32_t class, uint32_t spec, uint32_t mode, void * handler) {

--- a/src/mips/common/syscalls/syscalls.h
+++ b/src/mips/common/syscalls/syscalls.h
@@ -46,6 +46,13 @@ static __attribute__((always_inline)) void leaveCriticalSection() {
     __asm__ volatile("syscall\n" : "=r"(n) : "r"(n) : "at", "v0", "v1", "a1", "a2", "a3", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8", "t9", "memory");
 }
 
+static __attribute__((always_inline)) int changeThreadSubFunction(uint32_t address) {
+    register volatile int n asm("a0") = 3;
+    register volatile int tcb asm("a1") = address;
+    __asm__ volatile("syscall\n" : "=r"(n) : "r"(n), "r"(tcb) : "at", "v0", "v1", "a2", "a3", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8", "t9", "memory");
+    return 1; // TODO: Fixme - v0 should be returned
+}
+
 /* A0 table */
 static __attribute__((always_inline)) int syscall_strcmp(const char * s1, const char * s2) {
     register volatile int n asm("t1") = 0x17;

--- a/src/mips/openbios/handlers/irq.c
+++ b/src/mips/openbios/handlers/irq.c
@@ -43,17 +43,17 @@ static __attribute__((section(".ramtext"))) int IRQVerifier(void) {
     // they can't be cached by the compiler, if this is what the
     // original author was thinking.
     uint32_t mask = IMASK & IREG;
-    if ((mask & 0x004) != 0) deliverEvent(EVENT_CDROM, 0x1000);
-    if ((mask & 0x200) != 0) deliverEvent(EVENT_SPU, 0x1000);
-    if ((mask & 0x002) != 0) deliverEvent(EVENT_GPU, 0x1000);
-    if ((mask & 0x400) != 0) deliverEvent(EVENT_PIO, 0x1000);
-    if ((mask & 0x100) != 0) deliverEvent(EVENT_SIO, 0x1000);
-    if ((mask & 0x001) != 0) deliverEvent(EVENT_VBLANK, 0x1000);
-    if ((mask & 0x010) != 0) deliverEvent(EVENT_RTC0, 0x1000);
-    if ((mask & 0x020) != 0) deliverEvent(EVENT_RTC1, 0x1000); // Yes that's a copy-paste mistake from the BIOS code directly.
-    if ((mask & 0x040) != 0) deliverEvent(EVENT_RTC1, 0x1000); // Keeping it this way to avoid breaking stuff.
-    if ((mask & 0x080) != 0) deliverEvent(EVENT_CONTROLLER, 0x1000);
-    if ((mask & 0x008) != 0) deliverEvent(EVENT_DMA, 0x1000);
+    if ((mask & IRQ_CDROM) != 0)      deliverEvent(EVENT_CDROM, 0x1000);
+    if ((mask & IRQ_SPU) != 0)        deliverEvent(EVENT_SPU, 0x1000);
+    if ((mask & IRQ_GPU) != 0)        deliverEvent(EVENT_GPU, 0x1000);
+    if ((mask & IRQ_PIO) != 0)        deliverEvent(EVENT_PIO, 0x1000);
+    if ((mask & IRQ_SIO) != 0)        deliverEvent(EVENT_SIO, 0x1000);
+    if ((mask & IRQ_VBLANK) != 0)     deliverEvent(EVENT_VBLANK, 0x1000);
+    if ((mask & IRQ_TIMER0) != 0)     deliverEvent(EVENT_RTC0, 0x1000);
+    if ((mask & IRQ_TIMER1) != 0)     deliverEvent(EVENT_RTC1, 0x1000); // Yes that's a copy-paste mistake from the BIOS code directly.
+    if ((mask & IRQ_TIMER2) != 0)     deliverEvent(EVENT_RTC1, 0x1000); // Keeping it this way to avoid breaking stuff.
+    if ((mask & IRQ_CONTROLLER) != 0) deliverEvent(EVENT_CONTROLLER, 0x1000);
+    if ((mask & IRQ_DMA) != 0)        deliverEvent(EVENT_DMA, 0x1000);
     uint32_t ackMask = 0;
     int * ptr = s_IRQsAutoAck;
     for (int IRQ = 0; IRQ < 11; IRQ++, ptr++) {
@@ -104,7 +104,6 @@ static __attribute__((section(".ramtext"))) int T2verifier() {
     if (((IMASK & IRQ_TIMER2) == 0) || ((IREG & IRQ_TIMER2) == 0)) return 0;
     deliverEvent(0xf2000002, 2);
     return 1;
-
 }
 static __attribute__((section(".ramtext"))) void T2handler(int v) {
     if (!s_timersAutoAck[2]) return;

--- a/src/mips/openbios/handlers/syscall.c
+++ b/src/mips/openbios/handlers/syscall.c
@@ -34,8 +34,7 @@ SOFTWARE.
 #include "openbios/kernel/threads.h"
 
 static __attribute__((section(".ramtext"))) int syscallVerifier() {
-    struct Thread ** blocks = __globals.blocks;
-    struct Thread * currentThread = blocks[0];
+    struct Thread * currentThread = __globals.processes[0].thread;
     unsigned exCode = currentThread->registers.Cause & 0x3c;
     switch (exCode) {
         case 0x00:
@@ -54,7 +53,7 @@ static __attribute__((section(".ramtext"))) int syscallVerifier() {
                     currentThread->registers.SR |= 0x404;
                     break;
                 case 3:
-                    blocks[0] = (struct Thread *) currentThread->registers.GPR.n.a1;
+                    __globals.processes[0].thread = (struct Thread*)currentThread->registers.GPR.n.a1;
                     currentThread->registers.GPR.n.v0 = 1;
                     break;
                 default:

--- a/src/mips/openbios/kernel/events.c
+++ b/src/mips/openbios/kernel/events.c
@@ -92,7 +92,13 @@ __attribute__((section(".ramtext"))) void deliverEvent(uint32_t class, uint32_t 
 
 int enableEvent(uint32_t event) {
     struct EventInfo * ptr = __globals.events + (event & 0xffff);
-    if (ptr->flags) ptr->flags = EVENT_FLAG_ENABLED;
+    if (ptr->flags != 0) ptr->flags = EVENT_FLAG_ENABLED;
+    return 1;
+}
+
+int disableEvent(uint32_t event) {
+    struct EventInfo * ptr = __globals.events + (event & 0xffff);
+    if (ptr->flags != 0) ptr->flags = EVENT_FLAG_DISABLED;
     return 1;
 }
 

--- a/src/mips/openbios/kernel/events.h
+++ b/src/mips/openbios/kernel/events.h
@@ -33,5 +33,6 @@ void deliverEvent(uint32_t class, uint32_t spec);
 void undeliverEvent(uint32_t class, uint32_t spec);
 int testEvent(uint32_t event);
 int enableEvent(uint32_t event);
+int disableEvent(uint32_t event);
 int closeEvent(uint32_t event);
 int waitEvent(uint32_t event);

--- a/src/mips/openbios/kernel/globals.h
+++ b/src/mips/openbios/kernel/globals.h
@@ -39,10 +39,10 @@ extern struct {
 extern struct {
     /* 100 */ struct HandlersStorage * handlersArray;
     /* 104 */ uint32_t handlersArraySize;
-    /* 108 */ struct Thread ** blocks;
-    /* 10c */ struct Thread * threads;
-    /* 110 */ uint32_t xxx_04;
-    /* 114 */ uint32_t xxx_05;
+    /* 108 */ struct Process * processes;
+    /* 10c */ uint32_t processBlockSize;
+    /* 110 */ struct Thread * threads;
+    /* 114 */ uint32_t threadBlockSize;
     /* 118 */ uint32_t xxx_06;
     /* 11c */ uint32_t xxx_07;
     /* 120 */ struct EventInfo * events;

--- a/src/mips/openbios/kernel/handlers.c
+++ b/src/mips/openbios/kernel/handlers.c
@@ -49,6 +49,7 @@ SOFTWARE.
 #include "openbios/kernel/misc.h"
 #include "openbios/kernel/psxexe.h"
 #include "openbios/kernel/setjmp.h"
+#include "openbios/kernel/threads.h"
 #include "openbios/main/main.h"
 #include "openbios/sio0/pad.h"
 #include "openbios/sio0/sio0.h"
@@ -180,8 +181,8 @@ void * B0table[0x60] = {
     malloc, free, unimplemented, unimplemented, // 00
     unimplemented, unimplemented, unimplemented, deliverEvent, // 04
     openEvent, closeEvent, waitEvent, testEvent, // 08
-    enableEvent, unimplemented, unimplemented, unimplemented, // 0c
-    unimplemented, unimplemented, initPad, startPad, // 10
+    enableEvent, disableEvent, openThread, closeThread, // 0c
+    changeThread, unimplemented, initPad, startPad, // 10
     stopPad, initPadHighLevel, readPadHighLevel, returnFromException, // 14
     setDefaultExceptionJmpBuf, setExceptionJmpBuf, unimplemented, unimplemented, // 18
     unimplemented, unimplemented, unimplemented, unimplemented, // 1c
@@ -205,7 +206,7 @@ void * B0table[0x60] = {
 
 void * C0table[0x20] = {
     enqueueRCntIrqs, enqueueSyscallHandler, sysEnqIntRP, sysDeqIntRP, // 00
-    unimplemented, unimplemented, unimplemented, installExceptionHandler, // 04
+    unimplemented, getFreeTCBslot, unimplemented, installExceptionHandler, // 04
     unimplemented, unimplemented, setTimerAutoAck, unimplemented, // 08
     enqueueIrqHandler, unimplemented, unimplemented, unimplemented, // 0c
     unimplemented, unimplemented, setupFileIO, unimplemented, // 10

--- a/src/mips/openbios/kernel/handlers.c
+++ b/src/mips/openbios/kernel/handlers.c
@@ -169,7 +169,7 @@ static const void * romA0table[0xc0] = {
     setConfiguration, getConfiguration, setCDRomIRQAutoAck, setMemSize, // 9c
     unimplemented, unimplemented, enqueueCDRomHandlers, dequeueCDRomHandlers, // a0
     unimplemented, unimplemented, unimplemented, unimplemented, // a4
-    unimplemented, unimplemented, unimplemented, unimplemented, // a8
+    unimplemented, unimplemented, unimplemented, dummyMC, // a8
     unimplemented, unimplemented, unimplemented, unimplemented, // ac
     unimplemented, unimplemented, ioabortraw, unimplemented, // b0
     unimplemented, unimplemented, unimplemented, unimplemented, // b4
@@ -197,8 +197,8 @@ void * B0table[0x60] = {
     unimplemented, unimplemented, unimplemented, unimplemented, // 40
     unimplemented, unimplemented, unimplemented, addDevice, // 44
     unimplemented, unimplemented, dummyMC, dummyMC, // 48
-    unimplemented, unimplemented, unimplemented, unimplemented, // 4c
-    unimplemented, unimplemented, unimplemented, unimplemented, // 50
+    unimplemented, unimplemented, dummyMC, unimplemented, // 4c
+    dummyMC, unimplemented, unimplemented, unimplemented, // 50
     unimplemented, unimplemented, getC0table, getB0table, // 54
     unimplemented, unimplemented, unimplemented, setSIO0AutoAck, // 58
     unimplemented, unimplemented, unimplemented, unimplemented, // 5c
@@ -207,7 +207,7 @@ void * B0table[0x60] = {
 void * C0table[0x20] = {
     enqueueRCntIrqs, enqueueSyscallHandler, sysEnqIntRP, sysDeqIntRP, // 00
     unimplemented, getFreeTCBslot, unimplemented, installExceptionHandler, // 04
-    unimplemented, unimplemented, setTimerAutoAck, unimplemented, // 08
+    sysInitMemory, unimplemented, setTimerAutoAck, unimplemented, // 08
     enqueueIrqHandler, unimplemented, unimplemented, unimplemented, // 0c
     unimplemented, unimplemented, setupFileIO, unimplemented, // 10
     unimplemented, unimplemented, unimplemented, unimplemented, // 14

--- a/src/mips/openbios/kernel/misc.c
+++ b/src/mips/openbios/kernel/misc.c
@@ -46,3 +46,7 @@ void setMemSize(int memSize) {
     __globals60.ramsize = memSize;
     psxprintf("Change effective memory : %d MBytes\n", memSize);
 }
+
+void sysInitMemory(void *heapStart, size_t heapSize) {
+    // FIXME: STUB
+}

--- a/src/mips/openbios/kernel/misc.h
+++ b/src/mips/openbios/kernel/misc.h
@@ -25,5 +25,7 @@ SOFTWARE.
 */
 
 #pragma once
+#include <stddef.h>
 
 void setMemSize(int memSize);
+void sysInitMemory(void* heapStart, size_t heapSize);

--- a/src/mips/openbios/kernel/psxexe.c
+++ b/src/mips/openbios/kernel/psxexe.c
@@ -37,7 +37,7 @@ SOFTWARE.
 
 static int readHeader(int fd, struct psxExeHeader * header) {
     if (syscall_read(fd, g_readBuffer, 2048) >= 2048) {
-        memcpy(header, g_readBuffer + 16, sizeof(struct psxExeHeader));
+        memcpy(header, g_readBuffer + 16, 60); // BIOS does not copy the whole struct
         return 1;
     }
 
@@ -74,7 +74,7 @@ void loadAndExec(const char * filename, uint32_t stackStart, uint32_t stackSize)
     char c;
     char * ptr = localFilename;
 
-    while ((c = *filename) != 0 && (c != ':')) {
+    while (((c = *filename) != 0) && (c != ':')) {
         *ptr++ = c;
         filename++;
     }
@@ -82,7 +82,7 @@ void loadAndExec(const char * filename, uint32_t stackStart, uint32_t stackSize)
     while ((*ptr++ = toupper(*filename++)) != 0);
 
     ptr = localFilename;
-    while (((c = *ptr) != 0) || (c != ';')) ptr++;
+    while (((c = *ptr) != 0) && (c != ';')) ptr++;
     if (c == 0) strcat(localFilename, ";1");
 
     static uint32_t savedStackStart;

--- a/src/mips/openbios/kernel/threads.h
+++ b/src/mips/openbios/kernel/threads.h
@@ -31,7 +31,7 @@ struct Registers {
             uint32_t r0, at, v0, v1, a0, a1, a2, a3;
             uint32_t t0, t1, t2, t3, t4, t5, t6, t7;
             uint32_t s0, s1, s2, s3, s4, s5, s6, s7;
-            uint32_t t8, t9, k0, k1, gp, sp, s8, ra;
+            uint32_t t8, t9, k0, k1, gp, sp, fp, ra;
         } n;
         uint32_t r[32];
     } GPR;
@@ -47,4 +47,13 @@ struct Thread {
     uint32_t unknown[9];
 };
 
-int initThreads(int blocks, int count);
+struct Process {
+    struct Thread* thread;
+};
+
+int initThreads(int processCount, int threadCount);
+
+int getFreeTCBslot();
+int openThread(uint32_t pc, uint32_t sp, uint32_t gp);
+int closeThread(int threadId);
+int changeThread(int threadId);

--- a/src/mips/openbios/kernel/vectors.s
+++ b/src/mips/openbios/kernel/vectors.s
@@ -51,9 +51,9 @@ exceptionHandler:
     nop
     nop
     li    $k0, %lo(__globals)
-    lw    $k0, 8($k0) /* ->TCBArrayPtr */
+    lw    $k0, 8($k0) /* ->processes[0] */
     nop
-    lw    $k0, 0($k0) /* [0] */
+    lw    $k0, 0($k0) /* thread */
     nop
     addi  $k0, 8 /* &->Registers */
     /* From here on, $k0 is the pointer to the registers structure. */
@@ -192,9 +192,9 @@ next_priority:
 
     /* nobody took the call ? then longjmp into the unhandled exception buffer. */
     li    $k0, %lo(__globals) /* no idea why k0 is used again here... */
-    lw    $k0, 8($k0) /* ->TCBArrayPtr */
+    lw    $k0, 8($k0) /* ->processes[0] */
     lui   $a0, %hi(g_exceptionJmpBufPtr)
-    lw    $k0, 0($k0) /* [0] */
+    lw    $k0, 0($k0) /* thread */
     addiu $a0, %lo(g_exceptionJmpBufPtr)
     lw    $a0, 0($a0) /* such bad code... why... */
     li    $a1, 1 /* whyyyyy */
@@ -269,7 +269,7 @@ returnFromException:
     lw    $fp, 0x78($k1)
     lw    $ra, 0x7c($k1)
     jr    $k0
-    .word 0x42000010 /* rfe */
+    rfe
 
     .section .text, "ax", @progbits
     .align 2

--- a/src/mips/openbios/main/main.c
+++ b/src/mips/openbios/main/main.c
@@ -226,7 +226,7 @@ static void kernelSetup() {
     // allocator implementation, so let's free stuff instead
     // syscall_sysInitMemory(&heapBase, heapSize);
     syscall_kfree(__globals.events);
-    syscall_kfree(__globals.blocks);
+    syscall_kfree(__globals.processes);
     syscall_kfree(__globals.threads);
     syscall_kfree(__globals.handlersArray);
 


### PR DESCRIPTION
- Refactored IREG and IMASK to use IRQ_### constants
- Added `disableEvent` (THPS2 is using it)
- Changed `syscall_deliverEvent(uint32_t class, uint32_t mode)` to `syscall_deliverEvent(uint32_t class, uint32_t spec)`
- Fixed infinite loop in loadAndExec path parsing
```
// was
    while (((c = *ptr) != 0) || (c != ';')) ptr++;
// is
    while (((c = *ptr) != 0) && (c != ';')) ptr++;
```

- Changed `__globals` structure to store Process and Thread array - there is always only one process that simply points to currently active thread.
- Added `openThread`, `closeThread`, `changeThread`, `getFreTCBslot` functions
- Added `changeThreadSubFunction` syscall - **Need help there, don't know how to force GCC asm to return `v0`, hardcoded `return 1` for now**

- Rewritten findDirectoryEntryForFilename which was not able to run find .exe in subdirectories - needed for Mega Men X3, MGS. The function was looking for a subdirectory entry when already entered the subdirectory. The original function was too messy to see what was wrong there.
- Added stubs for `sysInitMemory` and few memory card functions - allows more games to boot.

Metal Gear Solid is one of the games that use PSX Threads, sadly it loops with `ChangeThread` behavior - might be memory card related.