### PR TITLE
[Interpreter] Set $ra in BGEZAL/BLTZAL after the branch comparison

### DIFF
--- a/src/core/psxinterpreter.cc
+++ b/src/core/psxinterpreter.cc
@@ -633,13 +633,13 @@ void InterpretedCPU::psxMULTU(uint32_t code) {
 #define RepZBranchLinki32(op)                                    \
     {                                                            \
         uint32_t ra = m_psxRegs.pc + 4;                          \
-        m_psxRegs.GPR.r[31] = ra;                                \
-        maybeCancelDelayedLoad(31);                              \
         if ((int32_t)_rRs_ op 0) {                               \
             uint32_t sp = m_psxRegs.GPR.n.sp;                    \
             doBranch(_BranchTarget_, true);                      \
             PCSX::g_emulator->m_callStacks->potentialRA(ra, sp); \
         }                                                        \
+        m_psxRegs.GPR.r[31] = ra;                                \
+        maybeCancelDelayedLoad(31);                              \
     }
 
 void InterpretedCPU::psxBGEZ(uint32_t code) { RepZBranchi32(>=) }         // Branch if Rs >= 0


### PR DESCRIPTION
Verified with Amidog's psxtest_cpu test. Behaviour is already correct in x64 JIT.
![image](https://user-images.githubusercontent.com/44909372/155225828-d99f4c7f-28b9-43bb-abfe-de28b01488d4.png)
