### PR TITLE
Fix gpu configure window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Enabled/
 Disabled/
 
 .vs/
+.vscode/*.log
 
 ipch/
 *.aps

--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ $(TARGET): $(OBJECTS)
 
 clean:
 	rm -f $(OBJECTS) $(TARGET) $(DEPS) gtest-all.o
-	$(MAKE) -C third_party/luajit clean
+	$(MAKE) -C third_party/luajit clean MACOSX_DEPLOYMENT_TARGET=10.15
 
 gtest-all.o: $(wildcard third_party/googletest/googletest/src/*.cc)
 	$(CXX) -O3 -g $(CXXFLAGS) -Ithird_party/googletest/googletest -Ithird_party/googletest/googletest/include -c third_party/googletest/googletest/src/gtest-all.cc

--- a/src/gpu/soft/gpu.cc
+++ b/src/gpu/soft/gpu.cc
@@ -139,6 +139,7 @@
 #include "gpu/soft/menu.h"
 #include "gpu/soft/prim.h"
 #include "tracy/Tracy.hpp"
+#include "imgui.h"
 
 //#define SMALLDEBUG
 //#include <dbgout.h>
@@ -1518,3 +1519,24 @@ void GPUsetfix(uint32_t dwFixBits) { dwEmuFixes = dwFixBits; }
 ////////////////////////////////////////////////////////////////////////
 
 extern "C" void softGPUvisualVibration(uint32_t iSmall, uint32_t iBig) {}
+
+
+bool PCSX::SoftGPU::impl::configure() {
+    if (!m_showCfg) return false;
+    bool changed = false;
+    ImGui::SetNextWindowPos(ImVec2(60, 60), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(300, 200), ImGuiCond_FirstUseEver);
+    static const char *ditherValues[] = {"No dithering (fastest)", "Game-dependent dithering (slow)",
+                                         "Always dither g-shaded polygons (slowest)"};
+
+    if (ImGui::Begin(_("Soft GPU configuration"), &m_showCfg)) {
+        if (ImGui::Combo("Dithering", &m_softPrim.m_useDither, ditherValues, 3)) {
+            changed = true;
+            g_emulator->settings.get<Emulator::SettingDither>() = m_softPrim.m_useDither;
+        }
+
+        ImGui::End();
+    }
+
+    return changed;
+}

--- a/src/gpu/soft/gpu.h
+++ b/src/gpu/soft/gpu.h
@@ -59,6 +59,7 @@
 void updateDisplay(void);
 void SetAutoFrameCap(void);
 void SetFixes(void);
+bool configure();
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/src/gpu/soft/interface.h
+++ b/src/gpu/soft/interface.h
@@ -48,13 +48,7 @@ class impl final : public GPU {
     virtual void writeStatus(uint32_t gdata) final;
     virtual int32_t dmaChain(uint32_t *baseAddrL, uint32_t addr) final;
     virtual void updateLace() final;
-    virtual bool configure() final {
-        if (m_showCfg) {
-            return m_softPrim.configure();
-        } else {
-            return false;
-        }
-    }
+    virtual bool configure() final;
 
     virtual void save(SaveStates::GPU &gpu) final;
     virtual void load(const SaveStates::GPU &gpu) final;

--- a/src/gpu/soft/prim.cc
+++ b/src/gpu/soft/prim.cc
@@ -88,7 +88,6 @@
 #include "gpu/soft/externals.h"
 #include "gpu/soft/gpu.h"
 #include "gpu/soft/soft.h"
-#include "imgui.h"
 
 ////////////////////////////////////////////////////////////////////////
 // globals
@@ -102,24 +101,6 @@ int iUseFixes;
 // ??
 bool bDoVSyncUpdate = false;
 
-bool PCSX::SoftGPU::SoftPrim::configure() {
-    bool changed = false;
-    ImGui::SetNextWindowPos(ImVec2(60, 60), ImGuiCond_FirstUseEver);
-    ImGui::SetNextWindowSize(ImVec2(300, 200), ImGuiCond_FirstUseEver);
-    static const char *ditherValues[] = {"No dithering (fastest)", "Game-dependent dithering (slow)",
-                                         "Always dither g-shaded polygons (slowest)"};
-
-    if (ImGui::Begin("Soft GPU configuration")) {
-        if (ImGui::Combo("Dithering", &m_useDither, ditherValues, 3)) {
-            changed = true;
-            g_emulator->settings.get<Emulator::SettingDither>() = m_useDither;
-        }
-
-        ImGui::End();
-    }
-
-    return changed;
-}
 
 static constexpr inline uint16_t BGR24to16(uint32_t BGR) {
     return (uint16_t)(((BGR >> 3) & 0x1f) | ((BGR & 0xf80000) >> 9) | ((BGR & 0xf800) >> 6));

--- a/src/gpu/soft/prim.h
+++ b/src/gpu/soft/prim.h
@@ -38,7 +38,6 @@ class SoftPrim : public SoftRenderer {
         }
     }
 
-    bool configure();
 
     inline void reset() {
         GlobalTextAddrX = 0;


### PR DESCRIPTION
Moved the GUI GPU Configure window method to the gpu/soft/gpu.cc file SoftGPU class. Doing this allow for adding the close 'X' button in the top right corner of the GPU configure window.

Added entry to gitignore to ignore *.log files inside the .vscode folder.

Added 'MACOSX_DEPLOYMENT_TARGET' environment to luajit clean recipe in Makefile to fix errors during 'make clean' on Mac due to the missing environment variable.