### PR TITLE
Set binDir to absolute path

### DIFF
--- a/src/main/main.cc
+++ b/src/main/main.cc
@@ -199,7 +199,7 @@ int pcsxMain(int argc, char **argv) {
     PCSX::Emulator *emulator = new PCSX::Emulator();
     PCSX::g_emulator = emulator;
     std::filesystem::path self = argv[0];
-    std::filesystem::path binDir = self.parent_path();
+    std::filesystem::path binDir = std::filesystem::absolute(self).parent_path();
     system->setBinDir(binDir);
     system->loadAllLocales();
 


### PR DESCRIPTION
This fixes an issue on macOS where finding font resources can fail via relative paths in certain environments such as the terminal. Using absolute paths for these lookups work in both the terminal and inside the .app.