### PR TITLE
Adjust data fifo empty behavior

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,6 +11,7 @@ Herben / Asmblur
 Ryusan
 Peach / wheremyfoodat
 Mariano
+John "Skitchin" Baumann
 
 
 PCSX-Reloaded

--- a/src/core/cdrom.cc
+++ b/src/core/cdrom.cc
@@ -1287,7 +1287,6 @@ class CDRomImpl : public PCSX::CDRom {
         }
 
         m_cmd = rt;
-        m_OCUP = 0;
 
         if (rt > cdCmdEnumCount) {
             CDROM_IO_LOG("CD1 write: %x (CdlUnknown)", rt);


### PR DESCRIPTION
The Data FIFO empty flag(1F801800h bit 6) behavior was modified in PR #718 to allow Unirom to properly detect when the data buffer was clear. I noticed a new freeze error in Gran Turismo 2 (Simulation Mode) when browsing the used car dealer.

Removing this line from cdrom.cc should fix this freezing behavior in GT2. It does not appear that writing to the Command Register(1F801801h.Index0) should result in the Data FIFO bit being cleared(0=empty). Tested with several other games and did not notice any adverse effects.