### PR TITLE
Various cdrom fixes

### DIFF
--- a/src/core/cdrom.cc
+++ b/src/core/cdrom.cc
@@ -855,7 +855,9 @@ class CDRomImpl : public PCSX::CDRom {
                     m_result[0] = m_statP;
                     m_result[1] = itob(m_resultTD[2]);
                     m_result[2] = itob(m_resultTD[1]);
-                    m_result[3] = itob(m_resultTD[0]);
+                    /* According to Nocash's documentation, the function doesn't care about ff.
+                    * This can be seen also in Mednafen's implementation. */
+                    //m_result[3] = itob(m_resultTD[0]);
                 }
                 break;
 


### PR DESCRIPTION
Hello,
here are various fixes that i took from other emulators such as Duckstation, Mednafen or no$cash's documentation.
I will make a summary of the fixes here :

- CdlSync should return an error.
The only game that is said to be affected by this is Spyro 2 for PAL regions. However, that variant still doesn't boot
because of the icache emulation code. (i've tested it on pcsx_rearmed and it doesn't need this fix)
I will open an issue about it i guess but for cdlsync, this is the expected behaviour.

- SetLoc should throw up an error on invalid sectors.
Only Sound Novel, The (Simple 1500 Series Vol. 31) is affected by this. In Duckstation, this caused a sound delay.
However, we are seemingly not affected by this.
We are also not throwing an error when though we should...

- Fix an error with CdlGetmode and change its name to GetParam (the intended name)
I can't believe they came up with this but a quick glance at the documentation should
tell you that it's obviously wrong.
That said, i don't believe any game is affected by this.

- Shorter delay for CdlPause when drive is in standby mode, make the delay value more accurate
Dead or Alive needs the shorter delay on standby mode otherwise : music will not resume when you pause ingame and unpause it.
I also added a comment about Gundam Battle Assault 2 PAL as ironically, Mednafen cannot run this game
due to an error in their Cdlpause delay "magic number".

- Reset is Init, Init is reset (Yes, for real), set m_mode to 0x20 upon reset
This was discovered by Mednafen and it's a very simple fix : just set m_mode to 0x20 when cdlreset is called.
This fixes a lockup This is Football 2 and Pooh's Party (that game locks up after you selected a character).

- Fix an error in CdlGetTD
Should not affect any game however.