### PR TITLE
Remove LDFLAGS for psyq-obj-parser to simplify deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ runtests: pcsx-redux-tests
 	./pcsx-redux-tests
 
 psyq-obj-parser: $(SUPPORT_OBJECTS) tools/psyq-obj-parser/psyq-obj-parser.cc
-	$(LD) -o $@ $(SUPPORT_OBJECTS) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) tools/psyq-obj-parser/psyq-obj-parser.cc -Ithird_party/ELFIO
+	$(LD) -o $@ $(SUPPORT_OBJECTS) $(CPPFLAGS) $(CXXFLAGS) tools/psyq-obj-parser/psyq-obj-parser.cc -Ithird_party/ELFIO
 
 ps1-packer: $(SUPPORT_OBJECTS) tools/ps1-packer/ps1-packer.cc
 	$(LD) -o $@ $(SUPPORT_OBJECTS) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) tools/ps1-packer/ps1-packer.cc


### PR DESCRIPTION
BEFORE:

```
root@91d6f9658f71:/esa# ldd psyq-obj-parser 
	linux-vdso.so.1 (0x00007ffd3d614000)
	libcapstone.so.3 => /lib/x86_64-linux-gnu/libcapstone.so.3 (0x00007f21b653d000)
	libfreetype.so.6 => /lib/x86_64-linux-gnu/libfreetype.so.6 (0x00007f21b647e000)
	libglfw.so.3 => not found
	libavcodec.so.58 => /lib/x86_64-linux-gnu/libavcodec.so.58 (0x00007f21b4ec1000)
	libavformat.so.58 => not found
	libavutil.so.56 => /lib/x86_64-linux-gnu/libavutil.so.56 (0x00007f21b4d98000)
	libswresample.so.3 => /lib/x86_64-linux-gnu/libswresample.so.3 (0x00007f21b4d74000)
	libuv.so.1 => not found
	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f21b4d69000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f21b4d46000)
	libnsl.so.1 => /lib/x86_64-linux-gnu/libnsl.so.1 (0x00007f21b4d29000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f21b4d23000)
	libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f21b4d05000)
	libGL.so.1 => /lib/x86_64-linux-gnu/libGL.so.1 (0x00007f21b4c7d000)
	libX11.so.6 => /lib/x86_64-linux-gnu/libX11.so.6 (0x00007f21b4b40000)
	libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f21b495e000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f21b480f000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f21b47f4000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f21b4600000)
	libpng16.so.16 => /lib/x86_64-linux-gnu/libpng16.so.16 (0x00007f21b45c8000)
	libvpx.so.6 => /lib/x86_64-linux-gnu/libvpx.so.6 (0x00007f21b4390000)
	libwebpmux.so.3 => /lib/x86_64-linux-gnu/libwebpmux.so.3 (0x00007f21b4384000)
	libwebp.so.6 => /lib/x86_64-linux-gnu/libwebp.so.6 (0x00007f21b431a000)
	liblzma.so.5 => /lib/x86_64-linux-gnu/liblzma.so.5 (0x00007f21b42f1000)
	librsvg-2.so.2 => /lib/x86_64-linux-gnu/librsvg-2.so.2 (0x00007f21b39c4000)
	libgobject-2.0.so.0 => /lib/x86_64-linux-gnu/libgobject-2.0.so.0 (0x00007f21b3964000)
	libglib-2.0.so.0 => /lib/x86_64-linux-gnu/libglib-2.0.so.0 (0x00007f21b383b000)
	libcairo.so.2 => /lib/x86_64-linux-gnu/libcairo.so.2 (0x00007f21b3718000)
	libzvbi.so.0 => /lib/x86_64-linux-gnu/libzvbi.so.0 (0x00007f21b3689000)
	libsnappy.so.1 => /lib/x86_64-linux-gnu/libsnappy.so.1 (0x00007f21b367e000)
	libaom.so.0 => /lib/x86_64-linux-gnu/libaom.so.0 (0x00007f21b31de000)
	libcodec2.so.0.9 => /lib/x86_64-linux-gnu/libcodec2.so.0.9 (0x00007f21b23fa000)
	libgsm.so.1 => /lib/x86_64-linux-gnu/libgsm.so.1 (0x00007f21b23eb000)
	libmp3lame.so.0 => /lib/x86_64-linux-gnu/libmp3lame.so.0 (0x00007f21b2373000)
	libopenjp2.so.7 => /lib/x86_64-linux-gnu/libopenjp2.so.7 (0x00007f21b231d000)
	libopus.so.0 => /lib/x86_64-linux-gnu/libopus.so.0 (0x00007f21b22be000)
	libshine.so.3 => /lib/x86_64-linux-gnu/libshine.so.3 (0x00007f21b20b1000)
	libspeex.so.1 => /lib/x86_64-linux-gnu/libspeex.so.1 (0x00007f21b2093000)
	libtheoraenc.so.1 => /lib/x86_64-linux-gnu/libtheoraenc.so.1 (0x00007f21b2056000)
	libtheoradec.so.1 => /lib/x86_64-linux-gnu/libtheoradec.so.1 (0x00007f21b2036000)
	libtwolame.so.0 => /lib/x86_64-linux-gnu/libtwolame.so.0 (0x00007f21b2010000)
	libvorbis.so.0 => /lib/x86_64-linux-gnu/libvorbis.so.0 (0x00007f21b1fe2000)
	libvorbisenc.so.2 => /lib/x86_64-linux-gnu/libvorbisenc.so.2 (0x00007f21b1f35000)
	libwavpack.so.1 => /lib/x86_64-linux-gnu/libwavpack.so.1 (0x00007f21b1f09000)
	libx264.so.155 => /lib/x86_64-linux-gnu/libx264.so.155 (0x00007f21b1c4b000)
	libx265.so.179 => /lib/x86_64-linux-gnu/libx265.so.179 (0x00007f21b0cdd000)
	libxvidcore.so.4 => /lib/x86_64-linux-gnu/libxvidcore.so.4 (0x00007f21b0bca000)
	libva.so.2 => /lib/x86_64-linux-gnu/libva.so.2 (0x00007f21b0ba1000)
	libva-drm.so.2 => /lib/x86_64-linux-gnu/libva-drm.so.2 (0x00007f21b0b9a000)
	libva-x11.so.2 => /lib/x86_64-linux-gnu/libva-x11.so.2 (0x00007f21b0b92000)
	libvdpau.so.1 => /lib/x86_64-linux-gnu/libvdpau.so.1 (0x00007f21b0b8c000)
	libdrm.so.2 => /lib/x86_64-linux-gnu/libdrm.so.2 (0x00007f21b0b78000)
	libOpenCL.so.1 => /lib/x86_64-linux-gnu/libOpenCL.so.1 (0x00007f21b096d000)
	libsoxr.so.0 => /lib/x86_64-linux-gnu/libsoxr.so.0 (0x00007f21b0900000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f21b67f0000)
	libGLdispatch.so.0 => /lib/x86_64-linux-gnu/libGLdispatch.so.0 (0x00007f21b0848000)
	libGLX.so.0 => /lib/x86_64-linux-gnu/libGLX.so.0 (0x00007f21b0814000)
	libxcb.so.1 => /lib/x86_64-linux-gnu/libxcb.so.1 (0x00007f21b07ea000)
	libcairo-gobject.so.2 => /lib/x86_64-linux-gnu/libcairo-gobject.so.2 (0x00007f21b07de000)
	libgdk_pixbuf-2.0.so.0 => /lib/x86_64-linux-gnu/libgdk_pixbuf-2.0.so.0 (0x00007f21b07b4000)
	libgio-2.0.so.0 => /lib/x86_64-linux-gnu/libgio-2.0.so.0 (0x00007f21b05d3000)
	libxml2.so.2 => /lib/x86_64-linux-gnu/libxml2.so.2 (0x00007f21b0419000)
	libpangocairo-1.0.so.0 => /lib/x86_64-linux-gnu/libpangocairo-1.0.so.0 (0x00007f21b0407000)
	libpango-1.0.so.0 => /lib/x86_64-linux-gnu/libpango-1.0.so.0 (0x00007f21b03b8000)
	libffi.so.7 => /lib/x86_64-linux-gnu/libffi.so.7 (0x00007f21b03ac000)
	libpcre.so.3 => /lib/x86_64-linux-gnu/libpcre.so.3 (0x00007f21b0337000)
	libpixman-1.so.0 => /lib/x86_64-linux-gnu/libpixman-1.so.0 (0x00007f21b0290000)
	libfontconfig.so.1 => /lib/x86_64-linux-gnu/libfontconfig.so.1 (0x00007f21b0249000)
	libxcb-shm.so.0 => /lib/x86_64-linux-gnu/libxcb-shm.so.0 (0x00007f21b0244000)
	libxcb-render.so.0 => /lib/x86_64-linux-gnu/libxcb-render.so.0 (0x00007f21b0235000)
	libXrender.so.1 => /lib/x86_64-linux-gnu/libXrender.so.1 (0x00007f21b002b000)
	libXext.so.6 => /lib/x86_64-linux-gnu/libXext.so.6 (0x00007f21b0014000)
	libogg.so.0 => /lib/x86_64-linux-gnu/libogg.so.0 (0x00007f21b0007000)
	libnuma.so.1 => /lib/x86_64-linux-gnu/libnuma.so.1 (0x00007f21afffa000)
	libXfixes.so.3 => /lib/x86_64-linux-gnu/libXfixes.so.3 (0x00007f21afff2000)
	libgomp.so.1 => /lib/x86_64-linux-gnu/libgomp.so.1 (0x00007f21affae000)
	libXau.so.6 => /lib/x86_64-linux-gnu/libXau.so.6 (0x00007f21affa8000)
	libXdmcp.so.6 => /lib/x86_64-linux-gnu/libXdmcp.so.6 (0x00007f21affa0000)
	libgmodule-2.0.so.0 => /lib/x86_64-linux-gnu/libgmodule-2.0.so.0 (0x00007f21aff9a000)
	libmount.so.1 => /lib/x86_64-linux-gnu/libmount.so.1 (0x00007f21aff3a000)
	libselinux.so.1 => /lib/x86_64-linux-gnu/libselinux.so.1 (0x00007f21aff0d000)
	libresolv.so.2 => /lib/x86_64-linux-gnu/libresolv.so.2 (0x00007f21afef1000)
	libicuuc.so.66 => /lib/x86_64-linux-gnu/libicuuc.so.66 (0x00007f21afd0b000)
	libpangoft2-1.0.so.0 => /lib/x86_64-linux-gnu/libpangoft2-1.0.so.0 (0x00007f21afcf2000)
	libfribidi.so.0 => /lib/x86_64-linux-gnu/libfribidi.so.0 (0x00007f21afcd5000)
	libthai.so.0 => /lib/x86_64-linux-gnu/libthai.so.0 (0x00007f21afcc8000)
	libharfbuzz.so.0 => /lib/x86_64-linux-gnu/libharfbuzz.so.0 (0x00007f21afbc3000)
	libexpat.so.1 => /lib/x86_64-linux-gnu/libexpat.so.1 (0x00007f21afb95000)
	libuuid.so.1 => /lib/x86_64-linux-gnu/libuuid.so.1 (0x00007f21afb8c000)
	libbsd.so.0 => /lib/x86_64-linux-gnu/libbsd.so.0 (0x00007f21afb72000)
	libblkid.so.1 => /lib/x86_64-linux-gnu/libblkid.so.1 (0x00007f21afb1b000)
	libpcre2-8.so.0 => /lib/x86_64-linux-gnu/libpcre2-8.so.0 (0x00007f21afa89000)
	libicudata.so.66 => /lib/x86_64-linux-gnu/libicudata.so.66 (0x00007f21adfc8000)
	libdatrie.so.1 => /lib/x86_64-linux-gnu/libdatrie.so.1 (0x00007f21adfbe000)
	libgraphite2.so.3 => /lib/x86_64-linux-gnu/libgraphite2.so.3 (0x00007f21adf91000)
```

AFTER:
```
root@91d6f9658f71:/esa# ldd psyq-obj-parser 
	linux-vdso.so.1 (0x00007fff44dbc000)
	libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007fafc4636000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fafc44e7000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fafc44cc000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fafc44a9000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fafc42b7000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fafc4828000)
```