### PR TITLE
Removing shader version heuristic.

### DIFF
--- a/src/gui/gui.cc
+++ b/src/gui/gui.cc
@@ -520,10 +520,7 @@ void PCSX::GUI::init() {
         s_gui->changeScale(viewport->DpiScale);
     };
     glfwSetKeyCallback(m_window, glfwKeyCallbackTrampoline);
-    // Some bad GPU drivers (*cough* Intel) don't like mixed shaders versions,
-    // and will silently fail to execute them.
-    // This is just a bad heuristic to try and keep it the same version.
-    ImGui_ImplOpenGL3_Init(m_hasCoreProfile ? GL_SHADER_VERSION : nullptr);
+    ImGui_ImplOpenGL3_Init(nullptr);
 
     if (glDebugMessageCallback &&
         (g_emulator->settings.get<Emulator::SettingGLErrorReporting>() || m_args.get<bool>("testmode", false))) {


### PR DESCRIPTION
It looks like ImGui's OpenGL renderer changed enough so that mixed shader version isn't an issue anymore.