### PR TITLE
Added KUSEG/KSEG0 BIOS to the JIT's block cache

### DIFF
--- a/src/core/ix86/iR3000A.cc
+++ b/src/core/ix86/iR3000A.cc
@@ -632,8 +632,6 @@ void X86DynaRecCPU::iPushReg(unsigned reg) {
     }
 
 bool X86DynaRecCPU::Init() {
-    int i;
-
     m_psxRecLUT = (uintptr_t *)calloc(0x010000, sizeof(uintptr_t));
 
 #ifndef _WIN32
@@ -650,11 +648,13 @@ bool X86DynaRecCPU::Init() {
         return false;
     }
 
-    for (i = 0; i < 0x80; i++) m_psxRecLUT[i + 0x0000] = (uintptr_t)&m_recRAM[(i & 0x1f) << 16];
+    for (auto i = 0; i < 0x80; i++) m_psxRecLUT[i] = (uintptr_t)&m_recRAM[(i & 0x1f) << 16]; // map KUSEG/KSEG0/KSEG1 WRAM respectively to the recompiler block LUT
     memcpy(m_psxRecLUT + 0x8000, m_psxRecLUT, 0x80 * sizeof(uintptr_t));
     memcpy(m_psxRecLUT + 0xa000, m_psxRecLUT, 0x80 * sizeof(uintptr_t));
 
-    for (i = 0; i < 0x08; i++) m_psxRecLUT[i + 0xbfc0] = (uintptr_t)&m_recROM[i << 16];
+    for (auto i = 0; i < 8; i++) m_psxRecLUT[i + 0x1fc0] = (uintptr_t)&m_recROM[i << 16]; // map KUSEG/KSEG0/KSEG1 BIOS respectively to the recompiler block LUT
+    memcpy(m_psxRecLUT + 0x9fc0, &m_psxRecLUT[0x1fc0], 8 * sizeof(uintptr_t));
+    memcpy(m_psxRecLUT + 0xbfc0, &m_psxRecLUT[0x1fc0], 8 * sizeof(uintptr_t));
 
     gen.x86Init(m_recMem);
 


### PR DESCRIPTION
Executing from there used to make the emulator blow up.
Now it still blows up occasionally but there's 1 less thing that can make it blow up.