### PR TITLE
Invalidate cache when assembling instructions

### DIFF
--- a/src/gui/widgets/assembly.cc
+++ b/src/gui/widgets/assembly.cc
@@ -930,6 +930,8 @@ if not success then return msg else return nil end
                 m_assembleStatus = L.tostring();
             }
             L.pop();
+            // Invalidate iCache when assembling to ensure cached instructions are not executed
+            g_emulator->m_cpu->invalidateCache();
         }
         ImGui::SameLine();
         if (ImGui::Button(_("Clear"))) m_assembleCode.clear();


### PR DESCRIPTION
The assembler in the debugger needs to invalidate icache when assembling to ensure the newly assembled instruction is executed rather than the original instructions in icache. 