### PR TITLE
Improve assembly screen context menu UX

### DIFF
--- a/src/gui/widgets/assembly.cc
+++ b/src/gui/widgets/assembly.cc
@@ -652,13 +652,12 @@ void PCSX::Widgets::Assembly::draw(GUI* gui, psxRegisters* registers, Memory* me
                 }
                 ImGui::Text("  %s:%8.8x %c%c%c%c %8.8x: ", section, dispAddr, tc(b[0]), tc(b[1]), tc(b[2]), tc(b[3]),
                             code);
-                auto toggleBP = [&]() mutable {
+                auto toggleBP = [&]() {
                     if (hasBP) {
                         g_emulator->m_debug->removeBreakpoint(currentBP);
                     } else {
                         g_emulator->m_debug->addBreakpoint(dispAddr, Debug::BreakpointType::Exec, 4, _("GUI"));
                     }
-                    hasBP = !hasBP;
                 };
                 if (ImGui::IsItemHovered() && ImGui::IsMouseDoubleClicked(0)) {
                     toggleBP();
@@ -670,11 +669,9 @@ void PCSX::Widgets::Assembly::draw(GUI* gui, psxRegisters* registers, Memory* me
                         char fmtAddr[10];
                         std::snprintf(fmtAddr, sizeof(fmtAddr), "%8.8x", dispAddr);
                         ImGui::SetClipboardText(fmtAddr);
-                        ImGui::CloseCurrentPopup();
                     }
-                    if (ImGui::MenuItem(_("Go to in Memory View"))) {
+                    if (ImGui::MenuItem(_("Go to in Memory Editor"))) {
                         jumpToMemory(dispAddr, 4);
-                        ImGui::CloseCurrentPopup();
                     }
                     if (ImGui::MenuItem(_("Run to Cursor"), nullptr, false, !PCSX::g_system->running())) {
                         g_emulator->m_debug->addBreakpoint(
@@ -683,12 +680,10 @@ void PCSX::Widgets::Assembly::draw(GUI* gui, psxRegisters* registers, Memory* me
                                 g_system->pause();
                                 return false;
                             });
-                        ImGui::CloseCurrentPopup();
                         g_system->resume();
                     }
                     if (ImGui::MenuItem(_("Toggle Breakpoint"))) {
                         toggleBP();
-                        ImGui::CloseCurrentPopup();
                     }
                     ImGui::EndPopup();
                 }


### PR DESCRIPTION
Changed the menu to use imgui menu widgets:
![image](https://user-images.githubusercontent.com/1065521/173660055-a7aa1673-3815-4980-a570-5d84fd1220ae.png)
![image](https://user-images.githubusercontent.com/1065521/173660563-1e4384e2-df58-4ca1-95dd-7796dc4f1f55.png)

Functional changes:
* Copy Address: copies instruction address to clipboard. Personally find this very useful during quick RE iterations
* Go to in Memory View: follows the address in memory view for quick patches, etc
* Toggle Breakpoint: replaces the previous set/remove breakpoint with a single menu item

Breakpoints can also now be toggled by double clicking the address.