### PR TITLE
Fixing argv array on Windows.

### DIFF
--- a/src/main/mainthunk.cc
+++ b/src/main/mainthunk.cc
@@ -57,7 +57,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance
     char **argv;
     int argc;
 
-    argvw = CommandLineToArgvW(lpCmdLine, &argc);
+    argvw = CommandLineToArgvW(GetCommandLineW(), &argc);
     if (!argvw) return -1;
     argv = (char **)calloc(argc + 1, sizeof(*argv));
     if (!argv) return -1;


### PR DESCRIPTION
Turns out that lpCmdLine from wWinMain isn't exactly what's expected into CommandLineToArgvw.