### PR TITLE
[CPU] Mark X86DynaRecCPU and InterpretedCPU classes as final

### DIFF
--- a/src/core/ix86/iR3000A.cc
+++ b/src/core/ix86/iR3000A.cc
@@ -73,7 +73,7 @@ void SPUwriteRegisterWrapper(unsigned long addr, unsigned short value) {
     PCSX::g_emulator->m_spu->writeRegister(addr, value);
 }
 
-class X86DynaRecCPU : public PCSX::R3000Acpu {
+class X86DynaRecCPU final : public PCSX::R3000Acpu {
     inline uintptr_t PC_REC(uint32_t addr) {
         uintptr_t base = m_psxRecLUT[addr >> 16];
         uint32_t offset = addr & 0xffff;

--- a/src/core/psxinterpreter.cc
+++ b/src/core/psxinterpreter.cc
@@ -92,7 +92,7 @@
 #define _BranchTarget_ ((int16_t)_Im_ * 4 + _PC_)            // Calculates the target during a branch instruction
 #define _SetLink(x) delayedLoad(x, _PC_ + 4);                // Sets the return address in the link register
 
-class InterpretedCPU : public PCSX::R3000Acpu {
+class InterpretedCPU final : public PCSX::R3000Acpu {
   public:
     InterpretedCPU() : R3000Acpu("Interpreted") {}
 


### PR DESCRIPTION
Doubt this will matter much, just added in case it helps compilers with devirtualization and since there's no reason for them not to be final.

Relevant: <https://devblogs.microsoft.com/cppblog/the-performance-benefits-of-final-classes/>