### PR TITLE
Move mac app codesigning into GitHub workflows

### DIFF
--- a/.github/scripts/create-app.sh
+++ b/.github/scripts/create-app.sh
@@ -58,6 +58,3 @@ install_name_tool -add_rpath @loader_path/../Frameworks ${APPROOT}/Contents/MacO
 
 # Linux desktop shortcuts not relevant.
 rm -rfv ${APPROOT}/Contents/Resources/share/applications
-
-# Ad-hoc codesign the app.
-codesign --force -s - -vvvv ${APPROOT}

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -69,6 +69,8 @@ jobs:
         echo '    }' >> PCSX-Redux.app/Contents/Resources/share/pcsx-redux/resources/version.json
         echo '  ]' >> PCSX-Redux.app/Contents/Resources/share/pcsx-redux/resources/version.json
         echo '}' >> PCSX-Redux.app/Contents/Resources/share/pcsx-redux/resources/version.json
+    - name: Signing Application
+      run: codesign --force -s - -vvvv PCSX-Redux.app
     - name: Adjusting for dmg folder
       run: |
         mkdir dmgdir


### PR DESCRIPTION
The app cannot be modified after signing, and there are some files copied into the app bundle during the CI workflows, so move signing as the last modifying step there.