### PR TITLE
Add comment field for break and syscall instructions to the MIPS asssembler

### DIFF
--- a/src/supportpsx/assembler/assembler.lua
+++ b/src/supportpsx/assembler/assembler.lua
@@ -39,6 +39,16 @@ PCSX.Assembler.Internals.checks.imm26 = function(imm, place)
     error("Argument " .. place .. " must be a number or a label")
 end
 
+PCSX.Assembler.Internals.checks.imm20 = function(imm, place)
+    if type(imm) == "number" then
+        if imm < 0 or imm > 0xfffff then
+            error("Immediate out of range: " .. imm)
+        end
+        return imm
+    end
+    error("Argument " .. place .. " must be a number")
+end
+
 PCSX.Assembler.Internals.checks.bimm16 = function(imm, place)
     if type(imm) == "number" then
         if (imm % 4) ~= 0 then
@@ -144,6 +154,9 @@ PCSX.Assembler.New = function()
         end
         if code.imm5 then
             ret = bit.bor(ret, code.imm5)
+        end
+        if code.imm20 then
+            ret = bit.bor(ret, code.imm20)
         end
         if code.rs then
             ret = bit.bor(ret, bit.lshift(code.rs, 21))

--- a/src/supportpsx/assembler/assembler.lua
+++ b/src/supportpsx/assembler/assembler.lua
@@ -156,7 +156,7 @@ PCSX.Assembler.New = function()
             ret = bit.bor(ret, code.imm5)
         end
         if code.imm20 then
-            ret = bit.bor(ret, code.imm20)
+            ret = bit.bor(ret, bit.lshift(code.imm20, 6))
         end
         if code.rs then
             ret = bit.bor(ret, bit.lshift(code.rs, 21))

--- a/src/supportpsx/assembler/extra.lua
+++ b/src/supportpsx/assembler/extra.lua
@@ -19,6 +19,7 @@
 local checkBImm16 = PCSX.Assembler.Internals.checks.bimm16
 local checkGPR = PCSX.Assembler.Internals.checks.gpr
 local checkImm5 = PCSX.Assembler.Internals.checks.imm5
+local checkImm20 = PCSX.Assembler.Internals.checks.imm20
 local checkCOP0 = PCSX.Assembler.Internals.checks.cop0
 
 PCSX.Assembler.Internals.specialInstructions = {
@@ -172,20 +173,32 @@ PCSX.Assembler.Internals.specialInstructions = {
     end,
 
     syscall = function(args)
-        if #args ~= 0 then
-            error("syscall takes no arguments")
+        if #args > 1 then
+            error("syscall takes one or no arguments")
         end
+        if #args == 1 then
         return {
             base = 0x0000000c,
+            imm20 = checkImm20(args[1])
+        }
+        end
+        return {
+            base = 0x0000000c
         }
     end,
 
     break_ = function(args)
-        if #args ~= 0 then
-            error("break takes no arguments")
+        if #args > 1 then
+            error("break takes one or no arguments")
         end
+        if #args == 1 then
         return {
             base = 0x0000000d,
+            imm20 = checkImm20(args[1])
+        }
+        end
+        return {
+            base = 0x0000000d
         }
     end,
 


### PR DESCRIPTION
The comment field in break is used on the PS1 for PCDRV functions + different sort of exceptions (eg div by zero) use different break comment fields. Syscall comment field is unused on PS1 but added because why not.