### PR TITLE
Kiosk Mode

### DIFF
--- a/src/core/psxemulator.cc
+++ b/src/core/psxemulator.cc
@@ -115,6 +115,14 @@ int PCSX::Emulator::init() {
 
     m_gpu = settings.get<SettingHardwareRenderer>() ? GPU::getOpenGL() : GPU::getSoft();
 
+    // Enable or disable Kiosk Mode if command line flags are set
+    if (args.get<bool>("kiosk")) {
+        settings.get<SettingKioskMode>() = true;
+    }
+    if (args.get<bool>("no-kiosk")) {
+        settings.get<SettingKioskMode>() = false;
+    }
+
     setPGXPMode(m_config.PGXP_Mode);
     m_pads->init();
     return ret;

--- a/src/core/psxemulator.h
+++ b/src/core/psxemulator.h
@@ -178,13 +178,14 @@ class Emulator {
     typedef Setting<bool, TYPESTRING("AutoUpdate"), false> SettingAutoUpdate;
     typedef Setting<int, TYPESTRING("MSAA"), 1> SettingMSAA;
     typedef Setting<bool, TYPESTRING("LinearFiltering"), true> SettingLinearFiltering;
+    typedef Setting<bool, TYPESTRING("KioskMode"), false> SettingKioskMode;
 
     Settings<SettingStdout, SettingLogfile, SettingMcd1, SettingMcd2, SettingBios, SettingPpfDir, SettingPsxExe,
              SettingXa, SettingSpuIrq, SettingBnWMdec, SettingScaler, SettingAutoVideo, SettingVideo, SettingFastBoot,
              SettingDebugSettings, SettingRCntFix, SettingIsoPath, SettingLocale, SettingMcd1Inserted,
              SettingMcd2Inserted, SettingDynarec, Setting8MB, SettingGUITheme, SettingDither, SettingGLErrorReporting,
              SettingGLErrorReportingSeverity, SettingFullCaching, SettingHardwareRenderer, SettingShownAutoUpdateConfig,
-             SettingAutoUpdate, SettingMSAA, SettingLinearFiltering>
+             SettingAutoUpdate, SettingMSAA, SettingLinearFiltering, SettingKioskMode>
         settings;
     class PcsxConfig {
       public:

--- a/src/gui/gui.cc
+++ b/src/gui/gui.cc
@@ -700,6 +700,10 @@ void PCSX::GUI::startFrame() {
     // this call seems to sometime fails when the window is minimized...?
     glDrawBuffers(1, DrawBuffers);  // "1" is the size of DrawBuffers
 
+    //If kiosk mode is enabled, ignore hotkeys
+    if (PCSX::g_emulator->settings.get<PCSX::Emulator::SettingKioskMode>().value)
+        return;
+
     // Check hotkeys (TODO: Make configurable)
     if (ImGui::IsKeyPressed(GLFW_KEY_ESCAPE)) {
         m_showMenu = !m_showMenu;


### PR DESCRIPTION
Added basic Kiosk Mode (aka "Kids Mode") functionality to the emulator. In its current form, menu access is prevented by disabling hotkey functionality when the setting value is set to true. When this mode is active the emulator is operated via pre-configured user settings and command line flags.

To avoid accidental user changes, the KioskMode setting can only be toggled by editing the pcsx.json file.