### PR TITLE
Fix for Armored Core misdetecting a Link cable being detected

### DIFF
--- a/src/core/psxhw.cc
+++ b/src/core/psxhw.cc
@@ -147,6 +147,13 @@ uint16_t PCSX::HW::psxHwRead16(uint32_t add) {
             hard = SIO1_readBaud16();
             SIO1_LOG("sio1 read16 %x; ret = %x\n", add & 0xf, hard);
             return hard;
+#else
+		/* Fixes Armored Core misdetecting the Link cable being detected.
+		 * We want to turn that thing off and force it to do local multiplayer instead.
+		 * Thanks Sony for the fix, they fixed it in their PS Classic fork.
+		 */
+		case 0x1f801054:
+			return 0x80;
 #endif
         case 0x1f801100:
             hard = PCSX::g_emulator->m_psxCounters->psxRcntRcount(0);


### PR DESCRIPTION
For some reason, the game detects that a link cable is plugged in and disables the local multiplayer as a result.
Thanks @sony for fixing the issue in their PS Classic branch for PCSX Rearmed, a simpler fix is done here instead.
Note that this could also be fixed by enabling the SIO1 plugin but we want at least to provide a fallback
for those that don't want to compile LINK support.


Before:
![135701174-e81bd6c6-3865-406a-9f16-e1b28ea0fd8f](https://user-images.githubusercontent.com/8717966/136702464-30dfabba-d96b-4770-a3b8-c7c674b97d43.png)
After:
![135701178-eaa40ecf-7462-4cb4-8b70-e414f52ba685](https://user-images.githubusercontent.com/8717966/136702465-8104f988-3988-4d06-9732-42a0c496f7c6.png)

In case you are curious : yes i tried a value of 0 but the issue would still happen regardless. Only 0x80 or beyond would work.