### PR TITLE
Improve mac app layout

### DIFF
--- a/.github/scripts/create-app.sh
+++ b/.github/scripts/create-app.sh
@@ -1,10 +1,16 @@
 #!/bin/sh
 
-brew install imagemagick dylibbundler
-
 APP=PCSX-Redux
+APPROOT="${APP}.app"
+
+# /usr/libexec needed for PlistBuddy used below.
 PATH="$PATH:/usr/libexec"
 
+# ImageMagik used for converting .ico files to .png files.
+# dylibbundler used for updating load commands for dylib dependencies.
+brew install imagemagick dylibbundler
+
+# Construct the app iconset.
 mkdir pcsx-redux.iconset
 convert resources/pcsx-redux.ico[0] -alpha on -background none -units PixelsPerInch -density 72 -resize 16x16 pcsx-redux.iconset/icon_16x16.png
 convert resources/pcsx-redux.ico[0] -alpha on -background none -units PixelsPerInch -density 144 -resize 32x32 pcsx-redux.iconset/icon_16x16@2x.png
@@ -18,13 +24,40 @@ convert resources/pcsx-redux.ico[0] -alpha on -background none -units PixelsPerI
 convert resources/pcsx-redux.ico[0] -alpha on -background none -units PixelsPerInch -density 144 -resize 1024x1024 pcsx-redux.iconset/icon_512x512@2x.png
 iconutil --convert icns pcsx-redux.iconset
 
-make install DESTDIR=${APP}.app/Contents/Resources
-mkdir -p ${APP}.app/Contents/MacOS
-ln -s ../Resources/bin/pcsx-redux ${APP}.app/Contents/MacOS/${APP}
-PlistBuddy ${APP}.app/Contents/Info.plist -c "add CFBundleDisplayName string ${APP}"
-PlistBuddy ${APP}.app/Contents/Info.plist -c "add CFBundleIconFile string pcsx-redux.icns"
-PlistBuddy ${APP}.app/Contents/Info.plist -c "add NSHighResolutionCapable bool true"
-PlistBuddy ${APP}.app/Contents/version.plist -c "add ProjectName string ${APP}"
-dylibbundler -od -b -x ./PCSX-Redux.app/Contents/Resources/bin/pcsx-redux -d ./PCSX-Redux.app/Contents/Resources/lib/ -p @executable_path/../lib/
-cp pcsx-redux.icns ${APP}.app/Contents/Resources/
-xattr -r -d com.apple.quarantine ${APP}.app
+# Install the contents into ./Contents/Resources temporarily.
+make install DESTDIR=${APPROOT}/Contents/Resources
+
+# Move the executable to ./Contents/MacOS/PCSX-Redux.
+mkdir -p ${APPROOT}/Contents/MacOS
+mv ${APPROOT}/Contents/Resources/bin/pcsx-redux ${APPROOT}/Contents/MacOS/${APP}
+
+# Delete the now empty bin directory.
+rmdir ${APPROOT}/Contents/Resources/bin
+
+# Copy the app icon to the expected location.
+cp pcsx-redux.icns ${APPROOT}/Contents/Resources/AppIcon.icns
+
+# Remove source images that were used to create the app icon.
+rm -rfv ${APPROOT}/Contents/Resources/share/icons
+
+# Create the required Info.plist and version.plist files
+# with the minimum information.
+PlistBuddy ${APPROOT}/Contents/Info.plist -c "add CFBundleDisplayName string ${APP}"
+PlistBuddy ${APPROOT}/Contents/Info.plist -c "add CFBundleIconName string AppIcon"
+PlistBuddy ${APPROOT}/Contents/Info.plist -c "add CFBundleIconFile string AppIcon"
+PlistBuddy ${APPROOT}/Contents/Info.plist -c "add NSHighResolutionCapable bool true"
+PlistBuddy ${APPROOT}/Contents/version.plist -c "add ProjectName string ${APP}"
+
+# Install dylib dependencies in ./Contents/Frameworks.
+# Update the dyld load commands for these.
+dylibbundler -od -b -x ${APPROOT}/Contents/MacOS/${APP} -d ${APPROOT}/Contents/Frameworks/ -p @rpath
+
+# Add a relative @rpath to ./Contents/Frameworks
+# so that dyld knows where to find dylib dependencies.
+install_name_tool -add_rpath @loader_path/../Frameworks ${APPROOT}/Contents/MacOS/${APP}
+
+# Linux desktop shortcuts not relevant.
+rm -rfv ${APPROOT}/Contents/Resources/share/applications
+
+# Ad-hoc codesign the app.
+codesign --force -s - -vvvv ${APPROOT}

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -73,12 +73,12 @@ jobs:
       run: |
         mkdir dmgdir
         mv PCSX-Redux.app dmgdir
-        cp dmgdir/PCSX-Redux.app/Contents/Resources/pcsx-redux.icns .
+        cp dmgdir/PCSX-Redux.app/Contents/Resources/AppIcon.icns .
     - name: Creating dmg icon
       run: |
-        sips -i pcsx-redux.icns
-        DeRez -only icns pcsx-redux.icns > icns.rsrc
-        cp pcsx-redux.icns dmgdir/.VolumeIcon.icns
+        sips -i AppIcon.icns
+        DeRez -only icns AppIcon.icns > icns.rsrc
+        cp AppIcon.icns dmgdir/.VolumeIcon.icns
         SetFile -c icnC dmgdir/.VolumeIcon.icns
         SetFile -a C dmgdir
     - name: Creating Application link

--- a/README.md
+++ b/README.md
@@ -34,13 +34,17 @@ Please consult [the documentation pages](https://pcsx-redux.consoledev.net) for 
 |[MacOS](https://install.appcenter.ms/orgs/grumpycoders/apps/pcsx-redux-macos/distribution_groups/public)|
 
 ### Note:
-Because Apple is being Apple, after installing the Application from the dmg file, in order to make it work properly, one has to run the following command:
+The macOS version of PCSX-Redux is not currently signed with a developer certificate so you may see a security warning when opening the application.
 
-```
-xattr -r -d com.apple.quarantine /path/to/PCSX-Redux.app
-```
+If you see a dialog with the message:
 
-If anyone has the means and the will to understand the derpiness of MacOS to debug this one, please feel free to send a pull request, or to open a detailed issue describing the root cause of this problem.
+> “PCSX-Redux” can’t be opened because Apple cannot check it for malicious software.
+
+You can allow the application to run by doing either of the following. You only need to do this once for freshly downloaded copies of PCSX-Redux.
+
+- Right-click the app and select Open. This signals an explicit decision on your part that you really want to open it, and adds a new "Open" button to the security warning dialog.
+
+- Alternatively, go to macOS Settings > Privacy & Security. Scroll down to see a section that will let you allow the app.
 
 ## How?
 The code is meant to be built using very modern compilers. Also it's still fairly experimental, and lots of things can break. If you still want to proceed, here are instructions to build it on Linux, MacOS and Windows. The code now comes in two big parts: the emulator itself, and [OpenBIOS](https://github.com/grumpycoders/pcsx-redux/tree/main/src/mips/openbios), which can be used as an alternative to the retail, copyright protected BIOS.


### PR DESCRIPTION
When downloading an app or disk image from the Web, files get the `com.apple.quarantine` attribute which signals to the OS that the app may be unsafe. The user can still let the app to run from Finder, which removes the attribute and allows future runs to proceed without a prompt.

However, if an app is irregular, the user can't approve it normally and it may get labeled as "damaged". The workaround is to remove the attribute with something like `xattr` in the terminal but that isn't necessary.

Change the `create-app.sh` script to bring the app into a more typical form for macOS and remove files that might interfere with code-signing or needlessly increase the app's size.

- Don't symlink the `pcsx-redux` binary. Make the real binary exist at `./Contents/MacOS/PCSX-Redux`.
  - Remove the now empty `./Contents/Resources/bin`.
- Call the app icon `AppIcon.icns` as is customary.
  - Remove source images after constructing the app icon.
- Move dylibs into `./Contents/Frameworks`.
  - Add this path to the executable's `@rpath`.
  - Use `@rpath` instead of `@executable_path` for library locations.
- Removing the quarantine attribute during the build has no effect.
- Remove the Linux desktop things from `./Contents/Resources/share/applications` as it isn't necessary for macOS.
- Ad-hoc codesign the app after making changes. This must *always* be the very last step.

Update the README about this.