### PR TITLE
Fixing OpenBios 'Invalid Disc' popup message; updated gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,12 @@ fb.bat
 
 # GPU dump files
 *.dump 
+
+# Runtime files in ./resources
+offscreen.frag
+offscreen.lua
+offscreen.vert
+output.frag
+output.lua
+output.vert
+pcsx.lua

--- a/src/mips/common/hardware/pcsxhw.h
+++ b/src/mips/common/hardware/pcsxhw.h
@@ -31,6 +31,6 @@ SOFTWARE.
 static __inline__ void pcsx_putc(int c) { *((volatile char* const)0x1f802080) = c; }
 static __inline__ void pcsx_debugbreak() { *((volatile char* const)0x1f802081) = 0; }
 static __inline__ void pcsx_exit(int code) { *((volatile int16_t* const)0x1f802082) = code; }
-static __inline__ void pcsx_message(const char* msg) { *((volatile char* const)0x1f802084) = msg; }
+static __inline__ void pcsx_message(const char* msg) { *((volatile char** const)0x1f802084) = msg; }
 
 static __inline__ int pcsx_present() { return *((volatile uint32_t* const)0x1f802080) == 0x58534350; }


### PR DESCRIPTION
There was a missing pointer deref causing issues reading the error message value in MIPS space for invalid disc inserted. 

Also, some of the runtime generated resource files that are automatically generated were added to gitignore.