### PR TITLE
Fixing PPF generation

### DIFF
--- a/src/cdrom/file.cc
+++ b/src/cdrom/file.cc
@@ -184,7 +184,7 @@ ssize_t PCSX::CDRIsoFile::write(const void* buffer_, size_t size) {
     uint32_t toCopy = size;
 
     size_t actualSize = 0;
-    uint32_t lba = m_lba + m_ptrR / sectorSize;
+    uint32_t lba = m_lba + m_ptrW / sectorSize;
     IEC60908b::MSF msf(lba + 150);
 
     while (toCopy != 0) {

--- a/src/cdrom/ppf.cc
+++ b/src/cdrom/ppf.cc
@@ -196,8 +196,10 @@ void PCSX::PPF::save(std::filesystem::path iso) {
     m_description.resize(50);
     ppf->writeString(m_description);
     for (auto& patch : m_patches) {
+        auto msf = patch.getKey();
+        auto ppfOffset = (msf.toLBA() - 150) * 2352;
         for (auto& d : patch.data) {
-            uint32_t offset = d.first;
+            uint32_t offset = d.first + ppfOffset;
             uint32_t len = d.second.size();
             auto bytes = reinterpret_cast<const uint8_t*>(d.second.data());
             while (len != 0) {


### PR DESCRIPTION
- properly using write offset instead of read for LBA computation
- properly adding sector offsets when dumping the ppf to disc