### PR TITLE
[SPU] Emulate SPUSTAT[5:0] as a mirror of SPUCNT[5:0]

### DIFF
--- a/src/spu/registers.cc
+++ b/src/spu/registers.cc
@@ -464,7 +464,7 @@ uint16_t PCSX::SPU::impl::readRegister(uint32_t reg) {
             return spuCtrl;
 
         case H_SPUstat:
-            return spuStat;
+            return (spuStat & ~0x3F) | (spuCtrl & 0x3F);
 
         case H_SPUaddr:
             return (uint16_t)(spuAddr >> 3);


### PR DESCRIPTION
Source:
https://psx-spx.consoledev.net/soundprocessingunitspu/#1f801daeh-spu-status-register-spustat-r