### PR TITLE
Fix Homebrew binutils formula

### DIFF
--- a/tools/macos-mips/mipsel-none-elf-binutils.rb
+++ b/tools/macos-mips/mipsel-none-elf-binutils.rb
@@ -3,7 +3,9 @@ class MipselNoneElfBinutils < Formula
   homepage "https://www.gnu.org/software/binutils/"
   url "https://ftp.gnu.org/gnu/binutils/binutils-2.39.tar.gz"
   sha256 "d12ea6f239f1ffe3533ea11ad6e224ffcb89eb5d01bbea589e9158780fa11f10"
-
+    
+  depends_on "texinfo" => :build
+  
   def install
     system "./configure", "--target=mipsel-none-elf",
                           "--disable-multilib",


### PR DESCRIPTION
Some recent changes in Mac Xcode command-line tools, we need texinfo available to the build process of binutils. In order to achieve this properly without user intervention, we declare texinfo (make info) as a dependency inside the formula.