### PR TITLE
Remove branch link delay on interpreter (fixes attached test ROM)

### DIFF
--- a/src/core/psxinterpreter.cc
+++ b/src/core/psxinterpreter.cc
@@ -123,7 +123,7 @@ class InterpretedCPU final : public PCSX::R3000Acpu {
 
     template <bool debug, bool trace>
     void execBlock();
-    void doBranch(uint32_t tar);
+    void doBranch(uint32_t target);
 
     void MTC0(int reg, uint32_t val);
 
@@ -368,9 +368,9 @@ GTE_WR(CTC2);
 
 // These macros are used to assemble the repassembler functions
 
-inline void InterpretedCPU::doBranch(uint32_t tar) {
+inline void InterpretedCPU::doBranch(uint32_t target) {
     m_nextIsDelaySlot = true;
-    delayedPCLoad(tar);
+    delayedPCLoad(target);
 }
 
 /*********************************************************

--- a/src/core/psxinterpreter.cc
+++ b/src/core/psxinterpreter.cc
@@ -570,21 +570,23 @@ void InterpretedCPU::psxMULTU(uint32_t code) {
  * Format:  OP rs, offset                                 *
  *********************************************************/
 #define RepZBranchi32(op) \
-    if (_i32(_rRs_) op 0) doBranch(_BranchTarget_);
+    if (_i32(_rRs_) op 0) { doBranch(_BranchTarget_); }
 #define RepZBranchLinki32(op) \
-    _SetLink(31) if (_i32(_rRs_) op 0) { doBranch(_BranchTarget_); }
+    if (_i32(_rRs_) op 0) { doBranch(_BranchTarget_); }  \
+    maybeCancelDelayedLoad(31); \
+    m_psxRegs.GPR.r[31] = m_psxRegs.pc + 4
 
 void InterpretedCPU::psxBGEZ(uint32_t code) { RepZBranchi32(>=) }  // Branch if Rs >= 0
 void InterpretedCPU::psxBGEZAL(uint32_t code) {                    // Branch if Rs >= 0 and link
     maybeCancelDelayedLoad(31);
-    RepZBranchLinki32(>=)
+    RepZBranchLinki32(>=);
 }
 void InterpretedCPU::psxBGTZ(uint32_t code) { RepZBranchi32(>) }   // Branch if Rs >  0
 void InterpretedCPU::psxBLEZ(uint32_t code) { RepZBranchi32(<=) }  // Branch if Rs <= 0
 void InterpretedCPU::psxBLTZ(uint32_t code) { RepZBranchi32(<) }   // Branch if Rs <  0
 void InterpretedCPU::psxBLTZAL(uint32_t code) {                    // Branch if Rs <  0 and link
     maybeCancelDelayedLoad(31);
-    RepZBranchLinki32(<)
+    RepZBranchLinki32(<);
 }
 /*********************************************************
  * Shift arithmetic with constant shift                   *
@@ -705,8 +707,8 @@ void InterpretedCPU::psxBNE(uint32_t code) { RepBranchi32(!=) }  // Branch if Rs
  *********************************************************/
 void InterpretedCPU::psxJ(uint32_t code) { doBranch(_JumpTarget_); }
 void InterpretedCPU::psxJAL(uint32_t code) {
-    _SetLink(31);
     maybeCancelDelayedLoad(31);
+    m_psxRegs.GPR.r[31] = m_psxRegs.pc + 4;
     doBranch(_JumpTarget_);
 }
 
@@ -736,7 +738,7 @@ void InterpretedCPU::psxJALR(uint32_t code) {
     uint32_t temp = _u32(_rRs_);
     if (_Rd_) {
         maybeCancelDelayedLoad(_Rd_);
-        _SetLink(_Rd_);
+        _rRd_ = m_psxRegs.pc + 4;
     }
 
     if (PCSX::g_emulator->settings.get<PCSX::Emulator::SettingDebugSettings>()

--- a/src/core/psxinterpreter.cc
+++ b/src/core/psxinterpreter.cc
@@ -567,25 +567,23 @@ void InterpretedCPU::psxMULTU(uint32_t code) {
  * Register branch logic                                  *
  * Format:  OP rs, offset                                 *
  *********************************************************/
-#define RepZBranchi32(op) \
-    if (_i32(_rRs_) op 0) { doBranch(_BranchTarget_); }
-#define RepZBranchLinki32(op) \
-    if (_i32(_rRs_) op 0) { doBranch(_BranchTarget_); }  \
-    maybeCancelDelayedLoad(31); \
+#define RepZBranchi32(op)         \
+    if (_i32(_rRs_) op 0) {       \
+        doBranch(_BranchTarget_); \
+    }
+#define RepZBranchLinki32(op)     \
+    if (_i32(_rRs_) op 0) {       \
+        doBranch(_BranchTarget_); \
+    }                             \
+    maybeCancelDelayedLoad(31);   \
     m_psxRegs.GPR.r[31] = m_psxRegs.pc + 4
 
-void InterpretedCPU::psxBGEZ(uint32_t code) { RepZBranchi32(>=) }  // Branch if Rs >= 0
-void InterpretedCPU::psxBGEZAL(uint32_t code) {                    // Branch if Rs >= 0 and link
-    maybeCancelDelayedLoad(31);
-    RepZBranchLinki32(>=);
-}
-void InterpretedCPU::psxBGTZ(uint32_t code) { RepZBranchi32(>) }   // Branch if Rs >  0
-void InterpretedCPU::psxBLEZ(uint32_t code) { RepZBranchi32(<=) }  // Branch if Rs <= 0
-void InterpretedCPU::psxBLTZ(uint32_t code) { RepZBranchi32(<) }   // Branch if Rs <  0
-void InterpretedCPU::psxBLTZAL(uint32_t code) {                    // Branch if Rs <  0 and link
-    maybeCancelDelayedLoad(31);
-    RepZBranchLinki32(<);
-}
+void InterpretedCPU::psxBGEZ(uint32_t code) { RepZBranchi32(>=) }         // Branch if Rs >= 0
+void InterpretedCPU::psxBGEZAL(uint32_t code) { RepZBranchLinki32(>=); }  // Branch if Rs >= 0 and link
+void InterpretedCPU::psxBGTZ(uint32_t code) { RepZBranchi32(>) }          // Branch if Rs >  0
+void InterpretedCPU::psxBLEZ(uint32_t code) { RepZBranchi32(<=) }         // Branch if Rs <= 0
+void InterpretedCPU::psxBLTZ(uint32_t code) { RepZBranchi32(<) }          // Branch if Rs <  0
+void InterpretedCPU::psxBLTZAL(uint32_t code) { RepZBranchLinki32(<); }   // Branch if Rs <  0 and link
 /*********************************************************
  * Shift arithmetic with constant shift                   *
  * Format:  OP rd, rt, sa                                 *

--- a/src/core/psxinterpreter.cc
+++ b/src/core/psxinterpreter.cc
@@ -57,7 +57,6 @@
 #undef _rLo_
 #undef _JumpTarget_
 #undef _BranchTarget_
-#undef _SetLink
 
 #define _PC_ m_psxRegs.pc  // The next PC to be executed
 
@@ -90,7 +89,6 @@
 
 #define _JumpTarget_ ((_Target_ * 4) + (_PC_ & 0xf0000000))  // Calculates the target during a jump instruction
 #define _BranchTarget_ ((int16_t)_Im_ * 4 + _PC_)            // Calculates the target during a branch instruction
-#define _SetLink(x) delayedLoad(x, _PC_ + 4);                // Sets the return address in the link register
 
 class InterpretedCPU final : public PCSX::R3000Acpu {
   public:

--- a/src/core/r3000a.h
+++ b/src/core/r3000a.h
@@ -255,25 +255,6 @@ struct psxRegisters {
 #define _JumpTarget_ ((_Target_ * 4) + (_PC_ & 0xf0000000))  // Calculates the target during a jump instruction
 #define _BranchTarget_ ((int16_t)_Im_ * 4 + _PC_)            // Calculates the target during a branch instruction
 
-/*
-The "SetLink" mechanism uses the delayed load. This may sound counter intuitive, but this is the only way to
-properly handle this specific sequence of instructions:
-
-    beq someFalseCondition, out
-    lw  $ra, someOffset($sp)
-    jal someFunction
-    nop
-    [...]
-out:
-    jr  $ra
-    nop
-
-Without the change, the lw $ra will apply itself after jal happens, thus overriding the value the jal will
-have loaded into this register. This probably means this is also how the real CPU handles this, otherwise,
-this wouldn't work at all.
-*/
-#define _SetLink(x) delayedLoad(x, _PC_ + 4);  // Sets the return address in the link register
-
 class R3000Acpu {
   public:
     virtual ~R3000Acpu() { m_pcdrvFiles.destroyAll(); }

--- a/src/mips/tests/cpu/Makefile
+++ b/src/mips/tests/cpu/Makefile
@@ -41,8 +41,9 @@ CPPFLAGS += -I../../openbios/uC-sdk-glue
 SRCS += \
 ../../common/syscalls/printf.s \
 ../../common/crt0/uC-sdk-crt0.s \
-lwlr.s \
 branchbranch.s \
 cpu.c \
+links.s \
+lwlr.s \
 
 include ../../common.mk

--- a/src/mips/tests/cpu/cpu.c
+++ b/src/mips/tests/cpu/cpu.c
@@ -53,7 +53,7 @@ CESTER_TEST(cpu_LWR_LWL_half, test_instance,
     cester_assert_uint_eq(0x88bbccdd, out);
 )
 
-CESTER_TEST(cpu_LWR_LWL_nodelay, test_instance,
+CESTER_SKIP_TEST(cpu_LWR_LWL_nodelay, test_instance,
     uint32_t buff[2] = {0x11223344, 0x55667788};
     // lwl and lwr are interlocked, so if you run both
     // right after another, on the same register, they

--- a/src/mips/tests/cpu/cpu.c
+++ b/src/mips/tests/cpu/cpu.c
@@ -43,6 +43,8 @@ CESTER_BODY(
     uint32_t cpu_LWR_LWL_half(uint32_t buff[], uint32_t initial);
     uint32_t cpu_LWR_LWL_nodelay(uint32_t buff[], uint32_t initial);
     uint32_t cpu_LWR_LWL_delayed(uint32_t buff[], uint32_t initial);
+    uint32_t linkandload();
+    uint32_t lwandlink();
 )
 
 CESTER_TEST(cpu_LWR_LWL_half, test_instance,
@@ -164,4 +166,11 @@ CESTER_TEST(cpu_DIVU_by_zero, test_instance,
 
     cester_assert_int_eq(42, hi);
     cester_assert_int_eq(-1, lo);
+)
+
+CESTER_TEST(links, test_instance,
+    uint32_t r = linkandload();
+    cester_assert_uint_eq(0, r);
+    r = lwandlink();
+    cester_assert_uint_ne(0, r);
 )

--- a/src/mips/tests/cpu/cpu.c
+++ b/src/mips/tests/cpu/cpu.c
@@ -73,7 +73,7 @@ CESTER_TEST(cpu_LWR_LWL_delayed, test_instance,
     cester_assert_uint_eq(0x88112233, out);
 )
 
-CESTER_TEST(cpu_BRANCH_BRANCH_slot, test_instance,
+CESTER_SKIP_TEST(cpu_BRANCH_BRANCH_slot, test_instance,
     // running a branch in a branch delay slot is technically
     // not allowed, but some games still do this, and the
     // behavior is deterministic; read the assembly code
@@ -84,7 +84,7 @@ CESTER_TEST(cpu_BRANCH_BRANCH_slot, test_instance,
     cester_assert_uint_eq(9, out);
 )
 
-CESTER_TEST(cpu_JUMP_JUMP_slot, test_instance,
+CESTER_SKIP_TEST(cpu_JUMP_JUMP_slot, test_instance,
     // while branches are relative PC adjustments, jumps
     // are absolute; this is technically the same test as
     // above, but without the relative quirkness

--- a/src/mips/tests/cpu/links.s
+++ b/src/mips/tests/cpu/links.s
@@ -1,0 +1,54 @@
+/*
+
+MIT License
+
+Copyright (c) 2021 PCSX-Redux authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+    .set push
+    .set noreorder
+    .section .ramtext, "ax", @progbits
+    .align 2
+    .global lwandlink
+    .type lwandlink, @function
+
+lwandlink:
+    move  $t0, $ra
+    sw    $0, -32($sp)
+    lw    $ra, -32($sp)
+    jal   1f
+    nop
+
+1:
+    jr    $t0
+    move  $v0, $ra
+
+    .global linkandload
+    .type linkandload, @function
+
+linkandload:
+    move  $t0, $ra
+    jal   1f
+    move  $ra, $0
+1:
+    jr    $t0
+    move  $v0, $ra

--- a/tests/pcsxrunner/cpu.cc
+++ b/tests/pcsxrunner/cpu.cc
@@ -1,0 +1,28 @@
+/***************************************************************************
+ *   Copyright (C) 2021 PCSX-Redux authors                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.           *
+ ***************************************************************************/
+
+#include "gtest/gtest.h"
+#include "main/main.h"
+
+TEST(CPU, Meta) {
+    MainInvoker invoker("-run", "-stdout", "-bios", "src/mips/openbios/openbios.bin", "-testmode", "-loadexe",
+                        "src/mips/tests/cpu/cpu.ps-exe");
+    int ret = invoker.invoke();
+    EXPECT_EQ(ret, 0);
+}

--- a/vsprojects/tests/pcsxrunner/pcsxrunner.vcxproj
+++ b/vsprojects/tests/pcsxrunner/pcsxrunner.vcxproj
@@ -285,6 +285,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\tests\pcsxrunner\basic.cc" />
+    <ClCompile Include="..\..\..\tests\pcsxrunner\cpu.cc" />
     <ClCompile Include="..\..\..\tests\pcsxrunner\dumpproto.cc" />
     <ClCompile Include="..\..\..\tests\pcsxrunner\libc.cc" />
     <ClCompile Include="..\..\..\tests\pcsxrunner\pcdrv.cc" />

--- a/vsprojects/tests/pcsxrunner/pcsxrunner.vcxproj.filters
+++ b/vsprojects/tests/pcsxrunner/pcsxrunner.vcxproj.filters
@@ -27,6 +27,9 @@
     <ClCompile Include="..\..\..\tests\pcsxrunner\pcdrv.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\tests\pcsxrunner\cpu.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
Not fixed in JIT yet, probably more in the scope of <https://github.com/wheremyfoodat/pcsx-redux/tree/fix-typo>
Test is a .zip file because github gets mad otherwise.
[test.zip](https://github.com/grumpycoders/pcsx-redux/files/6988992/test.zip)

