### PR TITLE
Reset window size on invalid config values

### DIFF
--- a/src/gui/gui.cc
+++ b/src/gui/gui.cc
@@ -296,8 +296,18 @@ end)(jit.status()))
             if ((j.count("loggers") == 1 && j["loggers"].is_object())) {
                 m_log.deserialize(j["loggers"]);
             }
+
+            auto& windowSizeX = settings.get<WindowSizeX>();
+            auto& windowSizeY = settings.get<WindowSizeY>();
+            if (!windowSizeX) {
+                windowSizeX = 1280;
+            }
+            if (!windowSizeY) {
+                windowSizeY = 800;
+            }
+
             glfwSetWindowPos(m_window, settings.get<WindowPosX>(), settings.get<WindowPosY>());
-            glfwSetWindowSize(m_window, settings.get<WindowSizeX>(), settings.get<WindowSizeY>());
+            glfwSetWindowSize(m_window, windowSizeX, windowSizeY);
             PCSX::g_emulator->m_spu->setCfg(j);
         } else {
             saveCfg();


### PR DESCRIPTION
This fixes a problem that occurred when the config values for the window size were corrupted on exit, for example by not getting the correct values back from `glfwGetWindowSize` while minimized.

Before (window size previously set to 0):
<img width="903" alt="bug" src="https://user-images.githubusercontent.com/85803645/121816138-5edb6100-cc69-11eb-8fb6-9caa14bff2da.png">

After the fix:
<img width="1281" alt="fixed" src="https://user-images.githubusercontent.com/85803645/121816141-669b0580-cc69-11eb-9b58-c6d5dafbd61c.png">
