### PR TITLE
Change in VRAM Viewer shader.

### DIFF
--- a/src/gui/widgets/vram-viewer.cc
+++ b/src/gui/widgets/vram-viewer.cc
@@ -77,7 +77,6 @@ uniform sampler2D u_writtenHighlight;
 
 in vec2 fragUV;
 out vec4 outColor;
-in vec4 gl_FragCoord;
 
 const float ridge = 1.5f;
 


### PR DESCRIPTION
Removed line in vec4 gl_FragCoord; in vram-viewer.cc to prevent incorrect rendering of the VRAM Viewer window in 
AMD GPUs which required a different version of GL to be defined. This change eliminates that workaround.