### PR TITLE
Relaxing syscall constraints.

### DIFF
--- a/src/mips/common/syscalls/syscalls.h
+++ b/src/mips/common/syscalls/syscalls.h
@@ -40,20 +40,18 @@ static __attribute__((always_inline)) int enterCriticalSection() {
     register int n asm("a0") = 1;
     register int r asm("v0");
     __asm__ volatile("syscall\n"
-                     : "=r"(n), "=r"(r)
+                     : "=r"(r)
                      : "r"(n)
-                     : "at", "v1", "a1", "a2", "a3", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8", "t9",
-                       "memory");
+                     : "memory");
     return r;
 }
 
 static __attribute__((always_inline)) void leaveCriticalSection() {
     register int n asm("a0") = 2;
     __asm__ volatile("syscall\n"
-                     : "=r"(n)
+                     :
                      : "r"(n)
-                     : "at", "v0", "v1", "a1", "a2", "a3", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8", "t9",
-                       "memory");
+                     : "memory");
 }
 
 static __attribute__((always_inline)) int changeThreadSubFunction(uint32_t address) {
@@ -61,9 +59,9 @@ static __attribute__((always_inline)) int changeThreadSubFunction(uint32_t addre
     register int tcb asm("a1") = address;
     register int r asm("v0");
     __asm__ volatile("syscall\n"
-                     : "=r"(r), "=r"(n), "=r"(tcb)
+                     : "=r"(r)
                      : "r"(n), "r"(tcb)
-                     : "at", "v1", "a2", "a3", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8", "t9", "memory");
+                     : "memory");
     return r;
 }
 


### PR DESCRIPTION
The syscall opcode will trigger a full interrupt, which won't actually modify any register beyond v0.