### PR TITLE
Fix OpenGL shader issues on Mac and older Intel machines 

### DIFF
--- a/src/gui/gui.cc
+++ b/src/gui/gui.cc
@@ -520,7 +520,7 @@ void PCSX::GUI::init() {
         s_gui->changeScale(viewport->DpiScale);
     };
     glfwSetKeyCallback(m_window, glfwKeyCallbackTrampoline);
-    ImGui_ImplOpenGL3_Init(nullptr);
+    ImGui_ImplOpenGL3_Init(IMGUI_SHADER_VERSION);
 
     if (glDebugMessageCallback &&
         (g_emulator->settings.get<Emulator::SettingGLErrorReporting>() || m_args.get<bool>("testmode", false))) {

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -63,10 +63,12 @@
 #include "widgets/memory_observer.h"
 #include "widgets/typed_debugger.h"
 
-#if defined(__APPLE__)
+#ifdef __APPLE__
 #define GL_SHADER_VERSION "#version 410\n"
+#define IMGUI_SHADER_VERSION "#version 410"
 #else
 #define GL_SHADER_VERSION "#version 300 es\n"
+#define IMGUI_SHADER_VERSION nullptr
 #endif
 
 struct GLFWwindow;

--- a/src/gui/widgets/shader-editor.cc
+++ b/src/gui/widgets/shader-editor.cc
@@ -256,6 +256,8 @@ void PCSX::Widgets::ShaderEditor::init() {
     m_quadVertices[2].positions[1] = 1.0;
     m_quadVertices[3].positions[0] = 1.0;
     m_quadVertices[3].positions[1] = 1.0;
+
+    setDefaults();
 }
 
 PCSX::OpenGL::Status PCSX::Widgets::ShaderEditor::compile(GUI *gui,


### PR DESCRIPTION
Sets OpenGL Shader version to 410 on Apple, otherwise sets shaders to 300 es and does not pass a shader version to Imgui.

Also, from debugging, even with the fix mentioned above, on redux startup, the shader editors initially try to compile without the shader source text set. This causes it to fail to compile the default shaders, and falls back to the fallback shaders, which are not supposed to work. When debugging, you can see the the shader source text is null when it initially tries to compile. Adding a call to `setDefaults()` in the shaderEditor `init` method ensures the default shader source text is set before the gui attempts to compile the shaders, resolving the issue.