### PR TITLE
Fixing crt-lottes' pixel shader

### DIFF
--- a/src/gui/shaders/crt-lottes.cc
+++ b/src/gui/shaders/crt-lottes.cc
@@ -53,9 +53,9 @@ uniform float u_warp;
 uniform int u_masktype;
 uniform bool u_grey;
 
-float maskDark = 1.0 - u_mask;
-float maskLight = 1.0 + u_mask;
-vec2 c_warp = vec2(u_warp / 32.0, u_warp / 24.0);
+float maskDark;
+float maskLight;
+vec2 c_warp;
 
 vec2 warp(vec2 pos) {
     pos = pos * 2.0 - 1.0;
@@ -104,6 +104,10 @@ vec3 fetch(vec2 pos) {
 in vec2 Frag_UV;
 layout (location = 0) out vec4 Out_Color;
 void main() {
+    maskDark = 1.0 - u_mask;
+    maskLight = 1.0 + u_mask;
+    c_warp = vec2(u_warp / 32.0, u_warp / 24.0);
+
     Out_Color.rgb = fetch(warp(Frag_UV.st));
     if (u_grey) {
         Out_Color.rgb = toGrey(Out_Color.rgb);


### PR DESCRIPTION
Some drivers don't like using uniform in computing global initializers.