### PR TITLE
Web server: add a reset function to asm symbols

### DIFF
--- a/src/core/web-server.cc
+++ b/src/core/web-server.cc
@@ -162,25 +162,45 @@ class AssemblyExecutor : public PCSX::WebExecutor {
         return urldata.path == "/api/v1/assembly/symbols";
     }
     virtual bool execute(PCSX::WebClient* client, PCSX::RequestData& request) final {
-        auto& cpu = PCSX::g_emulator->m_cpu;
-        auto& body = request.body;
-        PCSX::IO<PCSX::File> file = new PCSX::BufferFile(std::move(body));
-        while (file && !file->failed() && !file->eof()) {
-            auto line = file->gets();
-            auto tokens = PCSX::StringsHelpers::split(std::string_view(line), " ");
-            if (tokens.size() != 2) {
-                continue;
+        if (request.method == PCSX::RequestData::Method::HTTP_POST) {
+            auto vars = parseQuery(request.urlData.query);
+            auto ifunction = vars.find("function");
+            if (ifunction == vars.end()) {
+                client->write("HTTP/1.1 400 Bad Request\r\n\r\n");
+                return true;
             }
-            auto addressStr = tokens[0];
-            auto name = tokens[1];
-            uint32_t address;
-            auto result = std::from_chars(addressStr.data(), addressStr.data() + addressStr.size(), address, 16);
-            if (result.ec == std::errc::invalid_argument) continue;
+            std::string function = ifunction->second;
+            auto& cpu = PCSX::g_emulator->m_cpu;
+            if (function.compare("reset") == 0) {
+                cpu->m_symbols.clear();
+                client->write("HTTP/1.1 200 OK\r\n\r\n");
+                return true;
+            }
+            if (function.compare("upload") == 0)
+            {
+                auto& body = request.body;
+                PCSX::IO<PCSX::File> file = new PCSX::BufferFile(std::move(body));
+                while (file && !file->failed() && !file->eof()) {
+                    auto line = file->gets();
+                    auto tokens = PCSX::StringsHelpers::split(std::string_view(line), " ");
+                    if (tokens.size() != 2) {
+                        continue;
+                    }
+                    auto addressStr = tokens[0];
+                    auto name = tokens[1];
+                    uint32_t address;
+                    auto result = std::from_chars(addressStr.data(), addressStr.data() + addressStr.size(), address, 16);
+                    if (result.ec == std::errc::invalid_argument) continue;
 
-            cpu->m_symbols[address] = name;
+                    cpu->m_symbols[address] = name;
+                }
+                client->write("HTTP/1.1 200 OK\r\n\r\n");
+                return true;
+            }
+            client->write("HTTP/1.1 400 Bad Request\r\n\r\n");
+            return true;
         }
-        client->write("HTTP/1.1 200 OK\r\n\r\n");
-        return true;
+        return false;
     }
 
   public:

--- a/tools/ghidra_scripts/ReduxSymbols.java
+++ b/tools/ghidra_scripts/ReduxSymbols.java
@@ -26,7 +26,7 @@ public class ReduxSymbols extends GhidraScript {
 
     	HttpClient client = HttpClient.newHttpClient();
         HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create("http://localhost:8080/api/v1/assembly/symbols"))
+                .uri(URI.create("http://localhost:8080/api/v1/assembly/symbols?function=upload"))
                 .POST(HttpRequest.BodyPublishers.ofString(String.join("\n", symbols)))
                 .build();
 


### PR DESCRIPTION
* Change the `assembly/symbols` api to require a `function` variable
* Add a new functionality to reset the symbols loaded in redux