### PR TITLE
Allow memory view jumping to `0x807.....` range

### DIFF
--- a/src/gui/gui.cc
+++ b/src/gui/gui.cc
@@ -611,7 +611,7 @@ void PCSX::GUI::init() {
     m_outputShaderEditor.init();
 
     m_listener.listen<Events::GUI::JumpToMemory>([this](auto& event) {
-        const uint32_t base = (event.address >> 20) & 0xffc;
+        const uint32_t base = (event.address >> 20) & 0xff8;
         const uint32_t real = event.address & 0x7fffff;
         const uint32_t size = event.size;
         auto changeDataType = [](MemoryEditor* editor, int size) {


### PR DESCRIPTION
Stack values are usually in the `0x807.....` range but the mask checking the base address in the code would not cover it. I've modified the mask to ensure these addresses pass the check condition but anything above that (say `0x80800000`) does not. See below for before and after.

I'm unsure how original value was picked...

Also I guess this code (old and new) doesn't work in case 8MiB expansion pack thing is turned on? Though maybe that's unrelated, I'm not sure.

```
>>> hex(0x807fffff >> 20 & 0xffc)
'0x804'
>>> hex(0x80800000 >> 20 & 0xffc)
'0x808'
>>> hex(0x807fffff >> 20 & 0xff8)
'0x800'
>>> hex(0x80800000 >> 20 & 0xff8)
'0x808'
```