### PR TITLE
Add PAL Vertical Offset Fix

### DIFF
--- a/src/mips/psyqo/src/gpu.cpp
+++ b/src/mips/psyqo/src/gpu.cpp
@@ -52,8 +52,14 @@ void psyqo::GPU::initialize(const psyqo::GPU::Configuration &config) {
                  (config.config.videoInterlace << 5) | (config.config.hResolutionExtended << 6);
     // Horizontal Range
     Hardware::GPU::Ctrl = 0x06000000 | 0x260 | (0xc60 << 12);
+    
     // Vertical Range
-    Hardware::GPU::Ctrl = 0x07000000 | 16 | (255 << 10);
+    if (config.config.videoMode == Configuration::VM_NTSC) {
+        Hardware::GPU::Ctrl = 0x07000000 | 16 | (255 << 10);
+    } else {
+        Hardware::GPU::Ctrl = 0x07046C2B;
+    }
+    
     // Display Area
     Hardware::GPU::Ctrl = 0x05000000;
 


### PR DESCRIPTION
Screen output using PAL video was offset off the top of the screen. If statement to choose a different value when PAL is being used (thanks sickle) which addresses this.

Addresses the issue raised here https://github.com/grumpycoders/pcsx-redux/issues/1405
