### PR TITLE
Check ImGui header to fix builds on Linux with system zlib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PACKAGES := capstone freetype2 glfw3 libavcodec libavformat libavutil libswresam
 
 LOCALES := fr
 
-ifeq ($(wildcard third_party/zlib/zlib.h),)
+ifeq ($(wildcard third_party/imgui/imgui.h),)
 HAS_SUBMODULES = false
 else
 HAS_SUBMODULES = true


### PR DESCRIPTION
The recursive checkout check in `Makefile` was causing build failures on Linux systems that used the system `zlib`, since the header did not need to be included in the source tree. This broke the AUR package, which only checks out dependencies needed to build the project.

This PR switches to the imgui.h header, which is unlikely to be outside the source tree on Linux systems.