### PR TITLE
Revised m_ctrl data fifo behavior, remove related magic numbers

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,6 +11,7 @@ Herben / Asmblur
 Ryusan
 Peach / wheremyfoodat
 Mariano
+John "Skitchin" Baumann
 
 
 PCSX-Reloaded

--- a/src/core/cdrom.cc
+++ b/src/core/cdrom.cc
@@ -236,8 +236,9 @@ class CDRomImpl : public PCSX::CDRom {
 
         if (m_transferIndex >= bufSize) m_transferIndex -= bufSize;
 
+        // FIFO empty
         if (m_transferIndex == 0) {
-            m_ctrl &= ~0x40;
+            m_ctrl &= ~0x40; // Clear DRQSTS, 0=Empty
             m_read = 0;
         }
     }
@@ -1143,7 +1144,6 @@ class CDRomImpl : public PCSX::CDRom {
             return;
         }
 
-        m_ctrl |= 0x40;
         SetResultSize(1);
         m_statP |= STATUS_READ | STATUS_ROTATING;
         m_statP &= ~STATUS_SEEK;
@@ -1166,6 +1166,7 @@ class CDRomImpl : public PCSX::CDRom {
 
         memcpy(m_transfer, buf, DATA_SIZE);
         m_ppf.CheckPPFCache(m_transfer, m_prev[0], m_prev[1], m_prev[2]);
+        m_ctrl |= 0x40; // Clear DRQSTS, 1=NOT Empty
 
         CDROM_LOG("readInterrupt() Log: cdr.m_transfer %x:%x:%x\n", m_transfer[0], m_transfer[1], m_transfer[2]);
 

--- a/src/core/cdrom.cc
+++ b/src/core/cdrom.cc
@@ -1287,7 +1287,6 @@ class CDRomImpl : public PCSX::CDRom {
         }
 
         m_cmd = rt;
-        m_OCUP = 0;
 
         if (rt > cdCmdEnumCount) {
             CDROM_IO_LOG("CD1 write: %x (CdlUnknown)", rt);

--- a/src/core/cdrom.cc
+++ b/src/core/cdrom.cc
@@ -235,6 +235,11 @@ class CDRomImpl : public PCSX::CDRom {
         }
 
         if (m_transferIndex >= bufSize) m_transferIndex -= bufSize;
+
+        if (m_transferIndex == 0) {
+            m_ctrl &= ~0x40;
+            m_read = 0;
+        }
     }
 
     // FIXME: do this in SPU instead
@@ -1138,7 +1143,7 @@ class CDRomImpl : public PCSX::CDRom {
             return;
         }
 
-        m_OCUP = 1;
+        m_ctrl |= 0x40;
         SetResultSize(1);
         m_statP |= STATUS_READ | STATUS_ROTATING;
         m_statP &= ~STATUS_SEEK;
@@ -1241,12 +1246,6 @@ class CDRomImpl : public PCSX::CDRom {
             m_ctrl |= 0x20;
         } else {
             m_ctrl &= ~0x20;
-        }
-
-        if (m_OCUP) {
-            m_ctrl |= 0x40;
-        } else {
-            m_ctrl &= ~0x40;
         }
 
         m_ctrl |= 0x18;
@@ -1359,7 +1358,7 @@ class CDRomImpl : public PCSX::CDRom {
         unsigned char ret;
 
         if (m_read == 0) {
-            m_OCUP = 0;
+            m_ctrl &= ~0x40;
             ret = 0;
         } else {
             ret = m_transfer[m_transferIndex];

--- a/src/core/cdrom.cc
+++ b/src/core/cdrom.cc
@@ -1544,7 +1544,6 @@ class CDRomImpl : public PCSX::CDRom {
     }
 
     void reset() final {
-        m_OCUP = 0;
         m_reg1Mode = 0;
         m_cmdProcess = 0;
         m_ctrl = 0;

--- a/src/core/cdrom.h
+++ b/src/core/cdrom.h
@@ -72,7 +72,6 @@ class CDRom {
 
   protected:
     // savestate stuff starts here
-    uint8_t m_OCUP;
     uint8_t m_reg1Mode;
     uint8_t m_reg2;
     uint8_t m_cmdProcess;

--- a/src/core/sstate.cc
+++ b/src/core/sstate.cc
@@ -97,7 +97,6 @@ PCSX::SaveStates::SaveState PCSX::SaveStates::constructSaveState() {
             SIOWasMCD2Inserted { g_emulator->m_sio->m_wasMcd2Inserted },
         },
         CDRom {
-            CDOCUP { g_emulator->m_cdrom->m_OCUP },
             CDReg1Mode { g_emulator->m_cdrom->m_reg1Mode },
             CDReg2 { g_emulator->m_cdrom->m_reg2 },
             CDCmdProcess { g_emulator->m_cdrom->m_cmdProcess },

--- a/src/core/sstate.h
+++ b/src/core/sstate.h
@@ -148,7 +148,7 @@ typedef Protobuf::Message<TYPESTRING("SIO"), SIOBuffer, SIOStatusReg, SIOModeReg
     SIO;
 typedef Protobuf::MessageField<SIO, TYPESTRING("sio"), 7> SIOField;
 
-typedef Protobuf::FieldRef<Protobuf::UInt8, TYPESTRING("ocup"), 1> CDOCUP;
+// skip id 1
 typedef Protobuf::FieldRef<Protobuf::UInt8, TYPESTRING("reg1_mode"), 2> CDReg1Mode;
 typedef Protobuf::FieldRef<Protobuf::UInt8, TYPESTRING("reg2"), 3> CDReg2;
 typedef Protobuf::FieldRef<Protobuf::UInt8, TYPESTRING("cmd_process"), 4> CDCmdProcess;

--- a/src/core/sstate.h
+++ b/src/core/sstate.h
@@ -207,7 +207,7 @@ typedef Protobuf::FieldRef<Protobuf::Bool, TYPESTRING("track_changed"), 56> CDTr
 typedef Protobuf::FieldRef<Protobuf::Bool, TYPESTRING("location_changed"), 57> CDLocationChanged;
 
 typedef Protobuf::Message<
-    TYPESTRING("CDRom"), CDOCUP, CDReg1Mode, CDReg2, CDCmdProcess, CDCtrl, CDStat, CDStatP, CDTransfer, CDTransferIndex,
+    TYPESTRING("CDRom"), CDReg1Mode, CDReg2, CDCmdProcess, CDCtrl, CDStat, CDStatP, CDTransfer, CDTransferIndex,
     CDPrev, CDParam, CDResult, CDParamC, CDParamP, CDResultC, CDResultP, CDResultReady, CDCmd, CDRead, CDSetLocPending,
     CDReading, CDResultTN, CDResultTD, CDSetSectorPlay, CDSetSectorEnd, CDSetSector, CDTrack, CDPlay, CDMuted,
     CDCurTrack, CDMode, CDFile, CDChannel, CDSuceeded, CDFirstSector, CDIRQ, CDIrqRepeated, CDECycle, CDSeeked,


### PR DESCRIPTION
My last data fifo related commit still had some quirks related to the m_OCUP variable(seriously, wtf was that for), so I moved the DRQST toggles to somewhere more direct.

Added some enum declarations to help de-obfuscate the usage of m_ctrl