### PR TITLE
More input leniency in Typed Debugger import

### DIFF
--- a/src/gui/widgets/typed_debugger.cc
+++ b/src/gui/widgets/typed_debugger.cc
@@ -77,7 +77,12 @@ void PCSX::Widgets::TypedDebugger::import(std::string_view fileContents, ImportT
             }
 
             FieldOrArgumentData data;
-            const std::regex dataRegex(R"(([\w\s\*\[\]]+),(\w+),(\d+))");
+            // Allow the data type and field name to be just about anything, as
+            // long as it's between commas. While usually C/C++/whatever
+            // identifiers have some rules, in Ghidra you can really just set
+            // just about any label you want so be as generous as possible when
+            // accepting input.
+            const std::regex dataRegex(R"(([^,]+),([^,]+),(\d+))");
             std::smatch matches;
             if (std::regex_match(s, matches, dataRegex)) {
                 data.type = matches[1].str();


### PR DESCRIPTION
I have some fields and data types with question marks in them. Seems originally we were originally only accepting alphanumerics and underscores but I think Ghidra is very loose with what it allows. With this patch, all my field names and type names are loading in fine.

See the screenshot: the third field name was not rendered before this patch and it even caused the whole data type size to be off I think because it wouldn't count these non-conforming fields into the total size.

![after](https://user-images.githubusercontent.com/893115/234181375-44efc76b-b41c-4c8e-9e50-8aced7f98354.png)
