### PR TITLE
Implements capture/decode buffers for CD audio left/right.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,6 +10,7 @@ Nicolas "Pixel" Noble
 Herben / Asmblur
 Ryusan
 Peach / wheremyfoodat
+Mariano
 
 
 PCSX-Reloaded

--- a/src/core/logger.h
+++ b/src/core/logger.h
@@ -45,6 +45,7 @@ enum class LogClass : unsigned {
     GDB,            // GDB logs
     SYSTEM,         // system logs from the emulator itself
     LUA,            // logs emitted by the Lua VM
+    SPU,            // spu information
 };
 
 template <LogClass logClass, bool enabled>
@@ -71,10 +72,13 @@ typedef Logger<LogClass::SIO1, false> SIO1_LOGGER;
 typedef Logger<LogClass::GTE, false> GTE_LOGGER;
 typedef Logger<LogClass::CDROM, false> CDROM_LOGGER;
 typedef Logger<LogClass::CDROM_IO, false> CDROM_IO_LOGGER;
+
 typedef Logger<LogClass::HARDWARE, false> PSXHW_LOGGER;
 typedef Logger<LogClass::DMA, false> PSXDMA_LOGGER;
 typedef Logger<LogClass::MEMORY, false> PSXMEM_LOGGER;
 typedef Logger<LogClass::IRQ, false> PSXIRQ_LOGGER;
+typedef Logger<LogClass::SPU, false> PSXSPU_LOGGER;
+
 
 }  // namespace PCSX
 

--- a/src/core/psxemulator.cc
+++ b/src/core/psxemulator.cc
@@ -94,7 +94,7 @@ void PCSX::Emulator::EmuReset() {
     m_cheats->FreeCheatSearchResults();
     m_cheats->FreeCheatSearchMem();
     m_psxMem->psxMemReset();
-
+    m_spu->resetCaptureBuffer();
     m_psxCpu->psxReset();
     m_gpu->clearVRAM();
     m_pads->shutdown();

--- a/src/core/psxhw.cc
+++ b/src/core/psxhw.cc
@@ -44,6 +44,7 @@ void PCSX::HW::psxHwReset() {
     PCSX::g_emulator->m_mdec->mdecInit();  // initialize mdec decoder
     PCSX::g_emulator->m_cdrom->reset();
     PCSX::g_emulator->m_psxCounters->psxRcntInit();
+    PCSX::g_emulator->m_spu->resetCaptureBuffer();
 }
 
 uint8_t PCSX::HW::psxHwRead8(uint32_t add) {

--- a/src/core/spu.h
+++ b/src/core/spu.h
@@ -58,6 +58,9 @@ class SPUInterface {
     virtual void async(uint32_t) = 0;
     virtual void writeDMAMem(uint16_t *, int) = 0;
     virtual void readDMAMem(uint16_t *, int) = 0;
+    virtual void lockSPURAM() = 0;
+    virtual void unlockSPURAM() = 0;
+    virtual void resetCaptureBuffer() = 0;
     virtual json getCfg() = 0;
     virtual void setCfg(const json &j) = 0;
     virtual void debug() = 0;

--- a/src/core/sstate.h
+++ b/src/core/sstate.h
@@ -104,6 +104,7 @@ typedef Protobuf::Message<TYPESTRING("XA"), XAFrequency, XANBits, XAStereo, XANS
     XA;
 typedef Protobuf::MessageField<XA, TYPESTRING("xa"), 3> XAField;
 typedef Protobuf::Field<Protobuf::UInt32, TYPESTRING("irq"), 4> SPUIrq;
+
 typedef Protobuf::Field<Protobuf::UInt64, TYPESTRING("irqptr"), 5> SPUIrqPtr;
 typedef Protobuf::MessageField<::PCSX::SPU::Chan::Data, TYPESTRING("data"), 1> Data;
 typedef Protobuf::MessageField<::PCSX::SPU::ADSRInfo, TYPESTRING("adsr"), 2> ADSRInfo;
@@ -113,8 +114,15 @@ typedef Protobuf::RepeatedField<Channel, 24, TYPESTRING("channel"), 6> Channels;
 typedef Protobuf::Field<Protobuf::UInt32, TYPESTRING("addr"), 7> SPUAddr;
 typedef Protobuf::Field<Protobuf::UInt16, TYPESTRING("ctrl"), 8> SPUCtrl;
 typedef Protobuf::Field<Protobuf::UInt16, TYPESTRING("stat"), 9> SPUStat;
+//Capture buffer
+typedef Protobuf::Field<Protobuf::Int32, TYPESTRING("cbStartInd"), 10> CBStartIndex;
+typedef Protobuf::Field<Protobuf::Int32, TYPESTRING("cbCurrInd"), 11> CBCurrIndex;
+typedef Protobuf::Field<Protobuf::Int32, TYPESTRING("cbEndInd"), 12> CBEndIndex;
+typedef Protobuf::Field<Protobuf::FixedBytes<1024 * 8 * 2>, TYPESTRING("CBLeft"), 13> CBCDLeft;
+typedef Protobuf::Field<Protobuf::FixedBytes<1024 * 8 * 2>, TYPESTRING("CBRight"), 14> CBCDRight;
+
 typedef Protobuf::Message<TYPESTRING("SPU"), SPURam, SPUPorts, XAField, SPUIrq, SPUIrqPtr, Channels, SPUAddr, SPUCtrl,
-                          SPUStat>
+                          SPUStat, CBStartIndex, CBCurrIndex, CBEndIndex, CBCDLeft, CBCDRight>
     SPU;
 typedef Protobuf::MessageField<SPU, TYPESTRING("spu"), 6> SPUField;
 

--- a/src/core/sstate.h
+++ b/src/core/sstate.h
@@ -118,11 +118,13 @@ typedef Protobuf::Field<Protobuf::UInt16, TYPESTRING("stat"), 9> SPUStat;
 typedef Protobuf::Field<Protobuf::Int32, TYPESTRING("cbStartInd"), 10> CBStartIndex;
 typedef Protobuf::Field<Protobuf::Int32, TYPESTRING("cbCurrInd"), 11> CBCurrIndex;
 typedef Protobuf::Field<Protobuf::Int32, TYPESTRING("cbEndInd"), 12> CBEndIndex;
-typedef Protobuf::Field<Protobuf::FixedBytes<1024 * 8 * 2>, TYPESTRING("CBLeft"), 13> CBCDLeft;
-typedef Protobuf::Field<Protobuf::FixedBytes<1024 * 8 * 2>, TYPESTRING("CBRight"), 14> CBCDRight;
+typedef Protobuf::Field<Protobuf::Int32, TYPESTRING("cbVoiceInd"), 13> CBVoiceIndex;
+
+typedef Protobuf::Field<Protobuf::FixedBytes<1024 * 16 * 2>, TYPESTRING("CBLeft"), 14> CBCDLeft;
+typedef Protobuf::Field<Protobuf::FixedBytes<1024 * 16 * 2>, TYPESTRING("CBRight"), 15> CBCDRight;
 
 typedef Protobuf::Message<TYPESTRING("SPU"), SPURam, SPUPorts, XAField, SPUIrq, SPUIrqPtr, Channels, SPUAddr, SPUCtrl,
-                          SPUStat, CBStartIndex, CBCurrIndex, CBEndIndex, CBCDLeft, CBCDRight>
+                          SPUStat, CBStartIndex, CBCurrIndex, CBEndIndex, CBVoiceIndex, CBCDLeft, CBCDRight>
     SPU;
 typedef Protobuf::MessageField<SPU, TYPESTRING("spu"), 6> SPUField;
 

--- a/src/spu/cfg.cc
+++ b/src/spu/cfg.cc
@@ -97,8 +97,8 @@ with some games, but slows SPU processing.)"));
                             IM_ARRAYSIZE(interpolationValues));
     changed |= ImGui::Checkbox(_("Mono"), &settings.get<Mono>().value);
     ShowHelpMarker(_("Downmixes stereo to mono."));
-    changed |= ImGui::Checkbox(_("Decoded buffers IRQ"), &settings.get<DBufIRQ>().value);
-    ShowHelpMarker(_("Generates IRQs when buffers are decoded."));
+    changed |= ImGui::Checkbox(_("Capture/decode buffer IRQ"), &settings.get<DBufIRQ>().value);
+    ShowHelpMarker(_("Activates SPU IRQs based on writes to the decode/capture buffer. This option is necessary for some games."));
 
     ImGui::End();
     return changed;

--- a/src/spu/dma.cc
+++ b/src/spu/dma.cc
@@ -50,11 +50,11 @@ void PCSX::SPU::impl::unlockSPURAM() { cbMtx.unlock(); }
 
 void PCSX::SPU::impl::resetCaptureBuffer() {
     if (settings.get<DBufIRQ>().value) pMixIrq = spuMemC;  // enable decoded buffer irqs by setting the address
-    memset(captureBuffer->CDCapLeft, 0, CaptureBuffer::CB_SIZE);
-    memset(captureBuffer->CDCapRight, 0, CaptureBuffer::CB_SIZE);
-    captureBuffer->currIndex = 0;
-    captureBuffer->endIndex = 0;
-    captureBuffer->startIndex = 0;
+    memset(captureBuffer.CDCapLeft, 0, CaptureBuffer::CB_SIZE);
+    memset(captureBuffer.CDCapRight, 0, CaptureBuffer::CB_SIZE);
+    captureBuffer.currIndex = 0;
+    captureBuffer.endIndex = 0;
+    captureBuffer.startIndex = 0;
 }
 
     // Main RAM -> SPU RAM DMA

--- a/src/spu/dma.cc
+++ b/src/spu/dma.cc
@@ -29,14 +29,13 @@
 
 // SPU RAM -> Main RAM DMA
 void PCSX::SPU::impl::readDMAMem(uint16_t* mainMem, int size) {
-    if (pMixIrq) 
-        std::unique_lock<std::mutex> lock(cbMtx);
+    if (pMixIrq) cbMtx.lock();
 
     for (int i = 0; i < size; i++) {
         *mainMem++ = spuMem[spuAddr >> 1];  // Copy 2 bytes
         spuAddr = (spuAddr + 2) & 0x7ffff;  // Increment SPU address and wrap around
     }
-
+    if (pMixIrq) cbMtx.unlock();
     iSpuAsyncWait = 0;
 }
 
@@ -55,17 +54,18 @@ void PCSX::SPU::impl::resetCaptureBuffer() {
     captureBuffer.currIndex = 0;
     captureBuffer.endIndex = 0;
     captureBuffer.startIndex = 0;
+    capBufVoiceIndex = 0;
 }
 
     // Main RAM -> SPU RAM DMA
 void PCSX::SPU::impl::writeDMAMem(uint16_t* mainMem, int size) {
-    if (pMixIrq)
-        std::unique_lock<std::mutex> lock(cbMtx);
+    if (pMixIrq) cbMtx.lock();
 
     for (int i = 0; i < size; i++) {
         spuMem[spuAddr >> 1] = *mainMem++;  // Copy 2 bytes
         spuAddr = (spuAddr + 2) & 0x7ffff;  // Increment SPU address and wrap around
     }
 
+    if (pMixIrq) cbMtx.unlock();
     iSpuAsyncWait = 0;
 }

--- a/src/spu/freeze.cc
+++ b/src/spu/freeze.cc
@@ -68,6 +68,7 @@ void PCSX::SPU::impl::save(SaveStates::SPU &spu) {
     spu.get<SaveStates::CBCurrIndex>().value = captureBuffer.currIndex;
     spu.get<SaveStates::CBEndIndex>().value = captureBuffer.endIndex;
     spu.get<SaveStates::CBStartIndex>().value = captureBuffer.startIndex;
+    spu.get<SaveStates::CBVoiceIndex>().value = capBufVoiceIndex;
 
     spu.get<SaveStates::SPURam>().copyFrom(reinterpret_cast<uint8_t *>(spuMem));
     spu.get<SaveStates::SPUPorts>().copyFrom(reinterpret_cast<uint8_t *>(regArea));
@@ -115,6 +116,7 @@ void PCSX::SPU::impl::load(const SaveStates::SPU &spu) {
     captureBuffer.currIndex = spu.get<SaveStates::CBCurrIndex>().value;
     captureBuffer.endIndex = spu.get<SaveStates::CBEndIndex>().value;
     captureBuffer.startIndex = spu.get<SaveStates::CBStartIndex>().value;
+    capBufVoiceIndex = spu.get<SaveStates::CBVoiceIndex>().value;
 
     spu.get<SaveStates::SPURam>().copyTo(reinterpret_cast<uint8_t *>(spuMem));
     spu.get<SaveStates::SPUPorts>().copyTo(reinterpret_cast<uint8_t *>(regArea));

--- a/src/spu/freeze.cc
+++ b/src/spu/freeze.cc
@@ -62,6 +62,13 @@ typedef struct {
 void PCSX::SPU::impl::save(SaveStates::SPU &spu) {
     RemoveThread();
 
+    //Capture buffer
+    spu.get<SaveStates::CBCDLeft>().copyFrom(reinterpret_cast<uint8_t *>(captureBuffer.CDCapLeft));
+    spu.get<SaveStates::CBCDRight>().copyFrom(reinterpret_cast<uint8_t *>(captureBuffer.CDCapRight));
+    spu.get<SaveStates::CBCurrIndex>().value = captureBuffer.currIndex;
+    spu.get<SaveStates::CBEndIndex>().value = captureBuffer.endIndex;
+    spu.get<SaveStates::CBStartIndex>().value = captureBuffer.startIndex;
+
     spu.get<SaveStates::SPURam>().copyFrom(reinterpret_cast<uint8_t *>(spuMem));
     spu.get<SaveStates::SPUPorts>().copyFrom(reinterpret_cast<uint8_t *>(regArea));
     auto &xa = spu.get<SaveStates::XAField>();
@@ -102,6 +109,12 @@ void PCSX::SPU::impl::save(SaveStates::SPU &spu) {
 
 void PCSX::SPU::impl::load(const SaveStates::SPU &spu) {
     RemoveThread();  // we stop processing while doing the save!
+
+    spu.get<SaveStates::CBCDLeft>().copyTo(reinterpret_cast<uint8_t *>(captureBuffer.CDCapLeft));
+    spu.get<SaveStates::CBCDRight>().copyTo(reinterpret_cast<uint8_t *>(captureBuffer.CDCapRight));
+    captureBuffer.currIndex = spu.get<SaveStates::CBCurrIndex>().value;
+    captureBuffer.endIndex = spu.get<SaveStates::CBEndIndex>().value;
+    captureBuffer.startIndex = spu.get<SaveStates::CBStartIndex>().value;
 
     spu.get<SaveStates::SPURam>().copyTo(reinterpret_cast<uint8_t *>(spuMem));
     spu.get<SaveStates::SPUPorts>().copyTo(reinterpret_cast<uint8_t *>(regArea));

--- a/src/spu/interface.h
+++ b/src/spu/interface.h
@@ -92,6 +92,7 @@ class impl final : public SPUInterface {
 
     // spu
     void MainThread();
+    void writeCaptureBufferCD(int numbSamples);
     void SetupStreams();
     void RemoveStreams();
     void SetupThread();
@@ -131,6 +132,7 @@ class impl final : public SPUInterface {
 
     // psx buffer / addresses
     uint16_t regArea[10000];
+    // Note that SPU ram is a uint16_t, so total size is 512KB.
     uint16_t spuMem[256 * 1024];
     uint8_t *spuMemC;
     uint8_t *pSpuIrq = 0;
@@ -139,7 +141,7 @@ class impl final : public SPUInterface {
 
 
     struct CaptureBuffer {
-        static const int CB_SIZE = 1024 * 8;
+        static const int CB_SIZE = 1024 * 16;
         // These buffers have to be large enough to allow the CD-XA to stream in enough data.
         uint16_t CDCapLeft[CB_SIZE] = {0};
         uint16_t CDCapRight[CB_SIZE] = {0};
@@ -149,10 +151,12 @@ class impl final : public SPUInterface {
         int32_t currIndex = 0;
     };
     std::mutex cbMtx;
-    //std::mutex cbMtx;
 
+    // The temporary cap buffer for CD Audio left/right.
     CaptureBuffer captureBuffer;
-
+    // The cap buffer index for voice 1 and voice 3.
+    int32_t capBufVoiceIndex = 0;
+   
     // user settings
     SettingsType settings;
 

--- a/src/spu/interface.h
+++ b/src/spu/interface.h
@@ -48,6 +48,9 @@ class impl final : public SPUInterface {
     // void playSample(uint8_t);
     void writeRegister(uint32_t, uint16_t) final;
     uint16_t readRegister(uint32_t) final;
+    void lockSPURAM() final;
+    void unlockSPURAM() final;
+    void resetCaptureBuffer() final;
     void writeDMAMem(uint16_t *, int) final;
     void readDMAMem(uint16_t *, int) final;
     virtual void playADPCMchannel(xa_decode_t *) final;
@@ -133,6 +136,22 @@ class impl final : public SPUInterface {
     uint8_t *pSpuIrq = 0;
     uint8_t *pSpuBuffer;
     uint8_t *pMixIrq = 0;
+
+
+    struct CaptureBuffer {
+        static const int CB_SIZE = 1024 * 8;
+        // These buffers have to be large enough to allow the CD-XA to stream in enough data.
+        uint16_t CDCapLeft[CB_SIZE] = {0};
+        uint16_t CDCapRight[CB_SIZE] = {0};
+
+        int32_t startIndex = 0;
+        int32_t endIndex = 0;
+        int32_t currIndex = 0;
+    };
+    std::mutex cbMtx;
+    //std::mutex cbMtx;
+
+    CaptureBuffer *captureBuffer = nullptr;
 
     // user settings
     SettingsType settings;

--- a/src/spu/interface.h
+++ b/src/spu/interface.h
@@ -151,7 +151,7 @@ class impl final : public SPUInterface {
     std::mutex cbMtx;
     //std::mutex cbMtx;
 
-    CaptureBuffer *captureBuffer = nullptr;
+    CaptureBuffer captureBuffer;
 
     // user settings
     SettingsType settings;

--- a/src/spu/spu.cc
+++ b/src/spu/spu.cc
@@ -422,6 +422,9 @@ void PCSX::SPU::impl::MainThread() {
     unsigned int nSample;
     int ch, predict_nr, shift_factor, flags, d, s;
     int bIRQReturn = 0;
+    int32_t tmpCapVoice1Index = 0;
+    int32_t tmpCapVoice3Index = 0;
+
     SPUCHAN *pChannel;
     while (!bEndThread)  // until we are shutting down
     {
@@ -468,6 +471,9 @@ void PCSX::SPU::impl::MainThread() {
             goto GOON;  // -> directly jump to the continue point
         }
 
+        tmpCapVoice1Index = capBufVoiceIndex;
+        tmpCapVoice3Index = capBufVoiceIndex;
+
         //--------------------------------------------------//
         //- main channel loop                              -//
         //--------------------------------------------------//
@@ -481,7 +487,21 @@ void PCSX::SPU::impl::MainThread() {
                     dwNewChannel &= ~(1 << ch);  // clear new channel bit
                 }
 
-                if (!pChannel->data.get<PCSX::SPU::Chan::On>().value) continue;  // channel not playing? next
+                if (!pChannel->data.get<PCSX::SPU::Chan::On>().value) {
+                    // Although the voices may stop outputting audio, the capture buffer is still filling up.
+                    if (pMixIrq && ch == 1) {
+                        std::unique_lock<std::mutex> lock(cbMtx);
+                        for (int c = 0; c < NSSIZE; c++) 
+                            spuMem[tmpCapVoice1Index + c + 0x400] = 0;
+                        tmpCapVoice1Index = (tmpCapVoice1Index + NSSIZE) % 0x200;
+                    } else if (pMixIrq && ch == 3) {
+                        std::unique_lock<std::mutex> lock(cbMtx);
+                        for (int c = 0; c < NSSIZE; c++) 
+                            spuMem[tmpCapVoice3Index + c + 0x600] = 0;
+                        tmpCapVoice3Index = (tmpCapVoice3Index + NSSIZE) % 0x200;
+                    }
+                    continue;  // channel not playing? next
+                } 
 
                 if (pChannel->data.get<PCSX::SPU::Chan::ActFreq>().value !=
                     pChannel->data.get<PCSX::SPU::Chan::UsedFreq>().value)  // new psx frequency?
@@ -505,6 +525,17 @@ void PCSX::SPU::impl::MainThread() {
                                 pChannel->data.get<PCSX::SPU::Chan::On>().value = false;  // -> turn everything off
                                 pChannel->ADSRX.get<exVolume>().value = 0;
                                 pChannel->ADSRX.get<exEnvelopeVol>().value = 0;
+                                // Although the voices may stop outputting audio, the capture buffer is still filling
+                                // up. At this point, ns samples are already filled, we need (NSSIZE-ns) more samples.
+                                if (pMixIrq && ch == 1) {
+                                    std::unique_lock<std::mutex> lock(cbMtx);
+                                    for (int c = ns; c < NSSIZE; c++) spuMem[tmpCapVoice1Index + c + 0x400] = 0;
+                                    tmpCapVoice1Index = (tmpCapVoice1Index + (NSSIZE-ns)) % 0x200;
+                                } else if (pMixIrq && ch == 3) {
+                                    std::unique_lock<std::mutex> lock(cbMtx);
+                                    for (int c = ns; c < NSSIZE; c++) spuMem[tmpCapVoice3Index + c + 0x600] = 0;
+                                    tmpCapVoice3Index = (tmpCapVoice3Index + (NSSIZE - ns)) % 0x200;
+                                }
                                 goto ENDX;  // -> and done for this channel
                             }
 
@@ -621,7 +652,22 @@ void PCSX::SPU::impl::MainThread() {
                     else
                         fa = iGetInterpolationVal(pChannel);  // get sample val
 
-                    pChannel->data.get<PCSX::SPU::Chan::sval>().value = (m_adsr.mix(pChannel) * fa) / 1023;  // mix adsr
+
+                    int32_t mixedSample = (m_adsr.mix(pChannel) * fa) / 1023; // mix adsr
+                    pChannel->data.get<PCSX::SPU::Chan::sval>().value = mixedSample;  
+
+                    // Capture buffer should contain voice1/3 sample after any adsr processing but before volume processing?
+                    mixedSample = std::min(0xFFFF, std::max(-0xFFFF, mixedSample));
+                    if (pMixIrq && ch == 1) {
+                        std::unique_lock<std::mutex> lock(cbMtx);
+                        spuMem[tmpCapVoice1Index + 0x400] = mixedSample;
+                        tmpCapVoice1Index = (tmpCapVoice1Index + 1) % 0x200;
+                    }
+                    else if (pMixIrq && ch == 3) {
+                        std::unique_lock<std::mutex> lock(cbMtx);
+                        spuMem[tmpCapVoice3Index + 0x600] = mixedSample;
+                        tmpCapVoice3Index = (tmpCapVoice3Index + 1) % 0x200;
+                    }
 
                     if (pChannel->data.get<PCSX::SPU::Chan::FMod>().value == 2)  // fmod freq channel
                         iFMod[ns] = pChannel->data.get<PCSX::SPU::Chan::sval>()
@@ -659,26 +705,8 @@ void PCSX::SPU::impl::MainThread() {
             }
         }
 
-        // TODO: Also add voice 1 and voice 3 sample data to capture buffer.
         // Write from our temporary capture buffer to the actual SPU RAM.
-        if (pMixIrq) {
-            cbMtx.lock();
-            for (ns = 0; ns < NSSIZE; ns++) {
-                // If there are no samples left in the temp buffer,
-                // we still HAVE to keep writing to the capture buffer.
-                if (captureBuffer.startIndex == captureBuffer.endIndex) {
-                    spuMem[captureBuffer.currIndex] = 0;
-                    spuMem[captureBuffer.currIndex + 0x200] = 0;
-                } else {
-                    spuMem[captureBuffer.currIndex] = captureBuffer.CDCapLeft[captureBuffer.startIndex];
-                    spuMem[captureBuffer.currIndex + 0x200] = captureBuffer.CDCapRight[captureBuffer.startIndex];
-                    captureBuffer.startIndex = (captureBuffer.startIndex + 1) % CaptureBuffer::CB_SIZE;
-                }
-                captureBuffer.currIndex = (captureBuffer.currIndex + 1) % 0x200;
-            }
-            cbMtx.unlock();
-        }
-
+        writeCaptureBufferCD(NSSIZE);
 
         //---------------------------------------------------//
         //- here we have another 1 ms of sound data
@@ -786,6 +814,32 @@ void PCSX::SPU::impl::MainThread() {
     // end of big main loop...
 
     bThreadEnded = 1;
+}
+
+void PCSX::SPU::impl::writeCaptureBufferCD(int numbSamples) {
+    if (pMixIrq) {
+        std::unique_lock<std::mutex> lock(cbMtx);
+        for (int n = 0; n < numbSamples; n++) {
+            if (captureBuffer.startIndex == captureBuffer.endIndex) {
+                // If there are no samples left in the temp buffer,
+                // we still HAVE to keep writing to the capture buffer.
+                spuMem[captureBuffer.currIndex] = 0;
+                spuMem[captureBuffer.currIndex + 0x200] = 0;
+            } else {
+                spuMem[captureBuffer.currIndex] = captureBuffer.CDCapLeft[captureBuffer.startIndex];
+                spuMem[captureBuffer.currIndex + 0x200] = captureBuffer.CDCapRight[captureBuffer.startIndex];
+                captureBuffer.startIndex = (captureBuffer.startIndex + 1) % CaptureBuffer::CB_SIZE;
+            }
+            captureBuffer.currIndex = (captureBuffer.currIndex + 1) % 0x200;
+        }
+        // Update the capture buffer voice index, which in the end, should be the same as
+        // tmpCapVoice1Index, tmpCapVoice3Index and captureBuffer.currIndex.
+        // Unless I'm missing something in Pete's code.
+        /* capBufVoiceIndex = (capBufVoiceIndex + NSSIZE) % 0x200;
+        if ((tmpCapVoice1Index != tmpCapVoice3Index) || (tmpCapVoice3Index != captureBuffer.currIndex) ||
+            (captureBuffer.currIndex != capBufVoiceIndex))
+            g_system->log(LogClass::SPU, "Capture buffer indices are not the same.\n");*/
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/spu/spu.cc
+++ b/src/spu/spu.cc
@@ -666,15 +666,15 @@ void PCSX::SPU::impl::MainThread() {
             for (ns = 0; ns < NSSIZE; ns++) {
                 // If there are no samples left in the temp buffer,
                 // we still HAVE to keep writing to the capture buffer.
-                if (captureBuffer->startIndex == captureBuffer->endIndex) {
-                    spuMem[captureBuffer->currIndex] = 0;
-                    spuMem[captureBuffer->currIndex + 0x200] = 0;
+                if (captureBuffer.startIndex == captureBuffer.endIndex) {
+                    spuMem[captureBuffer.currIndex] = 0;
+                    spuMem[captureBuffer.currIndex + 0x200] = 0;
                 } else {
-                    spuMem[captureBuffer->currIndex] = captureBuffer->CDCapLeft[captureBuffer->startIndex];
-                    spuMem[captureBuffer->currIndex + 0x200] = captureBuffer->CDCapRight[captureBuffer->startIndex];
-                    captureBuffer->startIndex = (captureBuffer->startIndex + 1) % CaptureBuffer::CB_SIZE;
+                    spuMem[captureBuffer.currIndex] = captureBuffer.CDCapLeft[captureBuffer.startIndex];
+                    spuMem[captureBuffer.currIndex + 0x200] = captureBuffer.CDCapRight[captureBuffer.startIndex];
+                    captureBuffer.startIndex = (captureBuffer.startIndex + 1) % CaptureBuffer::CB_SIZE;
                 }
-                captureBuffer->currIndex = (captureBuffer->currIndex + 1) % 0x200;
+                captureBuffer.currIndex = (captureBuffer.currIndex + 1) % 0x200;
             }
             cbMtx.unlock();
         }
@@ -827,7 +827,6 @@ void PCSX::SPU::impl::playADPCMchannel(xa_decode_t *xap) {
 
 long PCSX::SPU::impl::init(void) {
     spuMemC = (uint8_t *)spuMem;  // just small setup
-    captureBuffer = new CaptureBuffer();
 
     wipeChannels();
     return 0;

--- a/src/spu/xa.cc
+++ b/src/spu/xa.cc
@@ -62,6 +62,10 @@ void PCSX::SPU::impl::FeedXA(xa_decode_t *xap) {
     spos = 0x10000L;
     sinc = (xap->nsamples << 16) / iSize;  // calc freq by num / size
 
+    // We need the lock for capture buffers. The question is, do we put it here or in the inner loop?
+    if (pMixIrq)
+        std::unique_lock<std::mutex> lock(cbMtx);
+
     if (xap->stereo) {
         uint32_t *pS = (uint32_t *)xap->pcm;
         uint32_t l = 0;
@@ -94,8 +98,16 @@ void PCSX::SPU::impl::FeedXA(xa_decode_t *xap) {
             }
 
             MiniAudio::Frame f;
-            f.L = static_cast<int16_t>(l & 0xffff) / voldiv;
-            f.R = static_cast<int16_t>(l >> 16) / voldiv;
+            int16_t rawSampleL = static_cast<int16_t>(l & 0xffff);
+            int16_t rawSampleR = static_cast<int16_t>(l >> 16);
+            if (pMixIrq) {
+                captureBuffer->CDCapLeft[captureBuffer->endIndex] = rawSampleL;
+                captureBuffer->CDCapRight[captureBuffer->endIndex] = rawSampleR;
+                captureBuffer->endIndex = (captureBuffer->endIndex + 1) % 0x200;
+            }
+            f.L =  rawSampleL / voldiv;
+            f.R = rawSampleR / voldiv;
+
             *XAFeed++ = f;
             spos += sinc;
         }
@@ -127,12 +139,22 @@ void PCSX::SPU::impl::FeedXA(xa_decode_t *xap) {
             }
 
             MiniAudio::Frame f;
-            f.L = static_cast<int16_t>(l) / voldiv;
+            int16_t rawSampleL = static_cast<int16_t>(l);
+            // Write the CD-XA samples (left/right) to a temporary buffer. Wrap around if necessary.
+            if (pMixIrq) {
+                captureBuffer->CDCapLeft[captureBuffer->endIndex] = (uint16_t)rawSampleL;
+                captureBuffer->CDCapRight[captureBuffer->endIndex] = (uint16_t)rawSampleL;
+                captureBuffer->endIndex = (captureBuffer->endIndex + 1) % CaptureBuffer::CB_SIZE;
+                if (captureBuffer->endIndex == captureBuffer->startIndex)
+                    g_system->printf(_("Capture buffer is overflowing.\n"));
+            }
+
+            f.L = rawSampleL / voldiv;
             f.R = f.L;
             *XAFeed++ = f;
             spos += sinc;
         }
     }
-
+    
     m_audioOut.feedStreamData(reinterpret_cast<MiniAudio::Frame *>(XABuffer), (XAFeed - XABuffer), 1);
 }

--- a/src/spu/xa.cc
+++ b/src/spu/xa.cc
@@ -101,9 +101,11 @@ void PCSX::SPU::impl::FeedXA(xa_decode_t *xap) {
             int16_t rawSampleL = static_cast<int16_t>(l & 0xffff);
             int16_t rawSampleR = static_cast<int16_t>(l >> 16);
             if (pMixIrq) {
-                captureBuffer->CDCapLeft[captureBuffer->endIndex] = rawSampleL;
-                captureBuffer->CDCapRight[captureBuffer->endIndex] = rawSampleR;
-                captureBuffer->endIndex = (captureBuffer->endIndex + 1) % 0x200;
+                captureBuffer.CDCapLeft[captureBuffer.endIndex] = rawSampleL;
+                captureBuffer.CDCapRight[captureBuffer.endIndex] = rawSampleR;
+                captureBuffer.endIndex = (captureBuffer.endIndex + 1) % 0x200;
+                if (captureBuffer.endIndex == captureBuffer.startIndex)
+                    g_system->printf(_("Capture buffer is overflowing.\n"));
             }
             f.L =  rawSampleL / voldiv;
             f.R = rawSampleR / voldiv;
@@ -142,10 +144,10 @@ void PCSX::SPU::impl::FeedXA(xa_decode_t *xap) {
             int16_t rawSampleL = static_cast<int16_t>(l);
             // Write the CD-XA samples (left/right) to a temporary buffer. Wrap around if necessary.
             if (pMixIrq) {
-                captureBuffer->CDCapLeft[captureBuffer->endIndex] = (uint16_t)rawSampleL;
-                captureBuffer->CDCapRight[captureBuffer->endIndex] = (uint16_t)rawSampleL;
-                captureBuffer->endIndex = (captureBuffer->endIndex + 1) % CaptureBuffer::CB_SIZE;
-                if (captureBuffer->endIndex == captureBuffer->startIndex)
+                captureBuffer.CDCapLeft[captureBuffer.endIndex] = (uint16_t)rawSampleL;
+                captureBuffer.CDCapRight[captureBuffer.endIndex] = (uint16_t)rawSampleL;
+                captureBuffer.endIndex = (captureBuffer.endIndex + 1) % CaptureBuffer::CB_SIZE;
+                if (captureBuffer.endIndex == captureBuffer.startIndex)
                     g_system->printf(_("Capture buffer is overflowing.\n"));
             }
 


### PR DESCRIPTION
- Updates a temporary buffer in xa.cc for CD audio left/right, which will be written to the capture buffer in spu.cc.
- Setting can be updated by the 'Capture/decode buffer IRQ' option in the SPU config. Setting will also be updated on hard reset.
- Contains several locks to assure thread-safe handling of SPU RAM. 