### PR TITLE
Allow building psyq-obj-parser.cc on its own more easily

### DIFF
--- a/src/core/psxemulator.h
+++ b/src/core/psxemulator.h
@@ -46,13 +46,7 @@
 
 #ifndef MAXPATHLEN
 #ifdef _WIN32
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
-#include <windows.h>
+#include "support/windowswrapper.h"
 #endif
 #ifdef MAX_PATH
 #define MAXPATHLEN MAX_PATH

--- a/src/gui/resources-unix.cc
+++ b/src/gui/resources-unix.cc
@@ -19,6 +19,7 @@
 
 #ifndef _WIN32
 
+#include "core/system.h"
 #include "gui/resources.h"
 #include "support/file.h"
 

--- a/src/support/file.cc
+++ b/src/support/file.cc
@@ -20,6 +20,8 @@
 #include "support/file.h"
 
 #include <algorithm>
+#include <assert.h>
+#include "support/windowswrapper.h"
 
 const uint8_t PCSX::File::m_internalBuffer = 0;
 

--- a/src/support/file.h
+++ b/src/support/file.h
@@ -24,8 +24,8 @@
 
 #include <filesystem>
 
-#include "core/psxemulator.h"
 #include "support/slice.h"
+#include "support/ssize_t.h"
 
 namespace PCSX {
 

--- a/src/support/ssize_t.h
+++ b/src/support/ssize_t.h
@@ -1,0 +1,25 @@
+/***************************************************************************
+ *   Copyright (C) 2022 PCSX-Redux authors                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.           *
+ ***************************************************************************/
+
+#pragma once
+
+
+#ifdef _WIN32
+typedef intptr_t ssize_t;
+#endif

--- a/src/support/windowswrapper.h
+++ b/src/support/windowswrapper.h
@@ -1,0 +1,32 @@
+/***************************************************************************
+ *   Copyright (C) 2022 PCSX-Redux authors                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.           *
+ ***************************************************************************/
+
+#pragma once
+
+#ifdef _WIN32
+// Chop down the size of the windows.h to reduce pollution and build times
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+// Don't #define min or max as it will break std::min/max
+#ifndef NOMINMAX
+#define NOMINMAX
+#include <windows.h>
+#endif
+#endif

--- a/src/support/windowswrapper.h
+++ b/src/support/windowswrapper.h
@@ -27,6 +27,6 @@
 // Don't #define min or max as it will break std::min/max
 #ifndef NOMINMAX
 #define NOMINMAX
-#include <windows.h>
 #endif
+#include <windows.h>
 #endif

--- a/tools/ps1-packer/ps1-packer.cc
+++ b/tools/ps1-packer/ps1-packer.cc
@@ -19,7 +19,7 @@
 
 #include <memory.h>
 #include <stdint.h>
-
+#include <assert.h>
 #include <vector>
 
 #include "flags.h"

--- a/tools/psyq-obj-parser/psyq-obj-parser.cc
+++ b/tools/psyq-obj-parser/psyq-obj-parser.cc
@@ -19,6 +19,7 @@
 
 #include <list>
 #include <map>
+#include <assert.h>
 
 #include "elfio/elfio.hpp"
 #include "flags.h"
@@ -26,6 +27,7 @@
 #include "support/file.h"
 #include "support/hashtable.h"
 #include "support/slice.h"
+#include "support/windowswrapper.h"
 
 #define vprint(...) \
     if (verbose) fmt::print(__VA_ARGS__)


### PR DESCRIPTION
Requires fmt/src/format.cc and src/support/file.cc currently. Main issue was dep core/psxemulator.h which I split out via core/ssize_t.h and some missing headers when not using whatever PCH system redux currently has.
