### PR TITLE
Correct labels for hi and lo registers, which were flipped

### DIFF
--- a/src/gui/widgets/registers.cc
+++ b/src/gui/widgets/registers.cc
@@ -46,10 +46,10 @@ void PCSX::Widgets::Registers::draw(PCSX::GUI* gui, PCSX::psxRegisters* register
                 if (counter >= 32) {
                     switch (counter) {
                         case 32:
-                            name = "hi";
+                            name = "lo";
                             break;
                         case 33:
-                            name = "lo";
+                            name = "hi";
                             break;
                         default:
                             name = "??";


### PR DESCRIPTION
Fix for issue #672. Compare the changed code to the definition of psxGPRRegs in r3000a.h to see the issue. 