### PR TITLE
Add missing cstdint

### DIFF
--- a/src/gui/widgets/registers.h
+++ b/src/gui/widgets/registers.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace PCSX {


### PR DESCRIPTION
Compilation was failing due to `uint` types being used without importing `cstdint`. There were 3 instances total: 1 in pcsx-redux and 2 in zep. This PR simply adds the missing library so compilation succeeds.