### PR TITLE
[SIO] Fix memory card block titles

### DIFF
--- a/src/core/sio.cc
+++ b/src/core/sio.cc
@@ -746,7 +746,7 @@ void PCSX::SIO::getMcdBlockInfo(int mcd, int block, McdBlock &info) {
         ts += b;
         uint16_t c = b;
         if (b & 0x80) {
-            c << 8;
+            c <<= 8;
             b = *ptr++;
             ts += b;
             c |= b;


### PR DESCRIPTION
Before vs after
![image](https://user-images.githubusercontent.com/44909372/154815929-c9dc50e4-45bf-42ca-a3b7-1738a0d2f5ba.png)
![image](https://user-images.githubusercontent.com/44909372/154815883-f94f0007-2800-4827-9bf5-e21db7a6b5ae.png)

Helps the games really discover their identity. No longer do they have to live just going "????????????????????????" when asked for their name.