### PR TITLE
Add a context menu to editable registers, move PC under GPR

### DIFF
--- a/src/gui/widgets/registers.cc
+++ b/src/gui/widgets/registers.cc
@@ -59,9 +59,24 @@ void PCSX::Widgets::Registers::draw(PCSX::GUI* gui, PCSX::psxRegisters* register
                     name = PCSX::Disasm::s_disRNameGPR[counter];
                 }
                 counter++;
-                std::string label = fmt::format(f_("Edit##{}"), name);
                 ImGui::Text("%s: %08x", name, reg);
+                std::string contextLabel = fmt::format(f_("Context##{}"), name);
+                if (ImGui::BeginPopupContextItem(contextLabel.c_str())) {
+                    if (ImGui::MenuItem(_("Go to in Assembly"))) {
+                        g_system->m_eventBus->signal(PCSX::Events::GUI::JumpToPC{reg});
+                    }
+                    if (ImGui::MenuItem(_("Go to in Memory Editor"))) {
+                        g_system->m_eventBus->signal(PCSX::Events::GUI::JumpToMemory{reg, 1});
+                    }
+                    if (ImGui::MenuItem(_("Copy Value"))) {
+                        char strVal[10];
+                        std::snprintf(strVal, sizeof(strVal), "%8.8x", reg);
+                        ImGui::SetClipboardText(strVal);
+                    }
+                    ImGui::EndPopup();
+                }
                 ImGui::SameLine();
+                std::string label = fmt::format(f_("Edit##{}"), name);
                 if (ImGui::SmallButton(label.c_str())) {
                     editorToOpen = fmt::format(f_("Edit value of {}"), name);
                     snprintf(m_registerEditor, 19, "%08x", reg);

--- a/src/gui/widgets/registers.h
+++ b/src/gui/widgets/registers.h
@@ -35,8 +35,11 @@ class Registers {
     bool& m_show;
 
   private:
+    void makeEditableRegister(const char *name, uint32_t reg);
+
     unsigned m_selected = 0;
     char m_registerEditor[20];
+    std::string m_editorToOpen;
 };
 
 }  // namespace Widgets


### PR DESCRIPTION
Several things here that I personally find useful during reverse engineering

![image](https://user-images.githubusercontent.com/1065521/173702224-32d5bf18-06f8-4382-b683-247e93d389dc.png)

Also move PC under GPR so you don't have switch tabs to access it (it's currently the only other editable register not under GPR).