### PR TITLE
SPU Code Refactoring - breaking up fat main loop - removing waiting c…

### DIFF
--- a/src/spu/interface.h
+++ b/src/spu/interface.h
@@ -91,8 +91,37 @@ class impl final : public SPUInterface {
     static const size_t NSSIZE = 45;
 
     // spu
+    class main_t_variables {
+      public:
+        int s_1, s_2, fa, ns;
+        uint8_t *start;
+        unsigned int nSample;
+        int ch, predict_nr, shift_factor, flags, d, s;
+        int bIRQReturn = 0;
+        int voldiv = 0;
+        int32_t tmpCapVoice1Index = 0;
+        int32_t tmpCapVoice3Index = 0;
+        PCSX::SPU::SPUCHAN *pChannel;
+        void reset() {
+            s_1 = s_2 = fa = ns = 0;
+            start = nullptr;
+            nSample = ch = predict_nr = shift_factor = flags = d = s = bIRQReturn = voldiv = 0;
+            tmpCapVoice1Index = 0;
+            tmpCapVoice3Index = 0;
+            pChannel = nullptr;
+        }
+    } _vars;
     void MainThread();
     void writeCaptureBufferCD(int numbSamples);
+    void mixAllChannels();
+    void main_t_pMixIrq();
+    void main_t_FeedStreamData();
+    void main_t_IrqCheck();
+    void main_t_FlagHandler();
+    void main_t_StopSign();
+    void main_t_SBPos_28();
+    void main_t_get_noise_or_sample_mixedSample();
+    void main_t_fmod_freq_channel();
     void SetupStreams();
     void RemoveStreams();
     void SetupThread();

--- a/src/spu/interface.h
+++ b/src/spu/interface.h
@@ -91,7 +91,7 @@ class impl final : public SPUInterface {
     static const size_t NSSIZE = 45;
 
     // spu
-    class main_t_variables {
+    struct MainThreadVariables {
       public:
         int s_1, s_2, fa, ns;
         uint8_t *start;
@@ -102,26 +102,18 @@ class impl final : public SPUInterface {
         int32_t tmpCapVoice1Index = 0;
         int32_t tmpCapVoice3Index = 0;
         PCSX::SPU::SPUCHAN *pChannel;
-        void reset() {
-            s_1 = s_2 = fa = ns = 0;
-            start = nullptr;
-            nSample = ch = predict_nr = shift_factor = flags = d = s = bIRQReturn = voldiv = 0;
-            tmpCapVoice1Index = 0;
-            tmpCapVoice3Index = 0;
-            pChannel = nullptr;
-        }
-    } _vars;
+    };
     void MainThread();
     void writeCaptureBufferCD(int numbSamples);
-    void mixAllChannels();
-    void main_t_pMixIrq();
-    void main_t_FeedStreamData();
-    void main_t_IrqCheck();
-    void main_t_FlagHandler();
-    void main_t_StopSign();
-    void main_t_SBPos_28();
-    void main_t_get_noise_or_sample_mixedSample();
-    void main_t_fmod_freq_channel();
+    void MixAllChannels(MainThreadVariables &mainThraadVars);
+    void PMixIrq(MainThreadVariables &mainThraadVars);
+    void FeedStreamData(MainThreadVariables &mainThraadVars);
+    void IrqCheck(MainThreadVariables &mainThraadVars);
+    void FlagHandler(MainThreadVariables &mainThraadVars);
+    void StopSign(MainThreadVariables &mainThraadVars);
+    void SBPos_28(MainThreadVariables &mainThraadVars); // needs a better explanatory naming, I didn't find one 
+    void GetNoiseOrSampleMixedSample(MainThreadVariables &mainThraadVars);
+    void FModFreqChannel(MainThreadVariables &mainThraadVars);
     void SetupStreams();
     void RemoveStreams();
     void SetupThread();

--- a/src/support/circular.h
+++ b/src/support/circular.h
@@ -25,9 +25,8 @@
 #include <chrono>
 #include <condition_variable>
 #include <mutex>
-#include <queue>
 #include <stdexcept>
-#include <tuple>
+
 namespace PCSX {
 
 template <typename T, size_t BS = 1024>
@@ -42,28 +41,10 @@ class Circular {
         std::unique_lock<std::mutex> l(m_mu);
         return bufferedLocked();
     }
-
-    std::queue<std::tuple<const T*, size_t>> tempQueue;
     bool enqueue(const T* data, size_t N) {
-        if (tempQueue.size()) {
-            // throw std::runtime_error("Trying to enqueue too much data");
-            tempQueue.push(std::make_tuple(data, N));
-            if (std::get<1>(tempQueue.front()) < BUFFER_SIZE) {
-                do {
-                    std::tuple<const T*, size_t> front = tempQueue.front();
-                    tempQueue.pop();
-                    startEnqueueSafe(std::get<0>(front), std::get<1>(front));
-                } while (tempQueue.size() && std::get<1>(tempQueue.front()) < BUFFER_SIZE);
-            }
-            return true;
-        } else if (N > BUFFER_SIZE) {
-            tempQueue.push(std::make_tuple(data, N));
-            return true;
-        } else {
-            return startEnqueueSafe(data, N);
+        if (N > BUFFER_SIZE) {
+            throw std::runtime_error("Trying to enqueue too much data");
         }
-    }
-    inline bool startEnqueueSafe(const T* data, size_t N) {
         std::unique_lock<std::mutex> l(m_mu);
         using namespace std::chrono_literals;
         bool safe = m_cv.wait_for(l, 200ms, [this, N]() -> bool { return N < availableLocked(); });


### PR DESCRIPTION
- Breaking up the monolithic `MainThread `method into manageable methods (more scalable)   
- Code Refactoring 
- Decreasing the probability of losing voice data by removing waiting cycles (`while `loop at `feedStreamData`)
- Adding a temporary queue in the `circular.h `to decrease voice data loss and **remove exception throwing**