### PR TITLE
Fix control menu breaking if multiple buttons are mapped to the same key

### DIFF
--- a/src/core/pad.cc
+++ b/src/core/pad.cc
@@ -430,7 +430,9 @@ bool PCSX::Pads::Pad::configure() {
                 ImGui::PushStyleColor(ImGuiCol_ButtonHovered, hilight);
                 hasToPop = true;
             }
-            if (ImGui::Button(glfwKeyToString(getButtonFromGUIIndex(i)).c_str(), ImVec2{-1, 0})) {
+
+            const auto keyName = fmt::format ("{}##{}", glfwKeyToString(getButtonFromGUIIndex(i)), i); // THe name of the mapped key
+            if (ImGui::Button(keyName.c_str(), ImVec2{-1, 0})) {
                 m_buttonToWait = i;
             }
             if (hasToPop) {

--- a/src/core/pad.cc
+++ b/src/core/pad.cc
@@ -425,9 +425,9 @@ bool PCSX::Pads::Pad::configure() {
             ImGui::TableSetColumnIndex(0);
             bool hasToPop = false;
             if (m_buttonToWait == i) {
-                const ImVec4 hilight = ImGui::GetStyle().Colors[ImGuiCol_TextDisabled];
-                ImGui::PushStyleColor(ImGuiCol_Button, hilight);
-                ImGui::PushStyleColor(ImGuiCol_ButtonHovered, hilight);
+                const ImVec4 highlight = ImGui::GetStyle().Colors[ImGuiCol_TextDisabled];
+                ImGui::PushStyleColor(ImGuiCol_Button, highlight);
+                ImGui::PushStyleColor(ImGuiCol_ButtonHovered, highlight);
                 hasToPop = true;
             }
 


### PR DESCRIPTION
As #534 shows, mapping a single key to multiple controller buttons would cause certain buttons in the "Controls" menu to stop functioning, because of ImGui ID collisions. This should work normally now.
