### PR TITLE
Fix CP2C Register Names Definition

### DIFF
--- a/src/core/disr3000a.cc
+++ b/src/core/disr3000a.cc
@@ -45,7 +45,7 @@ const char *PCSX::Disasm::s_disRNameCP2D[] = {
 
 const char *PCSX::Disasm::s_disRNameCP2C[] = {
     "r11r12", "r13r21", "r22r23", "r31r32", "r33", "trx",  "try",  "trz",   // 00
-    "l11l12", "l13l21", "l22l23", "l31l32", "l33", "rbk",  "bbk",  "gbk",   // 08
+    "l11l12", "l13l21", "l22l23", "l31l32", "l33", "rbk",  "gbk",  "bbk",   // 08
     "lr1lr2", "lr3lg1", "lg2lg3", "lb1lb2", "lb3", "rfc",  "gfc",  "bfc",   // 10
     "ofx",    "ofy",    "h",      "dqa",    "dqb", "zsf3", "zsf4", "flag",  // 18
 };


### PR DESCRIPTION
According to [documentation](https://psx-spx.consoledev.net/geometrytransformationenginegte/#background-color-bk-input-rw) register gbk is 14 and bbk is 15. However in the names array, gbk is 15 and bbk is 14. This PR swaps the two registers, fixing the mismatch.