### PR TITLE
CDROM: Ignore sectors with channel number 255

### DIFF
--- a/src/core/cdrom.cc
+++ b/src/core/cdrom.cc
@@ -1112,7 +1112,11 @@ class CDRomImpl : public PCSX::CDRom {
                 m_channel = m_transfer[4 + 1];
             }
 
-            if ((m_transfer[4 + 2] & 0x4) && (m_transfer[4 + 1] == m_channel) && (m_transfer[4 + 0] == m_file)) {
+			/* Gameblabla - Ignore sectors with channel 255. 
+			 * This fixes the missing sound in Blue's Clues : Blue's Big Musical.
+			 * (Taxi 2 is also said to be affected by the same issue)
+			 * */
+            if ((m_transfer[4 + 2] & 0x4) && (m_transfer[4 + 1] == m_channel) && (m_transfer[4 + 0] == m_file) && m_channel != 255) {
                 int ret = xa_decode_sector(&m_xa, m_transfer + 4, m_firstSector);
                 if (!ret) {
                     attenuate(m_xa.pcm, m_xa.nsamples, m_xa.stereo);


### PR DESCRIPTION
Inspired by fix in Duckstation :
https://github.com/stenzek/duckstation/commit/0710e3b6d384526ed939f742f8f657623bb354bb

Some games have junk audio sectors with a channel number of 255.
If these are not skipped, then they will play wrong file.

This was tested on "Blue's Clues : Blue's Big Musical" and it fixed the missing audio there.
Taxi 2 is also said to be affected by this.

Interestingly in Mednafen, they noted this :
```
PSX: Removed incorrect filtering of CD-XA ADPCM sectors based on the file and channel numbers of the first ADPCM sector played, 
originally added in 0.9.24-WIP to fix the speech playback in "Yarudora Series Vol.1: Double Cast", 
but made unnecessary by later sector buffering accuracy improvements; 
fixes missing audio in the FMVs of "Blue's Clues: Blue's Big Musical".
```

In our case however, it didn't break Yarudora's speech and it fixed Blue's Clues missing audio for us.