### PR TITLE
Tweak VRAM Viewer coordinates.

### DIFF
--- a/src/gui/widgets/vram-viewer.cc
+++ b/src/gui/widgets/vram-viewer.cc
@@ -400,7 +400,7 @@ void PCSX::Widgets::VRAMViewer::draw(GUI *gui, unsigned int VRAMTexture) {
             }
             ImGui::Separator();
             ImGui::Separator();
-            ImGui::Text("%.0f : %.0f", m_mouseUV.x * 1024.0f, m_mouseUV.y * 512.0f);
+            ImGui::Text("%.0f : %.0f", std::floor(m_mouseUV.x * 1024.0f), std::floor(m_mouseUV.y * 512.0f));
             ImGui::EndMenuBar();
         }
         drawVRAM(gui, VRAMTexture);


### PR DESCRIPTION
The coordinates displayed in the VRAM viewer are rounded up to the closest number, which means that if you place the cursor more than half a pixel away on either axis, the coordinates of the next pixel will be displayed instead of the coordinates of the current pixel.

# Before
![image](https://user-images.githubusercontent.com/5395186/175861950-fb923df3-b404-4730-85b5-7956e1d4e0b5.png)
*Notice how the cursor is at "0 : 0", but the viewer displays (1 : 1)* 

# After
![image](https://user-images.githubusercontent.com/5395186/175862369-46a63a45-f7c9-4477-8c01-265b10534bd0.png)
*Notice how the coordinates are now "0 : 0" as expected* 

