### PR TITLE
Fixed delta-over-time searches inverting bytes.

### DIFF
--- a/src/gui/widgets/memory_observer.cc
+++ b/src/gui/widgets/memory_observer.cc
@@ -221,7 +221,7 @@ void PCSX::Widgets::MemoryObserver::draw(const char* title) {
                     }
 
                     const uint8_t currentByte = memData[i];
-                    const uint8_t leftShift = 8 * (stride - 1 - i % stride);
+                    const uint8_t leftShift = 8 * (i % stride);
                     const uint32_t mask = 0xffffffff ^ (0xff << leftShift);
                     const int byteToWrite = currentByte << leftShift;
                     memValue = (memValue & mask) | byteToWrite;
@@ -410,7 +410,7 @@ int PCSX::Widgets::MemoryObserver::getMemValue(uint32_t absoluteAddress, const u
     assert(relativeAddress < memSize);
     for (uint32_t i = relativeAddress; i < relativeAddress + stride; ++i) {
         const uint8_t currentByte = memData[i];
-        const uint8_t leftShift = 8 * (stride - 1 - i % stride);
+        const uint8_t leftShift = 8 * (i % stride);
         const uint32_t mask = 0xffffffff ^ (0xff << leftShift);
         const int byteToWrite = currentByte << leftShift;
         memValue = (memValue & mask) | byteToWrite;


### PR DESCRIPTION
The exact restitution of multibyte sequences as they were represented in memory meant that, eg, the short `0001` was being interpreted as 0x0001 rather than 0x100 and therefore not only being inaccurately displayed but also considered lesser than `ff00`, which in turn was interpreted as 0xff00 rather than 0xff.