### PR TITLE
Dramatically increase exception stack size

### DIFF
--- a/src/mips/openbios/kernel/handlers.c
+++ b/src/mips/openbios/kernel/handlers.c
@@ -110,7 +110,7 @@ static void installExceptionHandler() { installHandler((uint32_t *)exceptionVect
 
 void __attribute__((noreturn)) returnFromException();
 
-#define EXCEPTION_STACK_SIZE 0x180
+#define EXCEPTION_STACK_SIZE 0x800
 
 static uint32_t s_exceptionStack[EXCEPTION_STACK_SIZE];
 void *g_exceptionStackPtr = s_exceptionStack + EXCEPTION_STACK_SIZE;


### PR DESCRIPTION
Some games, like Dragon Warrior VII, overabuse of the stack during interrupt handlers. Even on the real bios, they would cause stack overflows.

Hopefully, 2kB will be enough.