### PR TITLE
One more on odd lines for PAL HSYNC

### DIFF
--- a/src/core/psxcounters.cc
+++ b/src/core/psxcounters.cc
@@ -359,7 +359,7 @@ uint32_t PCSX::Counters::psxRcntRtarget(uint32_t index) {
 
 void PCSX::Counters::psxHsyncCalculate() {
     m_HSyncTotal[PCSX::Emulator::PSX_TYPE_NTSC] = 263;
-    m_HSyncTotal[PCSX::Emulator::PSX_TYPE_PAL] = 313;
+    m_HSyncTotal[PCSX::Emulator::PSX_TYPE_PAL] = 314; // actually one more on odd lines for PAL
     if (PCSX::g_emulator->config().VSyncWA) {
         m_HSyncTotal[PCSX::g_emulator->settings.get<PCSX::Emulator::SettingVideo>()] =
             m_HSyncTotal[PCSX::g_emulator->settings.get<PCSX::Emulator::SettingVideo>()] / PCSX::Emulator::BIAS;


### PR DESCRIPTION
As done by Duckstation, Mednafen and no$cash's documentation

Duckstation :
https://github.com/stenzek/duckstation/blob/bbcf1c67d1aefd5de9cdc9c158f92bc7aaecaa63/src/core/gpu.h#L56

Nocash :
https://www.problemkaputt.de/psx-spx.htm
(See GPU Timings -> Vertical timings)

They state that the number of scanlines per frame is 314, not 313.