### PR TITLE
Typed Debugger: jump button for expandable ptrs

### DIFF
--- a/src/gui/widgets/typed_debugger.cc
+++ b/src/gui/widgets/typed_debugger.cc
@@ -403,6 +403,12 @@ void PCSX::Widgets::TypedDebugger::displayNode(WatchTreeNode* node, const uint32
         ImGui::TableNextColumn();  // Value.
         if (isPointer) {
             ImGui::Text("0x%x", startAddress);
+            ImGui::SameLine();
+            const auto showMemButtonName = fmt::format(f_("Show in memory editor##{}{}"), currentAddress, extraImGuiId);
+            if (ImGui::Button(showMemButtonName.c_str())) {
+                const uint32_t editorAddress = startAddress - memBase;
+                g_system->m_eventBus->signal(PCSX::Events::GUI::JumpToMemory{editorAddress, 4});
+            }
         } else {
             ImGui::TextDisabled("--");
         }


### PR DESCRIPTION
For pointers that were roots of nodes, we would not offer a button to go to them. This is useful to have however, so let's add it.

Indeed, it'd be nice to be able to go to any address that we're rendering, but that's for a potential future refactor...

Before:

![xxx](https://user-images.githubusercontent.com/893115/234184388-2e909d6d-e80c-4858-a701-76f4be12ab31.png)

After:

![yyy](https://user-images.githubusercontent.com/893115/234184412-5913195b-76a3-40a9-b3fe-e8ea31f2a99f.png)
