### PR TITLE
Events::ExecutionFlow::Run -> Pause

### DIFF
--- a/src/core/eventslua.cc
+++ b/src/core/eventslua.cc
@@ -185,7 +185,7 @@ void PCSX::LuaBindings::open_events(Lua L) {
             } else if (name == "ExecutionFlow::Run") {
                 createListener<Events::ExecutionFlow::Run>(L);
             } else if (name == "ExecutionFlow::Pause") {
-                createListener<Events::ExecutionFlow::Run>(L);
+                createListener<Events::ExecutionFlow::Pause>(L);
             } else if (name == "ExecutionFlow::Reset") {
                 createListener<Events::ExecutionFlow::Reset>(L);
             } else if (name == "ExecutionFlow::SaveStateLoaded") {


### PR DESCRIPTION
Tiny fix for the `ExecutionFlow::Pause` Lua event, previous behavior would trigger the `Pause` callback when resuming debugger / `Run`.