### PR TITLE
Update ps-exe.ld

### DIFF
--- a/src/mips/cpe.ld
+++ b/src/mips/cpe.ld
@@ -30,10 +30,10 @@ OUTPUT_FORMAT("binary")
 EXTERN(_start)
 ENTRY(_start)
 
-TLOAD_ADDR = DEFINED(_TLOAD_ADDR) ? TLOAD_ADDR : 0x80010000;
+TLOAD_ADDR = DEFINED(TLOAD_ADDR) ? TLOAD_ADDR : 0x80010000;
 
 MEMORY {
-    loader      : ORIGIN = 0x8000ffea, LENGTH = 22
+    loader      : ORIGIN = (TLOAD_ADDR - 22), LENGTH = 22
     ram (rwx)   : ORIGIN = 0x80010000, LENGTH = 2M - 0x10000
     dcache      : ORIGIN = 0x1f800000, LENGTH = 0x400
 }

--- a/src/mips/ps-exe.ld
+++ b/src/mips/ps-exe.ld
@@ -30,10 +30,10 @@ OUTPUT_FORMAT("binary")
 EXTERN(_start)
 ENTRY(_start)
 
-TLOAD_ADDR = DEFINED(_TLOAD_ADDR) ? TLOAD_ADDR : 0x80010000;
+TLOAD_ADDR = DEFINED(TLOAD_ADDR) ? TLOAD_ADDR : 0x80010000;
 
 MEMORY {
-    loader      : ORIGIN = 0x8000f800, LENGTH = 2048
+    loader      : ORIGIN = (TLOAD_ADDR - 0x800), LENGTH = 2048
     ram (rwx)   : ORIGIN = 0x80010000, LENGTH = 2M - 0x10000
     dcache      : ORIGIN = 0x1f800000, LENGTH = 0x400
 }
@@ -91,6 +91,7 @@ SECTIONS {
         LONG(0);
 
         /* Skip the remaining fields as they're not supported by the BIOS */
+		/* e.g. 2048 header bytes minus whatever we've actually used */
         . = . + 1992;
     } > loader
 

--- a/src/mips/ps-exe.ld
+++ b/src/mips/ps-exe.ld
@@ -91,7 +91,7 @@ SECTIONS {
         LONG(0);
 
         /* Skip the remaining fields as they're not supported by the BIOS */
-		/* e.g. 2048 header bytes minus whatever we've actually used */
+        /* e.g. 2048 header bytes minus whatever we've actually used */
         . = . + 1992;
     } > loader
 


### PR DESCRIPTION
-Remove a stray underscore in _TLOAD_ADDR
-Generate the header at (TLOAD_ADDR-0x800) so a ps-exe org'd to e.g. 80100000 won't have a megabyte of zeros between the header and the first section.