### PR TITLE
Adding two missing memory card fuctions to openbios.

### DIFF
--- a/src/mips/openbios/kernel/handlers.c
+++ b/src/mips/openbios/kernel/handlers.c
@@ -242,7 +242,7 @@ void *B0table[0x60] = {
     mcAllowNewCard, Krom2RawAdd, unimplementedThunk, Krom2Offset, // 50
     unimplementedThunk, unimplementedThunk, getC0table, getB0table, // 54
     mcGetLastDevice, unimplementedThunk, unimplementedThunk, setSIO0AutoAck, // 58
-    unimplementedThunk, unimplementedThunk, unimplementedThunk, unimplementedThunk, // 5c
+    getCardStatus, waitCardStatus, unimplementedThunk, unimplementedThunk, // 5c
 };
 
 void *C0table[0x20] = {

--- a/src/mips/openbios/sio0/card.c
+++ b/src/mips/openbios/sio0/card.c
@@ -361,3 +361,14 @@ int __attribute__((section(".ramtext"))) mcInfoHandler() {
     }
     return 0;
 }
+
+uint8_t __attribute__((section(".ramtext"))) getCardStatus(int port) {
+    return g_mcFlags[port];
+}
+
+uint8_t __attribute__((section(".ramtext"))) waitCardStatus(int port) {
+    while ((g_mcFlags[port] & 1) == 0) {
+        atomic_signal_fence(memory_order_consume);
+    }
+    return g_mcFlags[port];
+}

--- a/src/mips/openbios/sio0/card.h
+++ b/src/mips/openbios/sio0/card.h
@@ -31,6 +31,8 @@ SOFTWARE.
 int initCard(int padStarted);
 int startCard();
 int stopCard();
+uint8_t getCardStatus(int port);
+uint8_t waitCardStatus(int port);
 
 void mcResetStatus();
 int mcWaitForStatus();


### PR DESCRIPTION
- getCardStatus (B0:5C)
- waitCardStatus (B0:5D)

Hopefully should fix a few games, including FF8 and Zero Divide.