### PR TITLE
Approach for supporting Overlays

### DIFF
--- a/src/mips/common.mk
+++ b/src/mips/common.mk
@@ -43,11 +43,11 @@ LDFLAGS += $(LDFLAGS_$(BUILD))
 OBJS += $(addsuffix .o, $(basename $(SRCS)))
 
 all: dep $(BINDIR)$(TARGET).$(TYPE)
+
+$(BINDIR)$(TARGET).$(TYPE): $(BINDIR)$(TARGET).elf
 ifneq ($(strip $(BINDIR)),)
 	mkdir -p $(BINDIR)
 endif
-
-$(BINDIR)$(TARGET).$(TYPE): $(BINDIR)$(TARGET).elf
 	$(PREFIX)-objcopy $(addprefix -R , $(OVERLAYSECTION)) -O binary $< $@
 	$(foreach ovl, $(OVERLAYSECTION), $(PREFIX)-objcopy -j $(ovl) -O binary $< $(BINDIR)Overlay$(ovl);)
 

--- a/src/mips/common.mk
+++ b/src/mips/common.mk
@@ -70,7 +70,7 @@ DEPS += $(patsubst %.s,  %.dep,$(filter %.s,$(SRCS)))
 dep: $(DEPS)	
 
 makeDir:
-ifneq ($(strip $(OVERLAYSCRIPT)),)
+ifneq ($(strip $(BINDIR)),)
 	mkdir -p $(BINDIR)
 endif
 

--- a/src/mips/cpe.ld
+++ b/src/mips/cpe.ld
@@ -151,7 +151,7 @@ SECTIONS {
     . = ALIGN(4);
     __bss_end = .;
 
-    __heap_start = .;
+    __heap_start = __heap_bas;
 
     __end = .;
 

--- a/src/mips/default.ld
+++ b/src/mips/default.ld
@@ -1,0 +1,1 @@
+__heap_base     = __bss_end;

--- a/src/mips/ps-exe.ld
+++ b/src/mips/ps-exe.ld
@@ -182,8 +182,9 @@ SECTIONS {
     . = ALIGN(4);
     __bss_end = .;
 
-    __heap_start = .;
-
+    __heap_start = __heap_base;
+	
+	. = ADDR(.text) - 0x800;
     __end = .;
 
     /DISCARD/ : { *(.MIPS.abiflags) }


### PR DESCRIPTION
This is my approach for how to support overlays, while still support non overlay projects.
To use an Overlay, a user would need to define in his MakeFile:

- OVERLAYSCRIPT

    This contains the name of there linker script inside there project. This linker script needs to define the overlay information and set a value for __heap_base
   

- OVERLAYSECTION

    This list contains the name of the overlay sections, that will be stripped from the executable. 
    
The make file also places the .elf and .ps-exe/.cpe file - including the overlays into a folder called "bin", which needs to exist.
Overlay files will be named "Overlay" follwed by there section name.

If OVERLAYSCRIPT is defined, the makefile defaults back to default.ld, containing the "old" definition for heapbase.