### PR TITLE
Round two of fixes.

### DIFF
--- a/src/lua/fileffi.lua
+++ b/src/lua/fileffi.lua
@@ -29,7 +29,7 @@ local sliceMeta = {
         elseif index == 'data' then
             return C.getSliceData(slice._wrapper)
         elseif index == 'size' then
-            return C.getSliceSize(slice._wrapper)
+            return tonumber(C.getSliceSize(slice._wrapper))
         end
         error('Unknown index `' .. index .. '` for LuaSlice')
     end,
@@ -224,7 +224,7 @@ local function createFileWrapper(wrapper)
         rTell = function(self) return C.rTell(self._wrapper) end,
         wSeek = wSeek,
         wTell = function(self) return C.wTell(self._wrapper) end,
-        size = function(self) return C.getFileSize(self._wrapper) end,
+        size = function(self) return tonumber(C.getFileSize(self._wrapper)) end,
         seekable = function(self) return C.isFileSeekable(self._wrapper) end,
         writable = function(self) return C.isFileWritable(self._wrapper) end,
         eof = function(self) return C.isFileEOF(self._wrapper) end,

--- a/src/support/uvfile.cc
+++ b/src/support/uvfile.cc
@@ -504,6 +504,9 @@ ssize_t PCSX::UvFile::write(const void *src, size_t size) {
         });
     });
     m_ptrW += size;
+    if (m_ptrW >= m_size) {
+        m_size = m_ptrW;
+    }
     return size;
 }
 
@@ -550,6 +553,9 @@ void PCSX::UvFile::write(Slice &&slice) {
         });
     });
     m_ptrW += size;
+    if (m_ptrW >= m_size) {
+        m_size = m_ptrW;
+    }
 }
 
 ssize_t PCSX::UvFile::readAt(void *dest, size_t size, size_t ptr) {

--- a/src/supportpsx/binffi.lua
+++ b/src/supportpsx/binffi.lua
@@ -118,7 +118,7 @@ PCSX.Binary.createExe = function(src, dest, addr, pc, gp, sp)
         error('Expected a number as sixth argument')
     end
 
-    local size = src.size()
+    local size = src:size()
     size = bit.band(size + 0x7ff, bit.bnot(0x7ff))
 
     dest:writeU32(0x582d5350)
@@ -134,11 +134,11 @@ PCSX.Binary.createExe = function(src, dest, addr, pc, gp, sp)
     dest:writeU32(0)
     dest:writeU32(0)
     dest:writeU32(sp)
-    while dest.size() < 0x800 do
-        dest:writeU32(0)
+    while dest:size() < 0x800 do
+        dest:writeU8(0)
     end
     dest:write(src:read(src:size()))
-    while dest.size() < 0x800 do
+    while bit.band(dest:size(), 0x7ff) ~= 0 do
         dest:writeU8(0)
     end
 end


### PR DESCRIPTION
- PCSX.Binary.createExe now properly uses :size methods.
- UvFile sizes now properly updating on writes.
- Lua :size methods now returns Lua numbers instead of FFI numbers.