### PR TITLE
Fix for Wild Arms USA being misdetected as a PAL game.

### DIFF
--- a/src/core/misc.cc
+++ b/src/core/misc.cc
@@ -273,7 +273,9 @@ bool CheckCdrom() {
     }
 
     if (PCSX::g_emulator->settings.get<PCSX::Emulator::SettingAutoVideo>()) {  // autodetect system (pal or ntsc)
-        if ((PCSX::g_emulator->m_cdromId[2] == 'e') || (PCSX::g_emulator->m_cdromId[2] == 'E') ||
+        if (
+			((PCSX::g_emulator->m_cdromId[0] == 's' || PCSX::g_emulator->m_cdromId[0] == 'S') && 
+			(PCSX::g_emulator->m_cdromId[2] == 'e' || PCSX::g_emulator->m_cdromId[2] == 'E')) ||
             !strncmp(PCSX::g_emulator->m_cdromId, "DTLS3035", 8) ||
             !strncmp(PCSX::g_emulator->m_cdromId, "PBPX95001", 9) ||  // according to redump.org, these PAL
             !strncmp(PCSX::g_emulator->m_cdromId, "PBPX95007", 9) ||  // discs have a non-standard ID;


### PR DESCRIPTION
Fix comes from a PCSX4ALL fork :
https://github.com/jdgleaver/RG350_pcsx4all/commit/c96751d43ff6373dda49b87a296df7cafffa5461
```
For some reason the CdromId of Wild Arms (US) is being incorrectly parsed as "EXESCUS94" when it should be "SCUS94608".
Coincidentally, the third character of "EXESCUS94" is an "E", which is what PCSX4ALL uses to detect if a game is PAL.
This fix makes it require that the first character is an "S" AND the third character is an "E" to be detected as PAL, so in the case of "EXESCUS94" it will be detected as NTSC.
```
Interestingly, the Region detection for the PS Classic fork is quite different (they check the license string).

Co-authored-by: bardeci <37640967+bardeci@users.noreply.github.com>