### PR TITLE
pad.h: Initialize m_gamepadsMap properly. 

### DIFF
--- a/src/core/pad.h
+++ b/src/core/pad.h
@@ -52,7 +52,7 @@ class Pads {
 
   private:
     EventBus::Listener m_listener;
-    int m_gamepadsMap[16];
+    int m_gamepadsMap[16] = {0};
 
     static const int GLFW_GAMEPAD_BUTTON_LEFT_TRIGGER = GLFW_GAMEPAD_BUTTON_LAST + 1;
     static const int GLFW_GAMEPAD_BUTTON_RIGHT_TRIGGER = GLFW_GAMEPAD_BUTTON_LAST + 2;


### PR DESCRIPTION
This fixes crash if any game is launched before user touched any controls settings:

```
Thread 1 "pcsx-redux" received signal SIGSEGV, Segmentation fault.
0x00000000004c3d70 in PCSX::Pads::Pad::getButtons (this=0xf766960) at src/core/pad.cc:189
189	        int glfwID = g_emulator->m_pads->m_gamepadsMap[m_padID];

(gdb) bt
#0  0x00000000004c3d70 in PCSX::Pads::Pad::getButtons() (this=0xf766960) at src/core/pad.cc:189
#1  0x00000000004c412c in PCSX::Pads::Pad::readPort(PadDataS*) (this=0xf766960, data=0x7fffffffd492) at src/core/pad.cc:257
#2  0x00000000004c417d in PCSX::Pads::startPoll(PCSX::Pads::Port) (this=0xf7668c0, port=PCSX::Pads::Port1) at src/core/pad.cc:263
#3  0x000000000051ae6e in PCSX::SIO::write8(unsigned char) (this=0x7fffec0ab010, value=1 '\001') at src/core/sio.cc:229
#4  0x00000000004fe4f9 in PCSX::HW::psxHwWrite8(unsigned int, unsigned char) (this=0xf6eab70, add=528486464, value=1 '\001') at src/core/psxhw.cc:342
#5  0x000000000050d5e9 in PCSX::Memory::psxMemWrite8(unsigned int, unsigned char) (this=0xf766860, mem=528486464, value=1 '\001') at src/core/psxmem.cc:359
#6  0x00000000005909e7 in psxMemWrite8Wrapper(uint32_t, uint8_t) (address=528486464, value=1 '\001') at src/core/DynaRec_x64/recompiler.h:55
#7  0x00000000096e9a66 in s_codeCache ()
#8  0x00007ffff7ffbc00 in _rtld_local_ro () at /lib64/ld-linux-x86-64.so.2
#9  0x00000000006c2192 in Complain(char const*) (msg=0x0) at src/main/mainthunk.cc:121
#10 0x00007fffffffdbd8 in  ()
#11 0x00007fffffffd5b0 in  ()
#12 0x00000000005b2bf7 in DynaRecCPU::Execute() (this=0xc3c99001ebffd586) at src/core/DynaRec_x64/recompiler.h:168

(gdb) p m_padID
$4 = 1011286016
```