### PR TITLE
Added ImGui window to customise theme, fixed InterruptScalar using deprecated function

### DIFF
--- a/src/gui/gui.cc
+++ b/src/gui/gui.cc
@@ -592,8 +592,6 @@ void PCSX::GUI::endFrame() {
 
     if (m_showDemo) ImGui::ShowDemoWindow();
 
-
-
     ImGui::SetNextWindowPos(ImVec2(10, 20), ImGuiCond_FirstUseEver);
     ImGui::SetNextWindowSize(ImVec2(1024, 512), ImGuiCond_FirstUseEver);
     m_mainVRAMviewer.render(m_VRAMTexture);

--- a/src/gui/gui.cc
+++ b/src/gui/gui.cc
@@ -530,6 +530,8 @@ void PCSX::GUI::endFrame() {
             }
             ImGui::Separator();
             if (ImGui::BeginMenu(_("Help"))) {
+                ImGui::MenuItem(_("ImGui Themes"), nullptr, &m_showThemes);
+                ImGui::Separator();
                 ImGui::MenuItem(_("Show ImGui Demo"), nullptr, &m_showDemo);
                 ImGui::Separator();
                 ImGui::MenuItem(_("About"), nullptr, &m_showAbout);
@@ -589,6 +591,8 @@ void PCSX::GUI::endFrame() {
     }
 
     if (m_showDemo) ImGui::ShowDemoWindow();
+
+
 
     ImGui::SetNextWindowPos(ImVec2(10, 20), ImGuiCond_FirstUseEver);
     ImGui::SetNextWindowSize(ImVec2(1024, 512), ImGuiCond_FirstUseEver);
@@ -666,6 +670,7 @@ void PCSX::GUI::endFrame() {
         m_breakpoints.draw(_("Breakpoints"));
     }
 
+    showThemes();
     about();
     interruptsScaler();
 
@@ -982,9 +987,28 @@ void PCSX::GUI::interruptsScaler() {
         }
         unsigned counter = 0;
         for (auto& scale : g_emulator->m_psxCpu->m_interruptScales) {
-            ImGui::SliderFloat(names[counter], &scale, 0.0f, 100.0f, "%.3f", 5.0f);
+            ImGui::SliderFloat(names[counter], &scale, 0.0f, 100.0f, "%.3f", ImGuiSliderFlags_AlwaysClamp);
             counter++;
         }
+    }
+    ImGui::End();
+}
+
+void PCSX::GUI::showThemes() {
+    if (!m_showThemes) return;
+    ImGui::Begin("Theme selector", &m_showThemes);
+    if (ImGui::BeginCombo("Themes", curr_item, ImGuiComboFlags_HeightLarge)) {
+        for (int n = 0; n < IM_ARRAYSIZE(imgui_themes); n++) {
+            bool selected = (curr_item == imgui_themes[n]);
+            if (ImGui::Selectable(imgui_themes[n], selected)) {
+                curr_item = imgui_themes[n];
+                apply_theme(n);
+            }
+            if (selected) {
+                ImGui::SetItemDefaultFocus();
+            }
+        }
+        ImGui::EndCombo();
     }
     ImGui::End();
 }

--- a/src/gui/gui.cc
+++ b/src/gui/gui.cc
@@ -994,8 +994,9 @@ void PCSX::GUI::interruptsScaler() {
 
 void PCSX::GUI::showThemes() {
     if (!m_showThemes) return;
-    ImGui::Begin("Theme selector", &m_showThemes);
-    if (ImGui::BeginCombo("Themes", curr_item, ImGuiComboFlags_HeightLarge)) {
+    const char* imgui_themes[6] = {"Default", "Classic", "Light", "Cherry", "Mono", "Dracula"};  // Used for theme combo box
+    ImGui::Begin(_("Theme selector"), &m_showThemes);
+    if (ImGui::BeginCombo(_("Themes"), curr_item, ImGuiComboFlags_HeightLarge)) {
         for (int n = 0; n < IM_ARRAYSIZE(imgui_themes); n++) {
             bool selected = (curr_item == imgui_themes[n]);
             if (ImGui::Selectable(imgui_themes[n], selected)) {

--- a/src/gui/gui.cc
+++ b/src/gui/gui.cc
@@ -994,7 +994,7 @@ void PCSX::GUI::interruptsScaler() {
 
 void PCSX::GUI::showThemes() {
     if (!m_showThemes) return;
-    const char* imgui_themes[6] = {"Default", "Classic", "Light", "Cherry", "Mono", "Dracula"};  // Used for theme combo box
+    static const char* imgui_themes[6] = {"Default", "Classic", "Light", "Cherry", "Mono", "Dracula"};  // Used for theme combo box
     ImGui::Begin(_("Theme selector"), &m_showThemes);
     if (ImGui::BeginCombo(_("Themes"), curr_item, ImGuiComboFlags_HeightLarge)) {
         for (int n = 0; n < IM_ARRAYSIZE(imgui_themes); n++) {

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -109,6 +109,7 @@ class GUI final {
     void endFrame();
 
     bool configure();
+    void showThemes(); // Theme window : Allows for custom imgui themes
     void about();
     void interruptsScaler();
 
@@ -158,6 +159,7 @@ class GUI final {
     bool &m_fullscreenRender = {settings.get<FullscreenRender>().value};
     bool &m_showMenu = {settings.get<ShowMenu>().value};
     int &m_idleSwapInterval = {settings.get<IdleSwapInterval>().value};
+    bool m_showThemes = false;
     bool m_showDemo = false;
     bool m_showAbout = false;
     bool m_showInterruptsScaler = false;
@@ -207,6 +209,14 @@ class GUI final {
     EventBus::Listener m_listener;
 
     void shellReached();
+
+    // ImGui themes: Defined in themes/imgui_themes.cc
+    const char *imgui_themes[6] = {"Default", "Classic", "Light", "Cherry", "Mono","Dracula"};  // Used for theme combo box
+    const char *curr_item = imgui_themes[0];
+    void apply_theme(int n);
+    void cherry_theme();
+    void mono_theme();
+    void dracula_theme();
 
     PCSX::u8string m_exeToLoad;
     Notifier m_notifier = {[]() { return _("Notification"); }};

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -210,9 +210,8 @@ class GUI final {
 
     void shellReached();
 
-    // ImGui themes: Defined in themes/imgui_themes.cc
-    const char *imgui_themes[6] = {"Default", "Classic", "Light", "Cherry", "Mono","Dracula"};  // Used for theme combo box
-    const char *curr_item = imgui_themes[0];
+    // ImGui themes: Defined in themes/imgui_themes.c
+    const char *curr_item = "Default";
     void apply_theme(int n);
     void cherry_theme();
     void mono_theme();

--- a/src/gui/themes/imgui_themes.cc
+++ b/src/gui/themes/imgui_themes.cc
@@ -1,0 +1,177 @@
+#pragma once
+#include "gui/gui.h"
+
+void PCSX::GUI::apply_theme(int n) {
+    switch (n) {
+    case 0:
+        ImGui::StyleColorsDark();
+        break;
+    case 1:
+        ImGui::StyleColorsClassic();
+        break;
+    case 2:
+        ImGui::StyleColorsLight();
+        break;
+    case 3:
+        cherry_theme();
+        break;
+    case 4:
+        mono_theme();
+        break;
+    case 5:
+        dracula_theme();
+        break;
+    }
+}
+
+void PCSX::GUI::cherry_theme() { //Theme by: r-lyeh
+    ImGui::StyleColorsDark(); //Reset styles
+
+    auto& style = ImGui::GetStyle();
+    style.Colors[ImGuiCol_Text] = ImVec4(0.860f, 0.930f, 0.890f, 0.78f);
+    style.Colors[ImGuiCol_TextDisabled] = ImVec4(0.860f, 0.930f, 0.890f, 0.28f);
+    style.Colors[ImGuiCol_WindowBg] = ImVec4(0.13f, 0.14f, 0.17f, 1.00f);
+    style.Colors[ImGuiCol_ChildBg] = ImVec4(0.200f, 0.220f, 0.270f, 0.58f);
+    style.Colors[ImGuiCol_PopupBg] = ImVec4(0.200f, 0.220f, 0.270f, 0.9f);
+    style.Colors[ImGuiCol_Border] = ImVec4(0.31f, 0.31f, 1.00f, 0.00f);
+    style.Colors[ImGuiCol_BorderShadow] = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
+    style.Colors[ImGuiCol_FrameBg] = ImVec4(0.200f, 0.220f, 0.270f,1.00f);
+    style.Colors[ImGuiCol_FrameBgHovered] = ImVec4(0.455f, 0.198f, 0.301f, 0.78);
+    style.Colors[ImGuiCol_FrameBgActive] = ImVec4(0.455f, 0.198f, 0.301f, 1.00f);
+    style.Colors[ImGuiCol_TitleBg] = ImVec4(0.232f, 0.201f, 0.271f, 1.00f);
+    style.Colors[ImGuiCol_TitleBgActive] = ImVec4(0.502f, 0.075f, 0.256f, 1.00f);
+    style.Colors[ImGuiCol_TitleBgCollapsed] = ImVec4(0.200f, 0.220f, 0.270f, 0.75f);
+    style.Colors[ImGuiCol_MenuBarBg] = ImVec4(0.200f, 0.220f, 0.270f, 0.47f);
+    style.Colors[ImGuiCol_ScrollbarBg] = ImVec4(0.200f, 0.220f, 0.270f, 1.00f);
+    style.Colors[ImGuiCol_ScrollbarGrab] = ImVec4(0.09f, 0.15f, 0.16f, 1.00f);
+    style.Colors[ImGuiCol_ScrollbarGrabHovered] = ImVec4(0.455f, 0.198f, 0.301f,0.78f);
+    style.Colors[ImGuiCol_ScrollbarGrabActive] = ImVec4(0.455f, 0.198f, 0.301f, 1.00f);
+    style.Colors[ImGuiCol_CheckMark] = ImVec4(0.71f, 0.22f, 0.27f, 1.00f);
+    style.Colors[ImGuiCol_SliderGrab] = ImVec4(0.47f, 0.77f, 0.83f, 0.14f);
+    style.Colors[ImGuiCol_SliderGrabActive] = ImVec4(0.71f, 0.22f, 0.27f, 1.00f);
+    style.Colors[ImGuiCol_Button] = ImVec4(0.47f, 0.77f, 0.83f, 0.14f);
+    style.Colors[ImGuiCol_ButtonHovered] = ImVec4(0.455f, 0.198f, 0.301f, .86f);
+    style.Colors[ImGuiCol_ButtonActive] = ImVec4(0.455f, 0.198f, 0.301f, 1.00f);
+    style.Colors[ImGuiCol_Header] = ImVec4(0.455f, 0.198f, 0.301f, .76f);
+    style.Colors[ImGuiCol_HeaderHovered] = ImVec4(0.455f, 0.198f, 0.301f,.86f);
+    style.Colors[ImGuiCol_HeaderActive] = ImVec4(0.502f, 0.075f, 0.256f, 1.00f);
+    style.Colors[ImGuiCol_ResizeGrip] = ImVec4(0.47f, 0.77f, 0.83f, 0.04f);
+    style.Colors[ImGuiCol_ResizeGripHovered] = ImVec4(0.455f, 0.198f, 0.301f, .78f);
+    style.Colors[ImGuiCol_ResizeGripActive] = ImVec4(0.455f, 0.198f, 0.301f, 1.00f);
+    style.Colors[ImGuiCol_PlotLines] = ImVec4(0.860f, 0.930f, 0.890f, 0.63f);
+    style.Colors[ImGuiCol_PlotLinesHovered] = ImVec4(0.455f, 0.198f, 0.301f, 1.00f);
+    style.Colors[ImGuiCol_PlotHistogram] = ImVec4(0.860f, 0.930f, 0.890f, 0.63f);
+    style.Colors[ImGuiCol_PlotHistogramHovered] = ImVec4(0.455f, 0.198f, 0.301f, 1.00f);
+    style.Colors[ImGuiCol_TextSelectedBg] = ImVec4(0.455f, 0.198f, 0.301f, .43f);
+
+    style.WindowPadding = ImVec2(6, 4);
+    style.WindowRounding = 0.0f;
+    style.FramePadding = ImVec2(5, 2);
+    style.FrameRounding = 3.0f;
+    style.ItemSpacing = ImVec2(7, 1);
+    style.TouchExtraPadding = ImVec2(0, 0);
+    style.IndentSpacing = 6.0f;
+    style.ScrollbarSize = 12.0f;
+    style.ScrollbarRounding = 16.0f;
+    style.GrabMinSize = 20.0f;
+    style.GrabRounding = 2.0f;
+    style.WindowTitleAlign.x = 0.50f;
+    style.Colors[ImGuiCol_Border] = ImVec4(0.539f, 0.479f, 0.255f, 0.162f);
+    style.FrameBorderSize = 0.0f;
+    style.WindowBorderSize = 1.0f;
+}
+
+void PCSX::GUI::mono_theme() { //Theme by codz01
+    ImGui::StyleColorsDark(); //Reset styles
+
+    ImGuiStyle& style = ImGui::GetStyle();
+    style.WindowRounding = 5.3f;
+    style.FrameRounding = 2.3f;
+    style.ScrollbarRounding = 0;
+
+    style.Colors[ImGuiCol_Text] = ImVec4(0.90f, 0.90f, 0.90f, 0.90f);
+    style.Colors[ImGuiCol_TextDisabled] = ImVec4(0.60f, 0.60f, 0.60f, 1.00f);
+    style.Colors[ImGuiCol_WindowBg] = ImVec4(0.09f, 0.09f, 0.15f, 1.00f);
+    style.Colors[ImGuiCol_ChildBg] = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
+    style.Colors[ImGuiCol_PopupBg] = ImVec4(0.05f, 0.05f, 0.10f, 0.85f);
+    style.Colors[ImGuiCol_Border] = ImVec4(0.70f, 0.70f, 0.70f, 0.65f);
+    style.Colors[ImGuiCol_BorderShadow] = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
+    style.Colors[ImGuiCol_FrameBg] = ImVec4(0.00f, 0.00f, 0.01f, 1.00f);
+    style.Colors[ImGuiCol_FrameBgHovered] = ImVec4(0.90f, 0.80f, 0.80f, 0.40f);
+    style.Colors[ImGuiCol_FrameBgActive] = ImVec4(0.90f, 0.65f, 0.65f, 0.45f);
+    style.Colors[ImGuiCol_TitleBg] = ImVec4(0.00f, 0.00f, 0.00f, 0.83f);
+    style.Colors[ImGuiCol_TitleBgCollapsed] = ImVec4(0.40f, 0.40f, 0.80f, 0.20f);
+    style.Colors[ImGuiCol_TitleBgActive] = ImVec4(0.00f, 0.00f, 0.00f, 0.87f);
+    style.Colors[ImGuiCol_MenuBarBg] = ImVec4(0.01f, 0.01f, 0.02f, 0.80f);
+    style.Colors[ImGuiCol_ScrollbarBg] = ImVec4(0.20f, 0.25f, 0.30f, 0.60f);
+    style.Colors[ImGuiCol_ScrollbarGrab] = ImVec4(0.55f, 0.53f, 0.55f, 0.51f);
+    style.Colors[ImGuiCol_ScrollbarGrabHovered] = ImVec4(0.56f, 0.56f, 0.56f, 1.00f);
+    style.Colors[ImGuiCol_ScrollbarGrabActive] = ImVec4(0.56f, 0.56f, 0.56f, 0.91f);
+    style.Colors[ImGuiCol_CheckMark] = ImVec4(0.90f, 0.90f, 0.90f, 0.83f);
+    style.Colors[ImGuiCol_SliderGrab] = ImVec4(0.70f, 0.70f, 0.70f, 0.62f);
+    style.Colors[ImGuiCol_SliderGrabActive] = ImVec4(0.30f, 0.30f, 0.30f, 0.84f);
+    style.Colors[ImGuiCol_Button] = ImVec4(0.48f, 0.72f, 0.89f, 0.49f);
+    style.Colors[ImGuiCol_ButtonHovered] = ImVec4(0.50f, 0.69f, 0.99f, 0.68f);
+    style.Colors[ImGuiCol_ButtonActive] = ImVec4(0.80f, 0.50f, 0.50f, 1.00f);
+    style.Colors[ImGuiCol_Header] = ImVec4(0.30f, 0.69f, 1.00f, 0.53f);
+    style.Colors[ImGuiCol_HeaderHovered] = ImVec4(0.44f, 0.61f, 0.86f, 1.00f);
+    style.Colors[ImGuiCol_HeaderActive] = ImVec4(0.38f, 0.62f, 0.83f, 1.00f);
+    style.Colors[ImGuiCol_ResizeGrip] = ImVec4(1.00f, 1.00f, 1.00f, 0.85f);
+    style.Colors[ImGuiCol_ResizeGripHovered] = ImVec4(1.00f, 1.00f, 1.00f, 0.60f);
+    style.Colors[ImGuiCol_ResizeGripActive] = ImVec4(1.00f, 1.00f, 1.00f, 0.90f);
+    style.Colors[ImGuiCol_PlotLines] = ImVec4(1.00f, 1.00f, 1.00f, 1.00f);
+    style.Colors[ImGuiCol_PlotLinesHovered] = ImVec4(0.90f, 0.70f, 0.00f, 1.00f);
+    style.Colors[ImGuiCol_PlotHistogram] = ImVec4(0.90f, 0.70f, 0.00f, 1.00f);
+    style.Colors[ImGuiCol_PlotHistogramHovered] = ImVec4(1.00f, 0.60f, 0.00f, 1.00f);
+    style.Colors[ImGuiCol_TextSelectedBg] = ImVec4(0.00f, 0.00f, 1.00f, 0.35f);
+}
+
+void PCSX::GUI::dracula_theme() {
+    ImGui::StyleColorsDark(); //Reset styles
+
+    ImGuiStyle& style = ImGui::GetStyle();
+    style.WindowRounding = 5.3f;
+    style.GrabRounding = style.FrameRounding = 2.3f;
+    style.ScrollbarRounding = 5.0f;
+    style.FrameBorderSize = 1.0f;
+    style.ItemSpacing.y = 6.5f;
+
+    style.Colors[ImGuiCol_Text] = { 0.73333335f, 0.73333335f, 0.73333335f, 1.00f };
+    style.Colors[ImGuiCol_TextDisabled] = { 0.34509805f, 0.34509805f, 0.34509805f, 1.00f };
+    style.Colors[ImGuiCol_WindowBg] = { 0.23529413f, 0.24705884f, 0.25490198f, 0.94f };
+    style.Colors[ImGuiCol_ChildBg] = { 0.23529413f, 0.24705884f, 0.25490198f, 0.00f };
+    style.Colors[ImGuiCol_PopupBg] = { 0.23529413f, 0.24705884f, 0.25490198f, 0.94f };
+    style.Colors[ImGuiCol_Border] = { 0.33333334f, 0.33333334f, 0.33333334f, 0.50f };
+    style.Colors[ImGuiCol_BorderShadow] = { 0.15686275f, 0.15686275f, 0.15686275f, 0.00f };
+    style.Colors[ImGuiCol_FrameBg] = { 0.16862746f, 0.16862746f, 0.16862746f, 0.54f };
+    style.Colors[ImGuiCol_FrameBgHovered] = { 0.453125f, 0.67578125f, 0.99609375f, 0.67f };
+    style.Colors[ImGuiCol_FrameBgActive] = { 0.47058827f, 0.47058827f, 0.47058827f, 0.67f };
+    style.Colors[ImGuiCol_TitleBg] = { 0.04f, 0.04f, 0.04f, 1.00f };
+    style.Colors[ImGuiCol_TitleBgCollapsed] = { 0.16f, 0.29f, 0.48f, 1.00f };
+    style.Colors[ImGuiCol_TitleBgActive] = { 0.00f, 0.00f, 0.00f, 0.51f };
+    style.Colors[ImGuiCol_MenuBarBg] = { 0.27058825f, 0.28627452f, 0.2901961f, 0.80f };
+    style.Colors[ImGuiCol_ScrollbarBg] = { 0.27058825f, 0.28627452f, 0.2901961f, 0.60f };
+    style.Colors[ImGuiCol_ScrollbarGrab] = { 0.21960786f, 0.30980393f, 0.41960788f, 0.51f };
+    style.Colors[ImGuiCol_ScrollbarGrabHovered] = { 0.21960786f, 0.30980393f, 0.41960788f, 1.00f };
+    style.Colors[ImGuiCol_ScrollbarGrabActive] = { 0.13725491f, 0.19215688f, 0.2627451f, 0.91f };
+    style.Colors[ImGuiCol_CheckMark] = { 0.90f, 0.90f, 0.90f, 0.83f };
+    style.Colors[ImGuiCol_SliderGrab] = { 0.70f, 0.70f, 0.70f, 0.62f };
+    style.Colors[ImGuiCol_SliderGrabActive] = { 0.30f, 0.30f, 0.30f, 0.84f };
+    style.Colors[ImGuiCol_Button] = { 0.33333334f, 0.3529412f, 0.36078432f, 0.49f };
+    style.Colors[ImGuiCol_ButtonHovered] = { 0.21960786f, 0.30980393f, 0.41960788f, 1.00f };
+    style.Colors[ImGuiCol_ButtonActive] = { 0.13725491f, 0.19215688f, 0.2627451f, 1.00f };
+    style.Colors[ImGuiCol_Header] = { 0.33333334f, 0.3529412f, 0.36078432f, 0.53f };
+    style.Colors[ImGuiCol_HeaderHovered] = { 0.453125f, 0.67578125f, 0.99609375f, 0.67f };
+    style.Colors[ImGuiCol_HeaderActive] = { 0.47058827f, 0.47058827f, 0.47058827f, 0.67f };
+    style.Colors[ImGuiCol_Separator] = { 0.31640625f, 0.31640625f, 0.31640625f, 1.00f };
+    style.Colors[ImGuiCol_SeparatorHovered] = { 0.31640625f, 0.31640625f, 0.31640625f, 1.00f };
+    style.Colors[ImGuiCol_SeparatorActive] = { 0.31640625f, 0.31640625f, 0.31640625f, 1.00f };
+    style.Colors[ImGuiCol_ResizeGrip] = { 1.00f, 1.00f, 1.00f, 0.85f };
+    style.Colors[ImGuiCol_ResizeGripHovered] = { 1.00f, 1.00f, 1.00f, 0.60f };
+    style.Colors[ImGuiCol_ResizeGripActive] = { 1.00f, 1.00f, 1.00f, 0.90f };
+    style.Colors[ImGuiCol_PlotLines] = { 0.61f, 0.61f, 0.61f, 1.00f };
+    style.Colors[ImGuiCol_PlotLinesHovered] = { 1.00f, 0.43f, 0.35f, 1.00f };
+    style.Colors[ImGuiCol_PlotHistogram] = { 0.90f, 0.70f, 0.00f, 1.00f };
+    style.Colors[ImGuiCol_PlotHistogramHovered] = { 1.00f, 0.60f, 0.00f, 1.00f };
+    style.Colors[ImGuiCol_TextSelectedBg] = { 0.18431373f, 0.39607847f, 0.79215693f, 0.90f };
+}

--- a/src/gui/themes/imgui_themes.cc
+++ b/src/gui/themes/imgui_themes.cc
@@ -28,6 +28,22 @@ void PCSX::GUI::cherry_theme() { //Theme by: r-lyeh
     ImGui::StyleColorsDark(); //Reset styles
 
     auto& style = ImGui::GetStyle();
+    style.WindowPadding = ImVec2(6, 4);
+    style.WindowRounding = 0.0f;
+    style.FramePadding = ImVec2(5, 2);
+    style.FrameRounding = 3.0f;
+    style.ItemSpacing = ImVec2(7, 1);
+    style.TouchExtraPadding = ImVec2(0, 0);
+    style.IndentSpacing = 6.0f;
+    style.ScrollbarSize = 12.0f;
+    style.ScrollbarRounding = 16.0f;
+    style.GrabMinSize = 20.0f;
+    style.GrabRounding = 2.0f;
+    style.WindowTitleAlign.x = 0.50f;
+    style.Colors[ImGuiCol_Border] = ImVec4(0.539f, 0.479f, 0.255f, 0.162f);
+    style.FrameBorderSize = 0.0f;
+    style.WindowBorderSize = 1.0f;
+
     style.Colors[ImGuiCol_Text] = ImVec4(0.860f, 0.930f, 0.890f, 0.78f);
     style.Colors[ImGuiCol_TextDisabled] = ImVec4(0.860f, 0.930f, 0.890f, 0.28f);
     style.Colors[ImGuiCol_WindowBg] = ImVec4(0.13f, 0.14f, 0.17f, 1.00f);
@@ -63,22 +79,6 @@ void PCSX::GUI::cherry_theme() { //Theme by: r-lyeh
     style.Colors[ImGuiCol_PlotHistogram] = ImVec4(0.860f, 0.930f, 0.890f, 0.63f);
     style.Colors[ImGuiCol_PlotHistogramHovered] = ImVec4(0.455f, 0.198f, 0.301f, 1.00f);
     style.Colors[ImGuiCol_TextSelectedBg] = ImVec4(0.455f, 0.198f, 0.301f, .43f);
-
-    style.WindowPadding = ImVec2(6, 4);
-    style.WindowRounding = 0.0f;
-    style.FramePadding = ImVec2(5, 2);
-    style.FrameRounding = 3.0f;
-    style.ItemSpacing = ImVec2(7, 1);
-    style.TouchExtraPadding = ImVec2(0, 0);
-    style.IndentSpacing = 6.0f;
-    style.ScrollbarSize = 12.0f;
-    style.ScrollbarRounding = 16.0f;
-    style.GrabMinSize = 20.0f;
-    style.GrabRounding = 2.0f;
-    style.WindowTitleAlign.x = 0.50f;
-    style.Colors[ImGuiCol_Border] = ImVec4(0.539f, 0.479f, 0.255f, 0.162f);
-    style.FrameBorderSize = 0.0f;
-    style.WindowBorderSize = 1.0f;
 }
 
 void PCSX::GUI::mono_theme() { //Theme by codz01

--- a/vsprojects/gui/gui.vcxproj
+++ b/vsprojects/gui/gui.vcxproj
@@ -118,6 +118,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\gui\gui.cc" />
+    <ClCompile Include="..\..\src\gui\themes\imgui_themes.cc" />
     <ClCompile Include="..\..\src\gui\widgets\assembly.cc" />
     <ClCompile Include="..\..\src\gui\widgets\breakpoints.cc" />
     <ClCompile Include="..\..\src\gui\widgets\dwarf.cc" />

--- a/vsprojects/gui/gui.vcxproj.filters
+++ b/vsprojects/gui/gui.vcxproj.filters
@@ -51,6 +51,9 @@
     <ClCompile Include="..\..\src\gui\widgets\source.cc">
       <Filter>Source Files\widgets</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\gui\themes\imgui_themes.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\gui\gui.h">


### PR DESCRIPTION
Added a window under "Help/ImGui Themes" that allows users to choose from a few ImGui themes. Also fixed an issue with InterruptScalar's SliderFloat() using flags instead of floats, see [this](https://github.com/ocornut/imgui/issues/3361). It's my first PR, so feedback and pointers are very much welcome :)