### PR TITLE
Lua uvFifoListener ffi

### DIFF
--- a/src/lua/luafile.h
+++ b/src/lua/luafile.h
@@ -23,6 +23,7 @@
 
 #include "lua/luawrapper.h"
 #include "support/file.h"
+#include "support/uvfile.h"
 
 namespace PCSX {
 
@@ -50,6 +51,12 @@ static constexpr inline int wheelConv(enum SeekWheel w) {
 struct LuaFile {
     LuaFile(IO<File> file) : file(file) {}
     IO<File> file;
+};
+
+struct LuaServer {
+    LuaServer(UvFifoListener* listener) : m_listener(listener) {}
+    UvFifoListener* m_listener = nullptr;
+    uv_async_t m_async;
 };
 
 void open_file(Lua);


### PR DESCRIPTION
Adds ability to spin up a uvFifoListener (similar to using uvFifo in Lua) but as a server instead of a client. 

- Garbage Collection for the fifo inside the wrapper needs adjusting
- UvFifoListener needs some pending changes to move m_async and tidy up a few things inside the class. This can be done after the current Lua changes are finalized