### PR TITLE
fix format security warnings

### DIFF
--- a/src/gpu/soft/gpu.cc
+++ b/src/gpu/soft/gpu.cc
@@ -944,7 +944,7 @@ bool PCSX::SoftGPU::impl::configure() {
 
 void PCSX::SoftGPU::impl::debug() {
     if (ImGui::Begin(_("Soft GPU debugger"), &m_showDebug)) {
-        ImGui::Text(
+        ImGui::TextUnformatted(
             _("Debugging features are not supported when using the software renderer yet\nConsider enabling the "
               "OpenGL "
               "GPU option instead."));

--- a/src/gui/gui.cc
+++ b/src/gui/gui.cc
@@ -155,7 +155,9 @@ static void drop_callback(GLFWwindow* window, int count, const char** paths) {
 
 static void ShowHelpMarker(const char* desc) {
     ImGui::SameLine();
-    ImGui::TextDisabled("(?)");
+    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyle().Colors[ImGuiCol_TextDisabled]);
+    ImGui::TextUnformatted("(?)");
+    ImGui::PopStyleColor();
     if (ImGui::IsItemHovered()) {
         ImGui::BeginTooltip();
         ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
@@ -1192,7 +1194,7 @@ in Configuration->Emulation, restart PCSX-Redux, then try again.)"));
                 uint32_t frameCount = g_emulator->m_spu->getFrameCount();
                 ImGui::Text(_("%.2f ms audio buffer (%i frames)"), 1000.0f * frameCount / 44100.0f, frameCount);
             } else {
-                ImGui::Text(_("Idle"));
+                ImGui::TextUnformatted(_("Idle"));
             }
 
             ImGui::EndMainMenuBar();
@@ -1971,7 +1973,7 @@ bool PCSX::GUI::about() {
     ImGui::SetNextWindowPos(ImVec2(200, 100), ImGuiCond_FirstUseEver);
     ImGui::SetNextWindowSize(ImVec2(880, 600), ImGuiCond_FirstUseEver);
     if (ImGui::Begin(_("About"), &m_showAbout)) {
-        ImGui::Text("PCSX-Redux");
+        ImGui::TextUnformatted("PCSX-Redux");
         ImGui::Separator();
         auto someString = [](const char* str, GLenum index) {
             const char* value = (const char*)glGetString(index);

--- a/src/gui/widgets/assembly.cc
+++ b/src/gui/widgets/assembly.cc
@@ -113,7 +113,7 @@ void PCSX::Widgets::Assembly::sameLine() { ImGui::SameLine(0.0f, 0.0f); }
 void PCSX::Widgets::Assembly::comma() {
     if (m_gotArg) {
         sameLine();
-        ImGui::Text(",");
+        ImGui::TextUnformatted(",");
     }
     m_gotArg = true;
 }
@@ -121,7 +121,7 @@ void PCSX::Widgets::Assembly::Invalid() {
     m_gotArg = false;
     sameLine();
     ImGui::PushStyleColor(ImGuiCol_Text, s_invalidColor);
-    ImGui::Text("(**invalid**)");
+    ImGui::TextUnformatted("(**invalid**)");
     ImGui::PopStyleColor();
 }
 
@@ -129,7 +129,9 @@ void PCSX::Widgets::Assembly::OpCode(const char* str) {
     m_gotArg = false;
     sameLine();
     if (m_notch || m_notchAfterSkip[0]) {
-        ImGui::TextDisabled("~ ");
+        ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyle().Colors[ImGuiCol_TextDisabled]);
+        ImGui::TextUnformatted("~ ");
+        ImGui::PopStyleColor();
         sameLine();
         ImGui::Text("%-6s", str);
     } else {
@@ -139,7 +141,7 @@ void PCSX::Widgets::Assembly::OpCode(const char* str) {
 void PCSX::Widgets::Assembly::GPR(uint8_t reg) {
     comma();
     sameLine();
-    ImGui::Text(" $");
+    ImGui::TextUnformatted(" $");
     sameLine();
     ImGui::TextUnformatted(s_disRNameGPR[reg]);
     if (ImGui::IsItemHovered()) {
@@ -153,7 +155,7 @@ void PCSX::Widgets::Assembly::GPR(uint8_t reg) {
 void PCSX::Widgets::Assembly::CP0(uint8_t reg) {
     comma();
     sameLine();
-    ImGui::Text(" $");
+    ImGui::TextUnformatted(" $");
     sameLine();
     ImGui::TextUnformatted(s_disRNameCP0[reg]);
     if (ImGui::IsItemHovered()) {
@@ -167,7 +169,7 @@ void PCSX::Widgets::Assembly::CP0(uint8_t reg) {
 void PCSX::Widgets::Assembly::CP2C(uint8_t reg) {
     comma();
     sameLine();
-    ImGui::Text(" $");
+    ImGui::TextUnformatted(" $");
     sameLine();
     ImGui::TextUnformatted(s_disRNameCP2C[reg]);
     if (ImGui::IsItemHovered()) {
@@ -181,7 +183,7 @@ void PCSX::Widgets::Assembly::CP2C(uint8_t reg) {
 void PCSX::Widgets::Assembly::CP2D(uint8_t reg) {
     comma();
     sameLine();
-    ImGui::Text(" $");
+    ImGui::TextUnformatted(" $");
     sameLine();
     ImGui::TextUnformatted(s_disRNameCP2D[reg]);
     if (ImGui::IsItemHovered()) {
@@ -195,7 +197,7 @@ void PCSX::Widgets::Assembly::CP2D(uint8_t reg) {
 void PCSX::Widgets::Assembly::HI() {
     comma();
     sameLine();
-    ImGui::Text(" $hi");
+    ImGui::TextUnformatted(" $hi");
     if (ImGui::IsItemHovered()) {
         ImGui::BeginTooltip();
         ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
@@ -207,7 +209,7 @@ void PCSX::Widgets::Assembly::HI() {
 void PCSX::Widgets::Assembly::LO() {
     comma();
     sameLine();
-    ImGui::Text(" $lo");
+    ImGui::TextUnformatted(" $lo");
     if (ImGui::IsItemHovered()) {
         ImGui::BeginTooltip();
         ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
@@ -721,7 +723,9 @@ settings, otherwise debugging features may not work.)");
                 }
                 if (skipNext && m_pseudoFilling) {
                     ImGui::SameLine(0.0f, 0.0f);
-                    ImGui::TextDisabled(" (pseudo)");
+                    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyle().Colors[ImGuiCol_TextDisabled]);
+                    ImGui::TextUnformatted(" (pseudo)");
+                    ImGui::PopStyleColor();
                 }
             };
             m_notchAfterSkip[0] = m_notchAfterSkip[1];

--- a/src/gui/widgets/breakpoints.cc
+++ b/src/gui/widgets/breakpoints.cc
@@ -24,7 +24,9 @@
 
 static void ShowHelpMarker(const char* desc) {
     ImGui::SameLine();
-    ImGui::TextDisabled("(?)");
+    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyle().Colors[ImGuiCol_TextDisabled]);
+    ImGui::TextUnformatted("(?)");
+    ImGui::PopStyleColor();
     if (ImGui::IsItemHovered()) {
         ImGui::BeginTooltip();
         ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);

--- a/src/gui/widgets/callstacks.cc
+++ b/src/gui/widgets/callstacks.cc
@@ -78,7 +78,9 @@ void PCSX::Widgets::CallStacks::draw(const char* title, PCSX::GUI* gui) {
             ImGui::SameLine();
             ImGui::TextUnformatted(" :: ");
             ImGui::SameLine();
-            ImGui::TextDisabled("<heuristic>");
+            ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyle().Colors[ImGuiCol_TextDisabled]);
+            ImGui::TextUnformatted("<heuristic>");
+            ImGui::PopStyleColor();
             ImGui::SameLine();
             ImGui::TextUnformatted(" :: ");
             ImGui::SameLine();

--- a/src/gui/widgets/dynarec_disassembly.cc
+++ b/src/gui/widgets/dynarec_disassembly.cc
@@ -69,7 +69,7 @@ void PCSX::Widgets::Disassembly::draw(GUI* gui, const char* title) {
     if (m_showError) {
         ImGui::OpenPopup(_("Disassembler Error"));
         if (ImGui::BeginPopupModal(_("Disassembler Error"), NULL, ImGuiWindowFlags_AlwaysAutoResize)) {
-            ImGui::Text(_("Disassembly Failed.\nCheck Logs"));
+            ImGui::TextUnformatted(_("Disassembly Failed.\nCheck Logs"));
             if (ImGui::Button(_("Close"))) {
                 ImGui::CloseCurrentPopup();
                 m_showError = false;

--- a/src/gui/widgets/handlers.cc
+++ b/src/gui/widgets/handlers.cc
@@ -37,7 +37,7 @@ void PCSX::Widgets::Handlers::draw(const uint32_t* psxMemory, const char* title)
     const unsigned count = memFile->readAt<uint32_t>(0x104) / 8;
 
     if (!arrayPointer) {
-        ImGui::Text(_("Invalid data at 0x100"));
+        ImGui::TextUnformatted(_("Invalid data at 0x100"));
         ImGui::End();
         return;
     }
@@ -55,7 +55,7 @@ void PCSX::Widgets::Handlers::draw(const uint32_t* psxMemory, const char* title)
         while (infoAddr) {
             uint32_t infoStructAddr = memFile->readAt<uint32_t>(infoAddr);
             if (!infoStructAddr) {
-                ImGui::Text(_("  Corrupted info"));
+                ImGui::TextUnformatted(_("  Corrupted info"));
                 break;
             }
             std::string buttonStr;
@@ -65,14 +65,14 @@ void PCSX::Widgets::Handlers::draw(const uint32_t* psxMemory, const char* title)
             if (ImGui::Button(buttonStr.c_str())) {
                 g_system->m_eventBus->signal(Events::GUI::JumpToMemory{infoAddr, 16});
             }
-            ImGui::Text(_("  verifier: "));
+            ImGui::TextUnformatted(_("  verifier: "));
             ImGui::SameLine();
             uint32_t verifierAddr = memFile->readAt<uint32_t>(infoStructAddr + 8);
             buttonStr = fmt::format("{:08x}##{}", verifierAddr, counter++);
             if (ImGui::Button(buttonStr.c_str())) {
                 g_system->m_eventBus->signal(Events::GUI::JumpToPC{verifierAddr});
             }
-            ImGui::Text(_("  handler: "));
+            ImGui::TextUnformatted(_("  handler: "));
             ImGui::SameLine();
             uint32_t handlerAddr = memFile->readAt<uint32_t>(infoStructAddr + 4);
             buttonStr = fmt::format("{:08x}##{}", handlerAddr, counter++);

--- a/src/gui/widgets/isobrowser.cc
+++ b/src/gui/widgets/isobrowser.cc
@@ -30,7 +30,9 @@
 
 static void ShowHelpMarker(const char* desc) {
     ImGui::SameLine();
-    ImGui::TextDisabled("(?)");
+    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyle().Colors[ImGuiCol_TextDisabled]);
+    ImGui::TextUnformatted("(?)");
+    ImGui::PopStyleColor();
     if (ImGui::IsItemHovered()) {
         ImGui::BeginTooltip();
         ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
@@ -104,7 +106,9 @@ void PCSX::Widgets::IsoBrowser::draw(CDRom* cdrom, const char* title) {
     auto iso = cdrom->m_iso.get();
 
     if (iso->failed()) {
-        ImGui::TextWrapped(_("No iso or invalid iso loaded."));
+        ImGui::PushTextWrapPos(0.0f);
+        ImGui::TextUnformatted(_("No iso or invalid iso loaded."));
+        ImGui::PopTextWrapPos();
         ImGui::End();
         return;
     }

--- a/src/gui/widgets/log.cc
+++ b/src/gui/widgets/log.cc
@@ -133,7 +133,7 @@ bool PCSX::Widgets::Log::draw(GUI* gui, const char* title) {
     // filter.Draw by default puts the label to the right side of the input box.
     // To rememdy this, and keep the ImGui ID stack happy, we just do ## for the filter ID
     // and draw our own text for the description of the input box
-    ImGui::Text("Search");
+    ImGui::TextUnformatted("Search");
     ImGui::SameLine();
     filter.Draw("##FilterBox", -100.0f);
 

--- a/src/gui/widgets/memcard_manager.cc
+++ b/src/gui/widgets/memcard_manager.cc
@@ -164,10 +164,14 @@ bool PCSX::Widgets::MemcardManager::draw(GUI* gui, const char* title) {
 
                 ImGui::TableSetColumnIndex(2);
                 if (block.isChained()) {
-                    ImGui::TextDisabled(_("Chained block"));
+                    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyle().Colors[ImGuiCol_TextDisabled]);
+                    ImGui::TextUnformatted(_("Chained block"));
+                    ImGui::PopStyleColor();
                     continue;
                 } else if (block.isErased()) {
-                    ImGui::TextDisabled(_("Free block"));
+                    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyle().Colors[ImGuiCol_TextDisabled]);
+                    ImGui::TextUnformatted(_("Free block"));
+                    ImGui::PopStyleColor();
                     continue;
                 } else {
                     if (gui->hasJapanese()) {
@@ -385,7 +389,9 @@ void PCSX::Widgets::MemcardManager::saveUndoBuffer(std::unique_ptr<uint8_t[]>&& 
 
 void PCSX::Widgets::MemcardManager::ShowHelpMarker(const char* desc) {
     ImGui::SameLine();
-    ImGui::TextDisabled("(?)");
+    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyle().Colors[ImGuiCol_TextDisabled]);
+    ImGui::TextUnformatted("(?)");
+    ImGui::PopStyleColor();
     if (ImGui::IsItemHovered()) {
         ImGui::BeginTooltip();
         ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);

--- a/src/gui/widgets/pio-cart.cc
+++ b/src/gui/widgets/pio-cart.cc
@@ -44,13 +44,13 @@ bool PCSX::Widgets::PIOCart::draw(const char* title) {
             changed = true;
         }
 
-        ImGui::Text(_("On/Off Switch:"));
+        ImGui::TextUnformatted(_("On/Off Switch:"));
         ImGui::SameLine();
         if (ImGui::Checkbox("##ToggleSwitch", &m_switchOn)) {
             g_emulator->m_pioCart->setSwitch(m_switchOn);
         }
         ImGui::SameLine();
-        ImGui::Text(m_switchOn ? _("On") : _("Off"));
+        ImGui::TextUnformatted(m_switchOn ? _("On") : _("Off"));
 
         if (ImGui::Checkbox(_("Connected"), &settings.get<Emulator::SettingPIOConnected>().value)) {
             g_emulator->m_pioCart->setLuts();

--- a/src/gui/widgets/sio1.cc
+++ b/src/gui/widgets/sio1.cc
@@ -114,7 +114,9 @@ static constexpr ImGuiTableFlags tableFlags = ImGuiTableFlags_SizingFixedFit | I
 
 void ShowHelpMarker(const char* desc) {
     ImGui::SameLine();
-    ImGui::TextDisabled("(?)");
+    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyle().Colors[ImGuiCol_TextDisabled]);
+    ImGui::TextUnformatted("(?)");
+    ImGui::PopStyleColor();
     if (ImGui::IsItemHovered()) {
         ImGui::BeginTooltip();
         ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);

--- a/src/gui/widgets/typed_debugger.cc
+++ b/src/gui/widgets/typed_debugger.cc
@@ -308,15 +308,17 @@ void PCSX::Widgets::TypedDebugger::displayBreakpointOptions(WatchTreeNode* node,
         ImGui::TableNextColumn();  // Name.
         bool open = ImGui::TreeNodeEx(fmt::format(f_("Display log entries##{}{}"), node->name.c_str(), address).c_str(),
                                       ImGuiTreeNodeFlags_SpanFullWidth);
+        ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyle().Colors[ImGuiCol_TextDisabled]);
         ImGui::TableNextColumn();  // Type.
-        ImGui::TextDisabled("--");
+        ImGui::TextUnformatted("--");
         ImGui::TableNextColumn();  // Size.
-        ImGui::TextDisabled("--");
+        ImGui::TextUnformatted("--");
         ImGui::TableNextColumn();  // Value.
-        ImGui::TextDisabled("--");
+        ImGui::TextUnformatted("--");
         ImGui::TableNextColumn();  // New value.
-        ImGui::TextDisabled("--");
+        ImGui::TextUnformatted("--");
         ImGui::TableNextColumn();  // Breakpoints.
+        ImGui::PopStyleColor();
         if (open) {
             uint32_t accumulatedOffset = 0;
             for (const auto& logEntry : node->logEntries) {
@@ -347,7 +349,9 @@ void PCSX::Widgets::TypedDebugger::displayBreakpointOptions(WatchTreeNode* node,
                     }
                 }
                 ImGui::TableNextColumn();  // New value.
-                ImGui::TextDisabled("--");
+                ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyle().Colors[ImGuiCol_TextDisabled]);
+                ImGui::TextUnformatted("--");
+                ImGui::PopStyleColor();
                 ImGui::TableNextColumn();  // Breakpoints.
             }
             ImGui::TreePop();
@@ -415,10 +419,14 @@ void PCSX::Widgets::TypedDebugger::displayNode(WatchTreeNode* node, const uint32
                 g_system->m_eventBus->signal(PCSX::Events::GUI::JumpToMemory{editorAddress, 4});
             }
         } else {
-            ImGui::TextDisabled("--");
+            ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyle().Colors[ImGuiCol_TextDisabled]);
+            ImGui::TextUnformatted("--");
+            ImGui::PopStyleColor();
         }
         ImGui::TableNextColumn();  // New value.
-        ImGui::TextDisabled("--");
+        ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyle().Colors[ImGuiCol_TextDisabled]);
+        ImGui::TextUnformatted("--");
+        ImGui::PopStyleColor();
         ImGui::TableNextColumn();  // Breakpoints.
         if (watchView) {
             displayBreakpointOptions(node, currentAddress);
@@ -456,7 +464,9 @@ void PCSX::Widgets::TypedDebugger::displayNode(WatchTreeNode* node, const uint32
                 g_system->m_eventBus->signal(PCSX::Events::GUI::JumpToMemory{editorAddress, 4});
             }
             ImGui::TableNextColumn();  // New value.
-            ImGui::TextDisabled("--");
+            ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyle().Colors[ImGuiCol_TextDisabled]);
+            ImGui::TextUnformatted("--");
+            ImGui::PopStyleColor();
             ImGui::TableNextColumn();  // Breakpoints.
             if (watchView) {
                 displayBreakpointOptions(node, currentAddress);
@@ -483,7 +493,9 @@ void PCSX::Widgets::TypedDebugger::displayNode(WatchTreeNode* node, const uint32
                 }
             }
             ImGui::TableNextColumn();  // New value.
-            ImGui::TextDisabled("--");
+            ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyle().Colors[ImGuiCol_TextDisabled]);
+            ImGui::TextUnformatted("--");
+            ImGui::PopStyleColor();
             ImGui::TableNextColumn();  // Breakpoints.
             if (watchView) {
                 displayBreakpointOptions(node, currentAddress);
@@ -510,7 +522,9 @@ void PCSX::Widgets::TypedDebugger::displayNode(WatchTreeNode* node, const uint32
         printValue(nodeType, node->size, memValue);
         ImGui::TableNextColumn();  // New value.
         displayNewValueInput(nodeType, node->size, memValue);
-        ImGui::TextDisabled("--");
+        ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyle().Colors[ImGuiCol_TextDisabled]);
+        ImGui::TextUnformatted("--");
+        ImGui::PopStyleColor();
         ImGui::TableNextColumn();  // Breakpoints.
         if (watchView) {
             displayBreakpointOptions(node, currentAddress);
@@ -633,11 +647,13 @@ void PCSX::Widgets::TypedDebugger::draw(const char* title, GUI* gui) {
 
     bool showImportDataTypesFileDialog = false;
     if (m_structs.empty()) {
-        ImGui::TextWrapped(
+        ImGui::PushTextWrapPos(0.0f);
+        ImGui::TextUnformatted(
             _("Data types can be imported from Ghidra using tools/ghidra_scripts/export_redux.py, which will "
               "generate a redux_data_types.txt file in its folder, or from any text file where each line specifies the "
               "data type's name and fields, separated by semi-colons; fields are specified in type-name-size tuples "
               "whose elements are separated by commas.\n\nFor example:\n"));
+        ImGui::PopTextWrapPos();
         gui->useMonoFont();
         ImGui::TextUnformatted("CdlLOC;u_char,minute,1;u_char,second,1;u_char,sector,1;u_char,track,1;\n\n");
         ImGui::PopFont();
@@ -667,11 +683,13 @@ void PCSX::Widgets::TypedDebugger::draw(const char* title, GUI* gui) {
 
     bool showImportFunctionsFileDialog = false;
     if (m_functions.empty()) {
-        ImGui::TextWrapped(
+        ImGui::PushTextWrapPos(0.0f);
+        ImGui::TextUnformatted(
             _("Functions can be imported from Ghidra using tools/ghidra_scripts/export_redux.py, which will generate "
               "a redux_funcs.txt file in its folder, or from any text file where each line specifies the function "
               "address, name and arguments, separated by semi-colons; arguments are specified in type-name-size tuples "
               "whose elements are separated by commas.\n\nFor example:\n"));
+        ImGui::PopTextWrapPos();
         gui->useMonoFont();
         ImGui::TextUnformatted("800148b8;task_main_800148B8;int,param_1,4;int,param_2,1;\n\n");
         ImGui::PopFont();

--- a/src/spu/cfg.cc
+++ b/src/spu/cfg.cc
@@ -23,7 +23,9 @@
 
 static void ShowHelpMarker(const char *desc) {
     ImGui::SameLine();
-    ImGui::TextDisabled("(?)");
+    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyle().Colors[ImGuiCol_TextDisabled]);
+    ImGui::TextUnformatted("(?)");
+    ImGui::PopStyleColor();
     if (ImGui::IsItemHovered()) {
         ImGui::BeginTooltip();
         ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);

--- a/src/spu/debug.cc
+++ b/src/spu/debug.cc
@@ -101,10 +101,10 @@ void PCSX::SPU::impl::debug() {
 
         ImGui::BeginChild("##debugSPUright", ImVec2(0, 0), true);
         {
-            ImGui::Text(_("ADSR channel info"));
+            ImGui::TextUnformatted(_("ADSR channel info"));
             ImGui::Columns(2);
             {
-                ImGui::Text(_("Attack:\nDecay:\nSustain:\nRelease:"));
+                ImGui::TextUnformatted(_("Attack:\nDecay:\nSustain:\nRelease:"));
                 ImGui::SameLine();
                 ImGui::Text("%i\n%i\n%i\n%i", ADSRX.get<exAttackRate>().value ^ 0x7f,
                             (ADSRX.get<exDecayRate>().value ^ 0x1f) / 4, ADSRX.get<exSustainRate>().value ^ 0x7f,
@@ -112,7 +112,7 @@ void PCSX::SPU::impl::debug() {
             }
             ImGui::NextColumn();
             {
-                ImGui::Text(_("Sustain level:\nSustain inc:\nCurr adsr vol:\nRaw enveloppe"));
+                ImGui::TextUnformatted(_("Sustain level:\nSustain inc:\nCurr adsr vol:\nRaw enveloppe"));
                 ImGui::SameLine();
                 ImGui::Text("%i\n%i\n%i\n%08x", ADSRX.get<exSustainLevel>().value >> 27,
                             ADSRX.get<exSustainIncrease>().value, ADSRX.get<exVolume>().value,
@@ -120,10 +120,10 @@ void PCSX::SPU::impl::debug() {
             }
             ImGui::Columns(1);
             ImGui::Separator();
-            ImGui::Text(_("Generic channel info"));
+            ImGui::TextUnformatted(_("Generic channel info"));
             ImGui::Columns(2);
             {
-                ImGui::Text(
+                ImGui::TextUnformatted(
                     _("On:\nStop:\nNoise:\nFMod:\nReverb:\nRvb active:\nRvb number:\nRvb offset:\nRvb repeat:"));
                 ImGui::SameLine();
                 ImGui::Text("%i\n%i\n%i\n%i\n%i\n%i\n%i\n%i\n%i", ch.data.get<Chan::On>().value,
@@ -134,7 +134,7 @@ void PCSX::SPU::impl::debug() {
             }
             ImGui::NextColumn();
             {
-                ImGui::Text(_("Start pos:\nCurr pos:\nLoop pos:\n\nRight vol:\nLeft vol:\n\nAct freq:\nUsed freq:"));
+                ImGui::TextUnformatted(_("Start pos:\nCurr pos:\nLoop pos:\n\nRight vol:\nLeft vol:\n\nAct freq:\nUsed freq:"));
                 ImGui::SameLine();
                 ImGui::Text("%li\n%li\n%li\n\n%6i  %04x\n%6i  %04x\n\n%i\n%i", ch.pStart - spuMemC, ch.pCurr - spuMemC,
                             ch.pLoop - spuMemC, ch.data.get<Chan::RightVolume>().value,
@@ -145,8 +145,8 @@ void PCSX::SPU::impl::debug() {
             ImGui::Columns(1);
             ImGui::BeginChild("##debugSPUXA", ImVec2(ImGui::GetWindowContentRegionWidth() * 0.5f, 0), true);
             {
-                ImGui::Text("XA");
-                ImGui::Text(_("Freq:\nStereo:\nSamples:\nVolume:\n"));
+                ImGui::TextUnformatted("XA");
+                ImGui::TextUnformatted(_("Freq:\nStereo:\nSamples:\nVolume:\n"));
                 ImGui::SameLine();
                 ImGui::Text("%i\n%i\n%i\n%5i  %5i", xapGlobal ? xapGlobal->freq : 0, xapGlobal ? xapGlobal->stereo : 0,
                             xapGlobal ? xapGlobal->nsamples : 0, iLeftXAVol, iRightXAVol);
@@ -155,8 +155,8 @@ void PCSX::SPU::impl::debug() {
             ImGui::SameLine();
             ImGui::BeginChild("##debugSPUstate", ImVec2(0, 0), true);
             {
-                ImGui::Text(_("Spu states"));
-                ImGui::Text(_("Irq addr:\nCtrl:\nStat:\nSpu mem:"));
+                ImGui::TextUnformatted(_("Spu states"));
+                ImGui::TextUnformatted(_("Irq addr:\nCtrl:\nStat:\nSpu mem:"));
                 ImGui::SameLine();
                 ImGui::Text("%li\n%04x\n%04x\n%i", pSpuIrq ? -1 : pSpuIrq - spuMemC, spuCtrl, spuStat, spuAddr);
             }


### PR DESCRIPTION
While packaging pcsx-redux for nixOS, I stumbled across the same problem as described in https://github.com/grumpycoders/pcsx-redux/issues/1250 and fixed it with this quick patch "to make it work on my machine".

It compiles fine with default settings, but it is possible that I didn't find every instance. Also, I am no C++ developer, have no experience with ImGui and just installed pcsx-redux for the first time, so I couldn't check if everything still  looks as intended.

For `ImGui::TextDisabled` and `ImGui::TextWrapped`, I expanded the "shortcuts" explained in [imgui.h](https://github.com/ocornut/imgui/blob/master/imgui.h#LL491C153-L491C153) to create unformatted equivalents, but there may be a better way to do this, feedback is appreciated :)