### PR TITLE
Web Server: fix VRAM get method

### DIFF
--- a/src/core/gpu.h
+++ b/src/core/gpu.h
@@ -80,6 +80,7 @@ class GPU {
 
     virtual void setDither(int setting) {}
     virtual uint8_t *getVRAM() { return nullptr; }
+    virtual uint16_t *getVRAMuw() { return nullptr; }
     virtual void clearVRAM() {}
 
     virtual void partialUpdateVRAM(int x, int y, int w, int h, const uint16_t *pixels) {}

--- a/src/core/web-server.cc
+++ b/src/core/web-server.cc
@@ -48,16 +48,10 @@ class VramExecutor : public PCSX::WebExecutor {
                 "HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\nContent-Length: 1048576\r\n\r\n");
             static constexpr uint32_t texSize = 1024 * 512 * sizeof(uint16_t);
             uint16_t* pixels = (uint16_t*)malloc(texSize);
-            int oldTexture;
-            glFlush();
-            glGetIntegerv(GL_TEXTURE_BINDING_2D, &oldTexture);
-            glBindTexture(GL_TEXTURE_2D, m_VRAMTexture);
-            glGetTexImage(GL_TEXTURE_2D, 0, GL_RGBA, GL_UNSIGNED_SHORT_5_5_5_1, pixels);
-            glBindTexture(GL_TEXTURE_2D, oldTexture);
+            memcpy(pixels, PCSX::g_emulator->m_gpu->getVRAMuw(), texSize);
             PCSX::Slice slice;
             slice.acquire(pixels, texSize);
             client->write(std::move(slice));
-
             return true;
         } else if (request.method == PCSX::RequestData::Method::HTTP_POST) {
             auto vars = parseQuery(request.urlData.query);

--- a/src/gpu/soft/interface.h
+++ b/src/gpu/soft/interface.h
@@ -54,6 +54,7 @@ class impl final : public GPU {
     virtual void load(const SaveStates::GPU &gpu) final;
     virtual void setDither(int setting) final { m_softPrim.m_useDither = setting; }
     virtual uint8_t *getVRAM() final { return psxVSecure; }
+    virtual uint16_t *getVRAMuw() final { return psxVuw; }
     virtual void partialUpdateVRAM(int x, int y, int w, int h, const uint16_t *pixels) final override {
         auto ptr = psxVuw;
         ptr += y * 1024 + x;


### PR DESCRIPTION
The `get` method for the VRAM endpoint wasn't retrieving the raw VRAM data from the emulator. Changed the code so that the returned bytes are exactly the values loaded in the VRAM.