### PR TITLE
Restore the wrapper after ClangCL setup.

### DIFF
--- a/vsprojects/pcsx-wrapper/pcsx-wrapper.vcxproj
+++ b/vsprojects/pcsx-wrapper/pcsx-wrapper.vcxproj
@@ -111,7 +111,6 @@
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
@@ -168,6 +167,11 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseWithClangCL|x64'">
+    <ClCompile>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\resources\pcsx-redux.rc" />


### PR DESCRIPTION
After using ClangCL, the wrapper once again requires the runtime dlls, which is counter productive to its existence.