### PR TITLE
Exclude build artifacts from mips .gitignore

### DIFF
--- a/src/mips/.gitignore
+++ b/src/mips/.gitignore
@@ -7,3 +7,7 @@ cmake-build-*/
 *.map
 *.cpe
 *.ps-exe
+
+# for nugget  mirror
+*.dep
+*.o


### PR DESCRIPTION
Fixes nugget mirror not having those rules.