### PR TITLE
Disabling C++ modules in Visual Studio

### DIFF
--- a/vsprojects/common.props
+++ b/vsprojects/common.props
@@ -15,6 +15,8 @@
       <SDLCheck>false</SDLCheck>
       <DisableSpecificWarnings>4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <WholeProgramOptimization>false</WholeProgramOptimization>
+      <EnableModules>false</EnableModules>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <AdditionalDependencies>crypt32.lib;dbghelp.lib;normaliz.lib;wldap32.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION
They aren't compatible with clang-cl at the moment.