### PR TITLE
Fixing race condition in UvFile on close.

### DIFF
--- a/src/support/uvfile.cc
+++ b/src/support/uvfile.cc
@@ -204,14 +204,25 @@ void PCSX::UvFile::closeInternal() {
     m_download = false;
     m_cacheProgress.store(0.0f);
     if (m_handle < 0) return;
-    request([handle = m_handle](auto loop) {
-        auto req = new uv_fs_t();
-        uv_fs_close(loop, req, handle, [](uv_fs_t *req) {
-            uv_fs_req_cleanup(req);
-            delete req;
-        });
+    request([handle = m_handle, pendingCloseInfo = m_pendingCloseInfo](auto loop) {
+        if (pendingCloseInfo->pendingWrites != 0) {
+            pendingCloseInfo->closePending = true;
+            return;
+        }
+        closeUVHandle(handle, loop, pendingCloseInfo);
     });
     m_handle = -1;
+}
+
+void PCSX::UvFile::closeUVHandle(uv_file handle, uv_loop_s *loop, PendingCloseInfo *pendingCloseInfo) {
+    auto req = new uv_fs_t();
+    req->data = pendingCloseInfo;
+    uv_fs_close(loop, req, handle, [](uv_fs_t *req) {
+        uv_fs_req_cleanup(req);
+        PendingCloseInfo *info = reinterpret_cast<PendingCloseInfo *>(req->data);
+        delete info;
+        delete req;
+    });
 }
 
 void PCSX::UvFile::openwrapper(const char *filename, int flags) {
@@ -412,12 +423,8 @@ ssize_t PCSX::UvFile::read(void *dest, size_t size) {
 
     if (progress == 1.0f) {
         if ((m_handle >= 0) && !writable()) {
-            request([handle = m_handle](auto loop) {
-                auto req = new uv_fs_t();
-                uv_fs_close(loop, req, handle, [](uv_fs_t *req) {
-                    uv_fs_req_cleanup(req);
-                    delete req;
-                });
+            request([handle = m_handle, pendingCloseInfo = m_pendingCloseInfo](auto loop) {
+                closeUVHandle(handle, loop, pendingCloseInfo);
             });
             m_handle = -1;
         }
@@ -473,18 +480,26 @@ ssize_t PCSX::UvFile::write(const void *src, size_t size) {
         uv_buf_t buf;
         uv_fs_t req;
         Slice slice;
+        uv_file handle;
+        PendingCloseInfo *pendingCloseInfo;
     };
     auto info = new Info();
     info->req.data = info;
     info->slice.copy(src, size);
     info->buf.base = reinterpret_cast<decltype(info->buf.base)>(const_cast<void *>(info->slice.data()));
     info->buf.len = size;
-    request([info, handle = m_handle, offset = m_ptrW](auto loop) {
-        uv_fs_write(loop, &info->req, handle, &info->buf, 1, offset, [](uv_fs_t *req) {
+    info->handle = m_handle;
+    info->pendingCloseInfo = m_pendingCloseInfo;
+    request([info, offset = m_ptrW](auto loop) {
+        info->pendingCloseInfo->pendingWrites++;
+        uv_fs_write(loop, &info->req, info->handle, &info->buf, 1, offset, [](uv_fs_t *req) {
             ssize_t ret = req->result;
             if (ret >= 0) s_dataWrittenTotal += ret;
             auto info = reinterpret_cast<Info *>(req->data);
             uv_fs_req_cleanup(req);
+            if ((--info->pendingCloseInfo->pendingWrites == 0) && info->pendingCloseInfo->closePending) {
+                closeUVHandle(info->handle, req->loop, info->pendingCloseInfo);
+            }
             delete info;
         });
     });
@@ -510,19 +525,27 @@ void PCSX::UvFile::write(Slice &&slice) {
         uv_buf_t buf;
         uv_fs_t req;
         Slice slice;
+        uv_file handle;
+        PendingCloseInfo *pendingCloseInfo;
     };
     auto size = slice.size();
     auto info = new Info();
     info->req.data = info;
     info->buf.len = size;
     info->slice = std::move(slice);
-    request([info, handle = m_handle, offset = m_ptrW](auto loop) {
+    info->handle = m_handle;
+    info->pendingCloseInfo = m_pendingCloseInfo;
+    request([info, offset = m_ptrW](auto loop) {
         info->buf.base = reinterpret_cast<decltype(info->buf.base)>(const_cast<void *>(info->slice.data()));
-        uv_fs_write(loop, &info->req, handle, &info->buf, 1, offset, [](uv_fs_t *req) {
+        info->pendingCloseInfo->pendingWrites++;
+        uv_fs_write(loop, &info->req, info->handle, &info->buf, 1, offset, [](uv_fs_t *req) {
             ssize_t ret = req->result;
             if (ret >= 0) s_dataWrittenTotal += ret;
             auto info = reinterpret_cast<Info *>(req->data);
             uv_fs_req_cleanup(req);
+            if ((--info->pendingCloseInfo->pendingWrites == 0) && info->pendingCloseInfo->closePending) {
+                closeUVHandle(info->handle, req->loop, info->pendingCloseInfo);
+            }
             delete info;
         });
     });
@@ -544,12 +567,8 @@ ssize_t PCSX::UvFile::readAt(void *dest, size_t size, size_t ptr) {
 
     if (progress == 1.0f) {
         if ((m_handle >= 0) && !writable()) {
-            request([handle = m_handle](auto loop) {
-                auto req = new uv_fs_t();
-                uv_fs_close(loop, req, handle, [](uv_fs_t *req) {
-                    uv_fs_req_cleanup(req);
-                    delete req;
-                });
+            request([handle = m_handle, pendingCloseInfo = m_pendingCloseInfo](auto loop) {
+                closeUVHandle(handle, loop, pendingCloseInfo);
             });
             m_handle = -1;
         }
@@ -603,18 +622,26 @@ ssize_t PCSX::UvFile::writeAt(const void *src, size_t size, size_t ptr) {
         uv_buf_t buf;
         uv_fs_t req;
         Slice slice;
+        uv_file handle;
+        PendingCloseInfo *pendingCloseInfo;
     };
     auto info = new Info();
     info->req.data = info;
     info->slice.copy(src, size);
     info->buf.base = reinterpret_cast<decltype(info->buf.base)>(const_cast<void *>(info->slice.data()));
     info->buf.len = size;
-    request([info, handle = m_handle, offset = ptr](auto loop) {
-        uv_fs_write(loop, &info->req, handle, &info->buf, 1, offset, [](uv_fs_t *req) {
+    info->handle = m_handle;
+    info->pendingCloseInfo = m_pendingCloseInfo;
+    request([info, offset = ptr](auto loop) {
+        info->pendingCloseInfo->pendingWrites++;
+        uv_fs_write(loop, &info->req, info->handle, &info->buf, 1, offset, [](uv_fs_t *req) {
             ssize_t ret = req->result;
             if (ret >= 0) s_dataWrittenTotal += ret;
             auto info = reinterpret_cast<Info *>(req->data);
             uv_fs_req_cleanup(req);
+            if ((--info->pendingCloseInfo->pendingWrites == 0) && info->pendingCloseInfo->closePending) {
+                closeUVHandle(info->handle, req->loop, info->pendingCloseInfo);
+            }
             delete info;
         });
     });
@@ -639,19 +666,27 @@ void PCSX::UvFile::writeAt(Slice &&slice, size_t ptr) {
         uv_buf_t buf;
         uv_fs_t req;
         Slice slice;
+        uv_file handle;
+        PendingCloseInfo *pendingCloseInfo;
     };
     auto size = slice.size();
     auto info = new Info();
     info->req.data = info;
     info->buf.len = size;
     info->slice = std::move(slice);
-    request([info, handle = m_handle, offset = ptr](auto loop) {
+    info->handle = m_handle;
+    info->pendingCloseInfo = m_pendingCloseInfo;
+    request([info, offset = ptr](auto loop) {
         info->buf.base = reinterpret_cast<decltype(info->buf.base)>(const_cast<void *>(info->slice.data()));
-        uv_fs_write(loop, &info->req, handle, &info->buf, 1, offset, [](uv_fs_t *req) {
+        info->pendingCloseInfo->pendingWrites++;
+        uv_fs_write(loop, &info->req, info->handle, &info->buf, 1, offset, [](uv_fs_t *req) {
             ssize_t ret = req->result;
             if (ret >= 0) s_dataWrittenTotal += ret;
             auto info = reinterpret_cast<Info *>(req->data);
             uv_fs_req_cleanup(req);
+            if ((--info->pendingCloseInfo->pendingWrites == 0) && info->pendingCloseInfo->closePending) {
+                closeUVHandle(info->handle, req->loop, info->pendingCloseInfo);
+            }
             delete info;
         });
     });

--- a/src/support/uvfile.h
+++ b/src/support/uvfile.h
@@ -213,6 +213,12 @@ class UvFile : public File, public UvThreadOp {
     uv_buf_t m_cacheBuf;
     uv_fs_t m_cacheReq;
     size_t m_cachePtr = 0;
+    struct PendingCloseInfo {
+        unsigned pendingWrites = 0;
+        bool closePending = false;
+    };
+    static void closeUVHandle(uv_file handle, uv_loop_s* loop, PendingCloseInfo* pendingCloseInfo);
+    PendingCloseInfo* m_pendingCloseInfo = new PendingCloseInfo();
 };
 
 class UvFifo : public File, public UvThreadOp {


### PR DESCRIPTION
Calling uv_fs_close doesn't actually flush pending writes, so we need to track them ourselves.