### PR TITLE
Fixing counter overflow.

### DIFF
--- a/src/core/psxcounters.cc
+++ b/src/core/psxcounters.cc
@@ -149,6 +149,7 @@ void PCSX::Counters::update() {
             diff = std::numeric_limits<uint32_t>::max();
             diff += cycle + 1;
             diff -= prev;
+            diff &= 0xffffffff;
         }
         diff *= 4410000;
         diff /= g_emulator->settings.get<Emulator::SettingScaler>();


### PR DESCRIPTION
64 bits numbers obviously won't overflow the way we'd expect them to with 32 bits math.