### PR TITLE
Fix timestamps in GUI file dialogs

### DIFF
--- a/src/core/system.h
+++ b/src/core/system.h
@@ -42,14 +42,14 @@ enum class LogClass : unsigned;
 typedef decltype(std::filesystem::path().u8string()) u8string;
 #define MAKEU8(x) reinterpret_cast<const decltype(PCSX::u8string::value_type()) *>(x)
 
+
 // another hack, until C++-20 properly gets std::chrono::clock_cast
-template<typename DstTP, typename SrcTP, typename DstClk = typename DstTP::clock, typename SrcClk = typename SrcTP::clock>
+template <typename DstTP, typename SrcTP, typename DstClk = typename DstTP::clock,
+          typename SrcClk = typename SrcTP::clock>
 DstTP ClockCast(const SrcTP tp) {
     const SrcTP srcNow = SrcClk::now();
     const DstTP dstNow = DstClk::now();
-    const std::chrono::system_clock::duration delta = tp - srcNow;
-    const DstTP ret = dstNow + delta;
-    return ret;
+    return std::chrono::time_point_cast<typename DstClk::duration>(tp - SrcTP + DstTP);
 }
 
 namespace Events {

--- a/src/core/system.h
+++ b/src/core/system.h
@@ -49,7 +49,7 @@ template <typename DstTP, typename SrcTP, typename DstClk = typename DstTP::cloc
 DstTP ClockCast(const SrcTP tp) {
     const SrcTP srcNow = SrcClk::now();
     const DstTP dstNow = DstClk::now();
-    return std::chrono::time_point_cast<typename DstClk::duration>(tp - SrcTP + DstTP);
+    return std::chrono::time_point_cast<typename DstClk::duration>(tp - srcNow + dstNow);
 }
 
 namespace Events {

--- a/src/core/system.h
+++ b/src/core/system.h
@@ -45,9 +45,11 @@ typedef decltype(std::filesystem::path().u8string()) u8string;
 // another hack, until C++-20 properly gets std::chrono::clock_cast
 template<typename DstTP, typename SrcTP, typename DstClk = typename DstTP::clock, typename SrcClk = typename SrcTP::clock>
 DstTP ClockCast(const SrcTP tp) {
-    const auto srcNow = SrcClk::now();
-    const auto dstNow = DstClk::now();
-    return dstNow + (tp - srcNow);
+    const SrcTP srcNow = SrcClk::now();
+    const DstTP dstNow = DstClk::now();
+    const std::chrono::system_clock::duration delta = tp - srcNow;
+    const DstTP ret = dstNow + delta;
+    return ret;
 }
 
 namespace Events {

--- a/src/core/system.h
+++ b/src/core/system.h
@@ -22,6 +22,7 @@
 
 #include <stdarg.h>
 
+#include <chrono>
 #include <filesystem>
 #include <limits>
 #include <map>
@@ -37,9 +38,17 @@ namespace PCSX {
 
 enum class LogClass : unsigned;
 
-// a hack, until c++-20 is fully adopted everywhere.
+// a hack, until C++-20 is fully adopted everywhere.
 typedef decltype(std::filesystem::path().u8string()) u8string;
 #define MAKEU8(x) reinterpret_cast<const decltype(PCSX::u8string::value_type()) *>(x)
+
+// another hack, until C++-20 properly gets std::chrono::clock_cast
+template<typename DstTP, typename SrcTP, typename DstClk = typename DstTP::clock, typename SrcClk = typename SrcTP::clock>
+DstTP ClockCast(const SrcTP tp) {
+    const auto srcNow = SrcClk::now();
+    const auto dstNow = DstClk::now();
+    return dstNow + (tp - srcNow);
+}
 
 namespace Events {
 struct SettingsLoaded {};

--- a/src/gui/widgets/filedialog.cc
+++ b/src/gui/widgets/filedialog.cc
@@ -148,7 +148,7 @@ bool PCSX::Widgets::FileDialog::draw() {
                 } else {
                     try {
                         auto lastWrite = std::filesystem::last_write_time(p);
-                        auto lastWriteSystemClock = std::chrono::clock_cast<std::chrono::system_clock>(lastWrite);
+                        auto lastWriteSystemClock = ClockCast<std::chrono::system_clock::time_point>(lastWrite);
                         std::time_t dateTime = std::chrono::system_clock::to_time_t(lastWriteSystemClock);
                         const std::tm* converted = std::localtime(&dateTime);
                         std::ostringstream formatted;

--- a/src/gui/widgets/filedialog.cc
+++ b/src/gui/widgets/filedialog.cc
@@ -147,11 +147,9 @@ bool PCSX::Widgets::FileDialog::draw() {
                     m_directories.push_back(p.path().filename().u8string());
                 } else {
                     try {
-                        auto status = p.status();
                         auto lastWrite = std::filesystem::last_write_time(p);
-                        auto timeSinceEpoch = lastWrite.time_since_epoch();
-                        auto count = timeSinceEpoch.count();
-                        std::time_t dateTime = count / 100000000;
+                        auto lastWriteSystemClock = clock_cast<std::chrono::system_clock>(lastWrite);
+                        std::time_t dateTime = std::chrono::system_clock::to_time_t(lastWriteSystemClock);
                         const std::tm* converted = std::localtime(&dateTime);
                         std::ostringstream formatted;
                         formatted << std::put_time(converted, "%c");

--- a/src/gui/widgets/filedialog.cc
+++ b/src/gui/widgets/filedialog.cc
@@ -148,7 +148,7 @@ bool PCSX::Widgets::FileDialog::draw() {
                 } else {
                     try {
                         auto lastWrite = std::filesystem::last_write_time(p);
-                        auto lastWriteSystemClock = clock_cast<std::chrono::system_clock>(lastWrite);
+                        auto lastWriteSystemClock = std::chrono::clock_cast<std::chrono::system_clock>(lastWrite);
                         std::time_t dateTime = std::chrono::system_clock::to_time_t(lastWriteSystemClock);
                         const std::tm* converted = std::localtime(&dateTime);
                         std::ostringstream formatted;


### PR DESCRIPTION
Addresses #502 

Verified on my Windows 10 machine that:
1) The timestamps were incorrect prior to the change reproducing #502 
2) And that they were correct after this change
![image](https://user-images.githubusercontent.com/17508706/134757682-68a76549-e9ed-4e7c-b96b-89e442883908.png)
