### PR TITLE
Properly purging all libuv events.

### DIFF
--- a/src/main/main.cc
+++ b/src/main/main.cc
@@ -108,7 +108,6 @@ class SystemImpl final : public PCSX::System {
     }
 
     virtual void purgeAllEvents() final override {
-        uv_stop(getLoop());
         uv_run(getLoop(), UV_RUN_DEFAULT);
     }
 


### PR DESCRIPTION
Fixes a crash on exit.