### PR TITLE
Disabling multiple viewports for Linux.

### DIFF
--- a/src/gui/gui.cc
+++ b/src/gui/gui.cc
@@ -491,7 +491,9 @@ void PCSX::GUI::init() {
     io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
     // io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;
     io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
+#ifndef __linux__
     io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;
+#endif
     io.ConfigFlags |= ImGuiConfigFlags_DpiEnableScaleViewports;
     // io.ConfigFlags |= ImGuiConfigFlags_DpiEnableScaleFonts;
 


### PR DESCRIPTION
Wayland is hopelessly broken, and there's no salvaging this mess.