### PR TITLE
Moving freetype's repo to github mirror.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -33,7 +33,7 @@
 	url = https://github.com/luvit/luv.git
 [submodule "third_party/freetype"]
 	path = third_party/freetype
-	url = https://gitlab.freedesktop.org/freetype/freetype.git
+	url = https://github.com/freetype/freetype.git
 [submodule "third_party/stb"]
 	path = third_party/stb
 	url = https://github.com/nothings/stb.git


### PR DESCRIPTION
Freedesktop's maintenance windows are way too big.