### PR TITLE
[GUI] Detailing the Spanish language variant

### DIFF
--- a/src/core/system.cc
+++ b/src/core/system.cc
@@ -46,7 +46,7 @@ const std::map<std::string, PCSX::System::LocaleInfo> PCSX::System::LOCALES = {
         {"el.po", {}, c_greekRanges},
     },
     {
-        "Español",
+        "Español (España)",
         {"es_ES.po", {}, nullptr},
     },
     {
@@ -70,7 +70,7 @@ const std::map<std::string, PCSX::System::LocaleInfo> PCSX::System::LOCALES = {
         {"mt.po", {}, c_malteseRanges},
     },
     {
-        "Português Brasileiro",
+        "Português (Brasil)",
         {"pt_BR.po", {}, nullptr},
     },
 };


### PR DESCRIPTION
Greetings. I just wanted to point out that the Spanish variant that was done on Transifex was Spanish (Spain). Since there are many other variants, I think it would be best to mark it properly in order to avoid any future translators that could start mixing different regions in the same language.

Thus, if someone wants to make a Spanish from another region, they could simply call for a new language (like that Chilean version that seems empty on Transifex) and do their own version without any mixes and mismatches. This is an attempt to futureproof the Spanish from Spain translation.