### PR TITLE
Delta-over-time search: replaced alignment with types.

### DIFF
--- a/src/gui/widgets/memory_observer.cc
+++ b/src/gui/widgets/memory_observer.cc
@@ -416,8 +416,7 @@ uint8_t PCSX::Widgets::MemoryObserver::getStrideFromValueType(ScanValueType valu
     case ScanValueType::Int:
         return 4;
     default:
-        assert(false);
-        return 1;
+        throw std::runtime_error("Invalid value type.");
     }
 }
 
@@ -442,8 +441,7 @@ int PCSX::Widgets::MemoryObserver::getValueAsSelectedType(int memValue) {
         case ScanValueType::Int:
             return memValue;
         default:
-            assert(false);
-            return memValue;
+            throw std::runtime_error("Invalid value type.");
     }
 }
 

--- a/src/gui/widgets/memory_observer.h
+++ b/src/gui/widgets/memory_observer.h
@@ -77,7 +77,9 @@ class MemoryObserver {
         UnknownInitialValue
     };
 
-    enum class ScanAlignment : uint8_t { OneByte = 1, TwoBytes = 2, FourBytes = 4 };
+    enum class ScanValueType { Char, Uchar, Short, Ushort, Int };
+    static uint8_t getStrideFromValueType(ScanValueType valueType);
+    int getValueAsSelectedType(int memValue);
 
     struct AddressValuePair {
         uint32_t address = 0;
@@ -85,7 +87,7 @@ class MemoryObserver {
     };
 
     ScanType m_scanType = ScanType::ExactValue;
-    ScanAlignment m_scanAlignment = ScanAlignment::OneByte;
+    ScanValueType m_scanValueType = ScanValueType::Short;
     std::vector<AddressValuePair> m_addressValuePairs;
     bool m_hex = false;
     bool m_useSIMD = false;


### PR DESCRIPTION
Currently, the user chooses whether to search for 1-, 2- or 4-byte sequences, but lack of typing means that all 1- and 2-byte values are displayed as positive integers.

These changes fix the problem by allowing the user to specify the type they are searching for from among char, uchar, short, ushort and int; signed variants of 1- and 2-byte values are displayed accurately and hex inputs are automatically converted between types.