### PR TITLE
Optimize OpenGL calls

### DIFF
--- a/src/gui/gui.cc
+++ b/src/gui/gui.cc
@@ -660,6 +660,10 @@ void PCSX::GUI::startFrame() {
         saveCfg();
     }
     glBindFramebuffer(GL_FRAMEBUFFER, m_offscreenFrameBuffer);
+    GLenum DrawBuffers[1] = {GL_COLOR_ATTACHMENT0};
+
+    // this call seems to sometime fails when the window is minimized...?
+    glDrawBuffers(1, DrawBuffers);  // "1" is the size of DrawBuffers
 
     // Check hotkeys (TODO: Make configurable)
     if (ImGui::IsKeyPressed(GLFW_KEY_ESCAPE)) {
@@ -711,13 +715,7 @@ void PCSX::GUI::setViewport() { glViewport(0, 0, m_renderSize.x, m_renderSize.y)
 void PCSX::GUI::flip() {
     const GLuint texture = m_offscreenTextures[m_currentTexture];
     glBindFramebuffer(GL_FRAMEBUFFER, m_offscreenFrameBuffer);
-    glBindTexture(GL_TEXTURE_2D, texture);
-
     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture, 0);
-    GLenum DrawBuffers[1] = {GL_COLOR_ATTACHMENT0};
-
-    // this call seems to sometime fails when the window is minimized...?
-    glDrawBuffers(1, DrawBuffers);  // "1" is the size of DrawBuffers
 
     assert(glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE);
     m_currentTexture ^= 1;

--- a/src/gui/gui.cc
+++ b/src/gui/gui.cc
@@ -713,7 +713,6 @@ void PCSX::GUI::flip() {
     glBindFramebuffer(GL_FRAMEBUFFER, m_offscreenFrameBuffer);
     glBindTexture(GL_TEXTURE_2D, texture);
 
-    glBindRenderbuffer(GL_RENDERBUFFER, m_offscreenDepthBuffer);
     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture, 0);
     GLenum DrawBuffers[1] = {GL_COLOR_ATTACHMENT0};
 

--- a/src/gui/widgets/shader-editor.cc
+++ b/src/gui/widgets/shader-editor.cc
@@ -757,7 +757,7 @@ void PCSX::Widgets::ShaderEditor::render(GUI *gui, GLuint textureID, const ImVec
     quadVertices[3].color[3] = 1.0;
 
     glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
-    glBufferData(GL_ARRAY_BUFFER, sizeof(VertexData) * 4, &quadVertices[0], GL_STATIC_DRAW);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(VertexData) * 4, &quadVertices[0], GL_DYNAMIC_DRAW);
     glDisable(GL_DEPTH_TEST);
 
     if (m_setupVAO) {

--- a/src/gui/widgets/shader-editor.cc
+++ b/src/gui/widgets/shader-editor.cc
@@ -757,7 +757,7 @@ void PCSX::Widgets::ShaderEditor::render(GUI *gui, GLuint textureID, const ImVec
     quadVertices[3].color[3] = 1.0;
 
     glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
-    glBufferData(GL_ARRAY_BUFFER, sizeof(VertexData) * 4, &quadVertices[0], GL_DYNAMIC_DRAW);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(VertexData) * 4, &quadVertices[0], GL_STATIC_DRAW);
     glDisable(GL_DEPTH_TEST);
 
     if (m_setupVAO) {

--- a/src/gui/widgets/shader-editor.h
+++ b/src/gui/widgets/shader-editor.h
@@ -90,6 +90,9 @@ class ShaderEditor {
 
     GLuint m_vao = 0;
     GLuint m_vbo = 0;
+    GLint m_imguiProjMtxLoc = -1; // -1 = not found
+    GLint m_shaderProjMtxLoc = -1;
+    GLint m_imguiProgram = 0;
 
     GUI* m_cachedGui = nullptr;
 };


### PR DESCRIPTION
Avoiding glGetUniformLocation/glGet calls: In constast to most OpenGL calls, which are pipelined, these force a CPU<->GPU sync, which is super bad for performance. glGetUniformLocation also has to do string parsing, as if it weren't slow enough already. For this reason, we cache the ImGui program ID, and the projection matrix uniform locations.

The glUniform calls don't really have to validate the uniform location, which is why the >= 0 calls got yeeted. If the uniform is valid, the glUniform call will work fine, if it's not then the uniform location will be -1 and the driver will ignore it.

Removing the glBindTexture in flip: You don't need to have a texture that's attached to an FBO be bound at the same time (Even better - you shouldn't have it attached, because it's unnecessary and might cause feedback loops).

Removing the glDrawBuffers call: Calling it just once on init should be ok.

Brrrr
![image](https://user-images.githubusercontent.com/44909372/164740437-876cb7df-c4a4-41fd-be39-3a274a0c65d4.png)
