### PR TITLE
Hardware register write size

### DIFF
--- a/src/core/DynaRec_x64/instructions.cc
+++ b/src/core/DynaRec_x64/instructions.cc
@@ -985,7 +985,7 @@ void DynaRecCPU::recLWR() {
 void DynaRecCPU::recSB() {
     if (m_regs[_Rs_].isConst()) {
         const uint32_t addr = m_regs[_Rs_].val + _Imm_;
-        const auto pointer = PCSX::g_emulator->m_psxMem->psxMemPointerWrite(addr);
+        const auto pointer = PCSX::g_emulator->m_psxMem->psxMemPointerWrite(addr, 8);
 
         if (pointer != nullptr) {
             if (m_regs[_Rt_].isConst()) {
@@ -998,11 +998,11 @@ void DynaRecCPU::recSB() {
             return;
         }
 
-        if (m_regs[_Rt_].isConst()) {  // Value to write in arg2
-            gen.moveImm(arg2, m_regs[_Rt_].val & 0xFF);
+        if (m_regs[_Rt_].isConst()) {  // Full 32-bit value to write in arg2
+            gen.moveImm(arg2, m_regs[_Rt_].val);
         } else {
             allocateReg(_Rt_);
-            gen.movzx(arg2, m_regs[_Rt_].allocatedReg.cvt8());
+            gen.mov(arg2, m_regs[_Rt_].allocatedReg);
         }
 
         gen.mov(arg1, addr);  // Address to write to in arg1 TODO: Optimize
@@ -1010,11 +1010,11 @@ void DynaRecCPU::recSB() {
     }
 
     else {
-        if (m_regs[_Rt_].isConst()) {  // Value to write in arg2
-            gen.moveImm(arg2, m_regs[_Rt_].val & 0xFF);
+        if (m_regs[_Rt_].isConst()) {  // Full 32-bit value to write in arg2
+            gen.moveImm(arg2, m_regs[_Rt_].val);
         } else {
             allocateReg(_Rt_);
-            gen.movzx(arg2, m_regs[_Rt_].allocatedReg.cvt8());
+            gen.mov(arg2, m_regs[_Rt_].allocatedReg);
         }
 
         allocateReg(_Rs_);
@@ -1026,7 +1026,7 @@ void DynaRecCPU::recSB() {
 void DynaRecCPU::recSH() {
     if (m_regs[_Rs_].isConst()) {
         const uint32_t addr = m_regs[_Rs_].val + _Imm_;
-        const auto pointer = PCSX::g_emulator->m_psxMem->psxMemPointerWrite(addr);
+        const auto pointer = PCSX::g_emulator->m_psxMem->psxMemPointerWrite(addr, 16);
         if (pointer != nullptr) {
             if (m_regs[_Rt_].isConst()) {
                 store<16>(m_regs[_Rt_].val & 0xFFFF, pointer);
@@ -1063,11 +1063,11 @@ void DynaRecCPU::recSH() {
             return;
         }
 
-        if (m_regs[_Rt_].isConst()) {  // Value to write in arg2
-            gen.moveImm(arg2, m_regs[_Rt_].val & 0xFFFF);
+        if (m_regs[_Rt_].isConst()) {  // Full 32-bit value to write in arg2
+            gen.moveImm(arg2, m_regs[_Rt_].val);
         } else {
             allocateReg(_Rt_);
-            gen.movzx(arg2, m_regs[_Rt_].allocatedReg.cvt16());
+            gen.mov(arg2, m_regs[_Rt_].allocatedReg);
         }
 
         gen.mov(arg1, addr);  // Address to write to in arg1   TODO: Optimize
@@ -1075,11 +1075,11 @@ void DynaRecCPU::recSH() {
     }
 
     else {
-        if (m_regs[_Rt_].isConst()) {  // Value to write in arg2
-            gen.moveImm(arg2, m_regs[_Rt_].val & 0xFFFF);
+        if (m_regs[_Rt_].isConst()) {  // Full 32-bit value to write in arg2
+            gen.moveImm(arg2, m_regs[_Rt_].val);
         } else {
             allocateReg(_Rt_);
-            gen.movzx(arg2, m_regs[_Rt_].allocatedReg.cvt16());
+            gen.mov(arg2, m_regs[_Rt_].allocatedReg);
         }
 
         allocateReg(_Rs_);
@@ -1091,7 +1091,7 @@ void DynaRecCPU::recSH() {
 void DynaRecCPU::recSW() {
     if (m_regs[_Rs_].isConst()) {
         const uint32_t addr = m_regs[_Rs_].val + _Imm_;
-        const auto pointer = PCSX::g_emulator->m_psxMem->psxMemPointerWrite(addr);
+        const auto pointer = PCSX::g_emulator->m_psxMem->psxMemPointerWrite(addr, 32);
         if (pointer != nullptr) {
             if (m_regs[_Rt_].isConst()) {
                 store<32>(m_regs[_Rt_].val, pointer);

--- a/src/core/DynaRec_x64/recompiler.h
+++ b/src/core/DynaRec_x64/recompiler.h
@@ -51,10 +51,11 @@ static void SPU_writeRegisterWrapper(uint32_t addr, uint16_t value) {
     PCSX::g_emulator->m_spu->writeRegister(addr, value);
 }
 
-static void psxMemWrite8Wrapper(uint32_t address, uint8_t value) {
+// For 8/16-bit writes, the entire value is put on the bus. This matters for certain IO registers
+static void psxMemWrite8Wrapper(uint32_t address, uint32_t value) {
     PCSX::g_emulator->m_psxMem->psxMemWrite8(address, value);
 }
-static void psxMemWrite16Wrapper(uint32_t address, uint16_t value) {
+static void psxMemWrite16Wrapper(uint32_t address, uint32_t value) {
     PCSX::g_emulator->m_psxMem->psxMemWrite16(address, value);
 }
 static void psxMemWrite32Wrapper(uint32_t address, uint32_t value) {

--- a/src/core/ix86/iR3000A.cc
+++ b/src/core/ix86/iR3000A.cc
@@ -50,8 +50,8 @@ using DynarecCallback = uint32_t (*)();
 uint8_t psxMemRead8Wrapper(uint32_t mem) { return PCSX::g_emulator->m_psxMem->psxMemRead8(mem); }
 uint16_t psxMemRead16Wrapper(uint32_t mem) { return PCSX::g_emulator->m_psxMem->psxMemRead16(mem); }
 uint32_t psxMemRead32Wrapper(uint32_t mem) { return PCSX::g_emulator->m_psxMem->psxMemRead32(mem); }
-void psxMemWrite8Wrapper(uint32_t mem, uint8_t value) { PCSX::g_emulator->m_psxMem->psxMemWrite8(mem, value); }
-void psxMemWrite16Wrapper(uint32_t mem, uint16_t value) { PCSX::g_emulator->m_psxMem->psxMemWrite16(mem, value); }
+void psxMemWrite8Wrapper(uint32_t mem, uint32_t value) { PCSX::g_emulator->m_psxMem->psxMemWrite8(mem, value); }
+void psxMemWrite16Wrapper(uint32_t mem, uint32_t value) { PCSX::g_emulator->m_psxMem->psxMemWrite16(mem, value); }
 void psxMemWrite32Wrapper(uint32_t mem, uint32_t value) { PCSX::g_emulator->m_psxMem->psxMemWrite32(mem, value); }
 uint32_t psxRcntRcountWrapper(uint32_t index) { return PCSX::g_emulator->m_psxCounters->psxRcntRcount(index); }
 uint32_t psxRcntRmodeWrapper(uint32_t index) { return PCSX::g_emulator->m_psxCounters->psxRcntRmode(index); }

--- a/src/core/psxhw.cc
+++ b/src/core/psxhw.cc
@@ -555,8 +555,8 @@ void PCSX::HW::psxHwWrite16(uint32_t add, uint32_t rawvalue) {
             } else {
                 psxHu16ref(add) = SWAP_LEu16(value);
                 PSXHW_LOG("*Unknown 16bit write at address %x value %x\n", add, value);
-                return;
             }
+            return;
     }
     if (addressInRegisterSpace(add)) {
         psxHu32ref(add) = SWAP_LEu32(rawvalue);

--- a/src/core/psxhw.cc
+++ b/src/core/psxhw.cc
@@ -36,6 +36,24 @@
 
 static inline void setIrq(uint32_t irq) { psxHu32ref(0x1070) |= SWAP_LEu32(irq); }
 
+static constexpr bool between(uint32_t val, uint32_t beg, uint32_t end) {
+    return (beg > end) ? false : (val >= beg && val <= end - 3);
+}
+
+static constexpr bool addressInRegisterSpace(uint32_t address) {
+    uint32_t _add = address & 0x1fffffff;
+
+    return (between(_add, 0x1f801000, 0x1f801023) ||               // MEMCTRL
+            between(_add, 0x1f801060, 0x1f801063) ||               // RAM_SIZE
+            between(_add, 0x1f801070, 0x1f801077) ||               // IRQCTRL
+            between(_add & 0xffffff0f, 0x1f801000, 0x1f801003) ||  // DMAx.ADDR
+            between(_add & 0xffffff0f, 0x1f801008, 0x1f80100f) ||  // DMAx.CTRL/MIRR
+            between(_add, 0x1f8010f0, 0x1f8010f7) ||               // DMA.DPCR/DICR
+            between(_add, 0x1f801100, 0x1f80110b) ||               // Timer 0
+            between(_add, 0x1f801110, 0x1f80111b) ||               // Timer 1
+            between(_add, 0x1f801120, 0x1f80112b));                // Timer 2
+}
+
 void PCSX::HW::psxHwReset() {
     if (PCSX::g_emulator->settings.get<PCSX::Emulator::SettingSpuIrq>()) setIrq(0x200);
 
@@ -356,7 +374,9 @@ uint32_t PCSX::HW::psxHwRead32(uint32_t add) {
     return hard;
 }
 
-void PCSX::HW::psxHwWrite8(uint32_t add, uint8_t value) {
+void PCSX::HW::psxHwWrite8(uint32_t add, uint32_t rawvalue) {
+    uint8_t value = (uint8_t)rawvalue;
+
     switch (add & 0x1fffffff) {
         case 0x1f801040:
             PCSX::g_emulator->m_sio->write8(value);
@@ -407,15 +427,27 @@ void PCSX::HW::psxHwWrite8(uint32_t add, uint8_t value) {
             break;
 
         default:
-            psxHu8ref(add) = value;
-            PSXHW_LOG("*Unknown 8bit write at address %x value %x\n", add, value);
+            if (addressInRegisterSpace(add)) {
+                psxHu32ref(add) = rawvalue;
+                PSXHW_LOG("*Unknown 8bit(actually 32bit) write at address %x value %x\n", add, rawvalue);
+            } else {
+                psxHu8ref(add) = value;
+                PSXHW_LOG("*Unknown 8bit write at address %x value %x\n", add, value);
+            }
             return;
     }
-    psxHu8ref(add) = value;
-    PSXHW_LOG("*Known 8bit write at address %x value %x\n", add, value);
+    if (addressInRegisterSpace(add)) {
+        psxHu32ref(add) = value;
+        PSXHW_LOG("*Known 8bit(actually 32bit) write at address %x value %x\n", add, rawvalue);
+    } else {
+        psxHu8ref(add) = value;
+        PSXHW_LOG("*Known 8bit write at address %x value %x\n", add, value);
+    }
 }
 
-void PCSX::HW::psxHwWrite16(uint32_t add, uint16_t value) {
+void PCSX::HW::psxHwWrite16(uint32_t add, uint32_t rawvalue) {
+    uint16_t value = (uint16_t)rawvalue;
+
     switch (add & 0x1fffffff) {
         case 0x1f801040:
             PCSX::g_emulator->m_sio->write8((unsigned char)value);
@@ -459,15 +491,14 @@ void PCSX::HW::psxHwWrite16(uint32_t add, uint16_t value) {
             SIO1_LOG("SIO1.BAUD write16 %x, %x\n", add & 0xf, value);
             break;
         case 0x1f801070:
-            PSXHW_LOG("IREG 16bit write %x\n", value);
+            PSXHW_LOG("IREG 16bit(actually 32bit) write %x\n", rawvalue);
             if (PCSX::g_emulator->settings.get<PCSX::Emulator::SettingSpuIrq>())
                 psxHu16ref(0x1070) |= SWAP_LEu16(0x200);
-            psxHu16ref(0x1070) &= SWAP_LEu16(value);
+            psxHu32ref(0x1070) &= SWAP_LEu32(rawvalue);
             return;
 
         case 0x1f801074:
             PSXHW_LOG("IMASK 16bit write %x\n", value);
-            psxHu16ref(0x1074) = SWAP_LEu16(value);
             break;
 
         case 0x1f801100:
@@ -518,12 +549,22 @@ void PCSX::HW::psxHwWrite16(uint32_t add, uint16_t value) {
                 break;
             }
 
-            psxHu16ref(add) = SWAP_LEu16(value);
-            PSXHW_LOG("*Unknown 16bit write at address %x value %x\n", add, value);
-            return;
+            if (addressInRegisterSpace(add)) {
+                psxHu32ref(add) = SWAP_LEu32(rawvalue);
+                PSXHW_LOG("*Unknown 16bit(actually 32bit) write at address %x value %x\n", add, rawvalue);
+            } else {
+                psxHu16ref(add) = SWAP_LEu16(value);
+                PSXHW_LOG("*Unknown 16bit write at address %x value %x\n", add, value);
+                return;
+            }
     }
-    psxHu16ref(add) = SWAP_LEu16(value);
-    PSXHW_LOG("*Known 16bit write at address %x value %x\n", add, value);
+    if (addressInRegisterSpace(add)) {
+        psxHu32ref(add) = SWAP_LEu32(rawvalue);
+        PSXHW_LOG("*Known 16bit(actually 32bit) write at address %x value %x\n", add, rawvalue);
+    } else {
+        psxHu16ref(add) = SWAP_LEu16(value);
+        PSXHW_LOG("*Known 16bit write at address %x value %x\n", add, value);
+    }
 }
 
 inline void PCSX::HW::psxDma0(uint32_t madr, uint32_t bcr, uint32_t chcr) {

--- a/src/core/psxhw.cc
+++ b/src/core/psxhw.cc
@@ -41,17 +41,17 @@ static constexpr bool between(uint32_t val, uint32_t beg, uint32_t end) {
 }
 
 static constexpr bool addressInRegisterSpace(uint32_t address) {
-    uint32_t _add = address & 0x1fffffff;
+    uint32_t masked_addr = address & 0x1fffffff;
 
-    return (between(_add, 0x1f801000, 0x1f801023) ||               // MEMCTRL
-            between(_add, 0x1f801060, 0x1f801063) ||               // RAM_SIZE
-            between(_add, 0x1f801070, 0x1f801077) ||               // IRQCTRL
-            between(_add & 0xffffff0f, 0x1f801000, 0x1f801003) ||  // DMAx.ADDR
-            between(_add & 0xffffff0f, 0x1f801008, 0x1f80100f) ||  // DMAx.CTRL/MIRR
-            between(_add, 0x1f8010f0, 0x1f8010f7) ||               // DMA.DPCR/DICR
-            between(_add, 0x1f801100, 0x1f80110b) ||               // Timer 0
-            between(_add, 0x1f801110, 0x1f80111b) ||               // Timer 1
-            between(_add, 0x1f801120, 0x1f80112b));                // Timer 2
+    return (between(masked_addr, 0x1f801000, 0x1f801023) ||               // MEMCTRL
+            between(masked_addr, 0x1f801060, 0x1f801063) ||               // RAM_SIZE
+            between(masked_addr, 0x1f801070, 0x1f801077) ||               // IRQCTRL
+            between(masked_addr & 0xffffff0f, 0x1f801000, 0x1f801003) ||  // DMAx.ADDR
+            between(masked_addr & 0xffffff0f, 0x1f801008, 0x1f80100f) ||  // DMAx.CTRL/MIRR
+            between(masked_addr, 0x1f8010f0, 0x1f8010f7) ||               // DMA.DPCR/DICR
+            between(masked_addr, 0x1f801100, 0x1f80110b) ||               // Timer 0
+            between(masked_addr, 0x1f801110, 0x1f80111b) ||               // Timer 1
+            between(masked_addr, 0x1f801120, 0x1f80112b));                // Timer 2
 }
 
 void PCSX::HW::psxHwReset() {

--- a/src/core/psxhw.h
+++ b/src/core/psxhw.h
@@ -67,8 +67,8 @@ class HW {
     uint8_t psxHwRead8(uint32_t add);
     uint16_t psxHwRead16(uint32_t add);
     uint32_t psxHwRead32(uint32_t add);
-    void psxHwWrite8(uint32_t add, uint8_t value);
-    void psxHwWrite16(uint32_t add, uint16_t value);
+    void psxHwWrite8(uint32_t add, uint32_t rawvalue);
+    void psxHwWrite16(uint32_t add, uint32_t rawvalue);
     void psxHwWrite32(uint32_t add, uint32_t value);
     int psxHwFreeze(gzFile f, int Mode);
 

--- a/src/core/psxinterpreter.cc
+++ b/src/core/psxinterpreter.cc
@@ -994,7 +994,7 @@ void InterpretedCPU::psxLWR(uint32_t code) {
     */
 }
 
-void InterpretedCPU::psxSB(uint32_t code) { PCSX::g_emulator->m_psxMem->psxMemWrite8(_oB_, (uint8_t)_rRt_); }
+void InterpretedCPU::psxSB(uint32_t code) { PCSX::g_emulator->m_psxMem->psxMemWrite8(_oB_, _rRt_); }
 void InterpretedCPU::psxSH(uint32_t code) {
     if (PCSX::g_emulator->settings.get<PCSX::Emulator::SettingDebugSettings>()
             .get<PCSX::Emulator::DebugSettings::Debug>()) {
@@ -1007,7 +1007,7 @@ void InterpretedCPU::psxSH(uint32_t code) {
             return;
         }
     }
-    PCSX::g_emulator->m_psxMem->psxMemWrite16(_oB_, (uint16_t)_rRt_);
+    PCSX::g_emulator->m_psxMem->psxMemWrite16(_oB_, _rRt_);
 }
 
 void InterpretedCPU::psxSW(uint32_t code) {

--- a/src/core/psxmem.cc
+++ b/src/core/psxmem.cc
@@ -343,7 +343,7 @@ uint32_t PCSX::Memory::psxMemRead32(uint32_t mem) {
     }
 }
 
-void PCSX::Memory::psxMemWrite8(uint32_t mem, uint8_t value) {
+void PCSX::Memory::psxMemWrite8(uint32_t mem, uint32_t value) {
     char *p;
     uint32_t t;
 
@@ -368,7 +368,7 @@ void PCSX::Memory::psxMemWrite8(uint32_t mem, uint8_t value) {
     }
 }
 
-void PCSX::Memory::psxMemWrite16(uint32_t mem, uint16_t value) {
+void PCSX::Memory::psxMemWrite16(uint32_t mem, uint32_t value) {
     char *p;
     uint32_t t;
 

--- a/src/core/psxmem.cc
+++ b/src/core/psxmem.cc
@@ -496,14 +496,16 @@ const void *PCSX::Memory::psxMemPointerRead(uint32_t address) {
     }
 }
 
-const void *PCSX::Memory::psxMemPointerWrite(uint32_t address) {
+const void *PCSX::Memory::psxMemPointerWrite(uint32_t address, int size) {
     const auto page = address >> 16;
 
     if (page == 0x1f80 || page == 0x9f80 || page == 0xbf80) {
         if ((address & 0xffff) < 0x400)
             return &g_psxH[address & 0x3FF];
         else {
-            switch (address) {  // IO regs that are safe to write to directly
+            switch (address) {
+                // IO regs that are safe to write to directly. For some of these,
+                // Writing a 8-bit/16-bit value actually writes the entire 32-bit reg, so they're not safe to write directly
                 case 0x1f801080:
                 case 0x1f801084:
                 case 0x1f801090:
@@ -520,7 +522,7 @@ const void *PCSX::Memory::psxMemPointerWrite(uint32_t address) {
                 case 0x1f8010e4:
                 case 0x1f801074:
                 case 0x1f8010f0:
-                    return &g_psxH[address & 0xffff];
+                    return size == 32 ? &g_psxH[address & 0xffff] : nullptr;
 
                 default:
                     return nullptr;

--- a/src/core/psxmem.h
+++ b/src/core/psxmem.h
@@ -142,8 +142,8 @@ class Memory {
     uint8_t psxMemRead8(uint32_t mem);
     uint16_t psxMemRead16(uint32_t mem);
     uint32_t psxMemRead32(uint32_t mem);
-    void psxMemWrite8(uint32_t mem, uint8_t value);
-    void psxMemWrite16(uint32_t mem, uint16_t value);
+    void psxMemWrite8(uint32_t mem, uint32_t value);
+    void psxMemWrite16(uint32_t mem, uint32_t value);
     void psxMemWrite32(uint32_t mem, uint32_t value);
     const void *psxMemPointerRead(uint32_t address);
     const void *psxMemPointerWrite(uint32_t address);

--- a/src/core/psxmem.h
+++ b/src/core/psxmem.h
@@ -146,7 +146,7 @@ class Memory {
     void psxMemWrite16(uint32_t mem, uint32_t value);
     void psxMemWrite32(uint32_t mem, uint32_t value);
     const void *psxMemPointerRead(uint32_t address);
-    const void *psxMemPointerWrite(uint32_t address);
+    const void *psxMemPointerWrite(uint32_t address, int size);
 
     void setLuts();
 


### PR DESCRIPTION
Attempts to correct the write width to register space in accordance with the specifications document.

When accessing the cd player visualizer/sound scope, the shell performs a 16-bit write to DMA PCR. This would cause Redux to discard the upper 16-bits of the register, where as the console would actually perform a 32-bit write.