### PR TITLE
Add AUR Package to README for Arch-Based Distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ sudo apt-get install -y build-essential git make pkg-config clang g++ g++-mipsel
 
  - Arch derivatives :
 
+The pcsx-redux-git can be installed from the AUR using your AUR helper of choice (e.g., paru):
+
+```bash
+paru -S pcsx-redux-git
+```
+
+Alternatively, the following steps describe how to install dependencies and compile manually:
+
 ```bash
 sudo pacman -S clang git make pkg-config ffmpeg libuv zlib sdl2 glfw-x11 curl xorg-server-xvfb
 ```

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ sudo apt-get install -y build-essential git make pkg-config clang g++ g++-mipsel
 
  - Arch derivatives :
 
-The pcsx-redux-git can be installed from the AUR using your AUR helper of choice (e.g., paru):
+The `pcsx-redux-git` package can be installed from the AUR using your AUR helper of choice (e.g., paru):
 
 ```bash
 paru -S pcsx-redux-git


### PR DESCRIPTION
This adds the AUR package [pcsx-redux-git](https://aur.archlinux.org/packages/pcsx-redux-git) to the README instructions for Arch-based distros. I've kept the previous instructions as they're still useful for setting up a dev environment and/or manually compiling. Let me know if you think this needs anything else!