### PR TITLE
Add named save states widget, disable menu entries for numbered/quick…

### DIFF
--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -49,6 +49,7 @@
 #include "gui/widgets/luaeditor.h"
 #include "gui/widgets/luainspector.h"
 #include "gui/widgets/memcard_manager.h"
+#include "gui/widgets/named_savestates.h"
 #include "gui/widgets/pio-cart.h"
 #include "gui/widgets/registers.h"
 #include "gui/widgets/shader-editor.h"
@@ -98,6 +99,7 @@ class GUI final : public UI {
     typedef Setting<bool, TYPESTRING("ShowAssembly")> ShowAssembly;
     typedef Setting<bool, TYPESTRING("ShowDisassembly")> ShowDisassembly;
     typedef Setting<bool, TYPESTRING("ShowBreakpoints")> ShowBreakpoints;
+    typedef Setting<bool, TYPESTRING("ShowNamedSaveStates")> ShowNamedSaveStates;
     typedef Setting<bool, TYPESTRING("ShowEvents")> ShowEvents;
     typedef Setting<bool, TYPESTRING("ShowHandlers")> ShowHandlers;
     typedef Setting<bool, TYPESTRING("ShowKernelLog")> ShowKernelLog;
@@ -146,8 +148,8 @@ class GUI final : public UI {
     Settings<Fullscreen, FullWindowRender, ShowMenu, ShowLog, WindowPosX, WindowPosY, WindowSizeX, WindowSizeY,
              IdleSwapInterval, ShowLuaConsole, ShowLuaInspector, ShowLuaEditor, ShowMainVRAMViewer, ShowCLUTVRAMViewer,
              ShowVRAMViewer1, ShowVRAMViewer2, ShowVRAMViewer3, ShowVRAMViewer4, ShowMemoryObserver, ShowTypedDebugger,
-             ShowMemcardManager, ShowRegisters, ShowAssembly, ShowDisassembly, ShowBreakpoints, ShowEvents,
-             ShowHandlers, ShowKernelLog, ShowCallstacks, ShowSIO1, ShowIsoBrowser, ShowGPULogger, MainFontSize,
+             ShowMemcardManager, ShowRegisters, ShowAssembly, ShowDisassembly, ShowBreakpoints, ShowNamedSaveStates,
+             ShowEvents, ShowHandlers, ShowKernelLog, ShowCallstacks, ShowSIO1, ShowIsoBrowser, ShowGPULogger, MainFontSize,
              MonoFontSize, GUITheme, AllowMouseCaptureToggle, EnableRawMouseMotion, WidescreenRatio, ShowPIOCartConfig,
              ShowMemoryEditor1, ShowMemoryEditor2, ShowMemoryEditor3, ShowMemoryEditor4, ShowMemoryEditor5,
              ShowMemoryEditor6, ShowMemoryEditor7, ShowMemoryEditor8, ShowParallelPortEditor, ShowScratchpadEditor,
@@ -375,6 +377,7 @@ class GUI final : public UI {
     Widgets::FileDialog<> m_openBinaryDialog = {[]() { return _("Open Binary"); }};
     Widgets::FileDialog<> m_selectBiosDialog = {[]() { return _("Select BIOS"); }};
     Widgets::FileDialog<> m_selectEXP1Dialog = {[]() { return _("Select EXP1"); }};
+    Widgets::NamedSaveStates m_namedSaveStates = {settings.get<ShowNamedSaveStates>().value};
     Widgets::Breakpoints m_breakpoints = {settings.get<ShowBreakpoints>().value};
     Widgets::IsoBrowser m_isoBrowser = {settings.get<ShowIsoBrowser>().value};
 
@@ -405,9 +408,15 @@ class GUI final : public UI {
     EventBus::Listener m_listener;
 
     std::string buildSaveStateFilename(int i);
+    bool saveStateExists(std::filesystem::path filename);
+
+  public:
     void saveSaveState(std::filesystem::path filename);
     void loadSaveState(std::filesystem::path filename);
+    std::string getSaveStatePrefix(bool includeSeparator);
+    static std::string getSaveStatePostfix();
 
+  private:
     void applyTheme(int theme);
     void cherryTheme();
     void monoTheme();

--- a/src/gui/widgets/named_savestates.cc
+++ b/src/gui/widgets/named_savestates.cc
@@ -1,0 +1,180 @@
+
+#include "gui/widgets/named_savestates.h"
+
+#include "core/cdrom.h"
+#include "core/debug.h"
+#include "gui/gui.h"
+#include "imgui.h"
+#include "imgui_internal.h"
+
+void PCSX::Widgets::NamedSaveStates::draw(GUI* gui, const char* title) {
+    ImGui::SetNextWindowPos(ImVec2(520, 30), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(600, 500), ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin(title, &m_show)) {
+        ImGui::End();
+        return;
+    }
+
+    ImGuiStyle& style = ImGui::GetStyle();
+    const float heightSeparator = style.ItemSpacing.y;
+    const float footerHeight = (heightSeparator * 2 + ImGui::GetTextLineHeightWithSpacing()) * 4;
+    const float glyphWidth = ImGui::GetFontSize();
+
+    // Any ImGui::Text() preceeding a ImGui::InputText() will be incorrectly aligned, use this value to awkwardly account for this
+    // Luckily this value is consistent no matter what the UI main font size is set to
+    const float verticalAlignAdjust = 3.0f;
+
+    // Create a button for each named save state
+    ImGui::BeginChild("SaveStatesList", ImVec2(0, -footerHeight), true);
+    auto saveStates = getNamedSaveStates(gui);
+    for (const auto& saveStatePair : saveStates) {
+        // The button is invisible so we can adjust the highlight separately
+        if (ImGui::InvisibleButton(saveStatePair.second.c_str(),
+                                   ImVec2(-FLT_MIN, glyphWidth + style.FramePadding.y * 2),
+                                   ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_PressedOnDoubleClick)) {
+            // Copy the name to the input box
+            strcpy_s(m_namedSaveNameString, 128, saveStatePair.second.c_str());
+            // Load the save state if it was a double-click
+            if (ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left)) {
+                loadSaveState(gui, saveStatePair.first);
+            }
+        }
+        // Add a base coloured rect - highlight it if hovering over the button or the current InputText below matches it
+        bool matches = strcmpi(m_namedSaveNameString, saveStatePair.second.c_str()) == 0;
+        bool hovered = ImGui::IsItemHovered();
+        ImGui::GetWindowDrawList()->AddRectFilled(
+            ImGui::GetCurrentContext()->LastItemData.Rect.Min, ImGui::GetCurrentContext()->LastItemData.Rect.Max,
+            ImGui::ColorConvertFloat4ToU32(
+                ImGui::GetStyle()
+                    .Colors[matches ? ImGuiCol_HeaderActive : (hovered ? ImGuiCol_HeaderHovered : ImGuiCol_Header)]));
+        // Finally the butotn text
+        ImGui::GetWindowDrawList()->AddText(
+            ImVec2(ImGui::GetCurrentContext()->LastItemData.Rect.Min.x + style.FramePadding.y,
+                   ImGui::GetCurrentContext()->LastItemData.Rect.Min.y + style.FramePadding.y),
+            ImGui::GetColorU32(ImGuiCol_Text), saveStatePair.second.c_str());
+    }
+    ImGui::EndChild();
+
+    // Move the leading text down to align with the following InputText()
+    float posY = ImGui::GetCursorPosY();
+    ImGui::SetCursorPosY(posY + verticalAlignAdjust);
+
+    ImGui::Text(_("Filename: "));
+    ImGui::SameLine();
+    ImGui::Text(gui->getSaveStatePrefix(true).c_str());
+    ImGui::SameLine(0.0f, 0.0f);
+
+    // Restore the vertical value
+    ImGui::SetCursorPosY(posY);
+
+    // Ensure that we don't add invalid characters to the filename
+    // This also filters on pasted text
+    struct TextFilters {
+        static int FilterNonPathCharacters(ImGuiInputTextCallbackData* data) {
+            // Filter the core problematic characters for Windows and Linux
+            // Anything remaining outside of [a-zA-Z0-9._-] is also allowed
+            switch (data->EventChar) {
+                case '\\':
+                case '/':
+                case '<':
+                case '>':
+                case '|':
+                case '\"':
+                case ':':
+                case '?':
+                case '*':
+                case 0:
+                    return 1;
+            }
+            return 0;
+        }
+    };
+
+    ImGui::InputTextWithHint("##SaveNameInput", "Enter the name of your save state here", m_namedSaveNameString, 128,
+                             ImGuiInputTextFlags_CallbackCharFilter, TextFilters::FilterNonPathCharacters);
+    ImGui::SameLine(0.0f, 0.0f);
+
+    // Trailing text alignment also needs adjusting, but in the opposite direction
+    ImGui::SetCursorPosY(ImGui::GetCursorPosY() - verticalAlignAdjust);
+    ImGui::Text(gui->getSaveStatePostfix().c_str());
+
+    ImGui::Separator();
+
+    // Add various buttons based on whether a save state exists with that name
+    auto found = std::find_if(saveStates.begin(), saveStates.end(), [=](auto saveStatePair) {
+        return strlen(m_namedSaveNameString) > 0 && strcmpi(m_namedSaveNameString, saveStatePair.second.c_str()) == 0;
+        });
+    bool exists = found != saveStates.end();
+
+    float width = ImGui::GetCurrentContext()->LastItemData.Rect.GetWidth();
+    ImVec2 buttonDims = ImVec2(-FLT_MIN, glyphWidth + style.FramePadding.y * 2);
+    ImVec2 halfDims = ImVec2((width - (style.FramePadding.x * 6.0f)) * 0.5f, buttonDims.y);
+
+    if (!exists) {
+        if (strlen(m_namedSaveNameString) > 0) {
+            // The save state doesn't exist, and the name is valid
+            std::string pathStr = fmt::format("{}{}{}", gui->getSaveStatePrefix(true), m_namedSaveNameString, gui->getSaveStatePostfix());
+            std::filesystem::path newPath = pathStr;
+            if (ImGui::Button(_("Create save"), buttonDims)) {
+                saveSaveState(gui, newPath);
+            }
+        }
+    } else {
+        // The save state exists
+        if (ImGui::Button(_("Overwrite save"), halfDims)) {
+            saveSaveState(gui, found->first);
+        }
+        ImGui::SameLine();
+        if (ImGui::Button(_("Load save"), halfDims)) {
+            loadSaveState(gui, found->first);
+        }
+        // Add a deliberate spacer before the delete button
+        // There is no delete confirmation, and this makes a mis-click less likely to hit it
+        ImGui::Dummy(buttonDims);
+        if (ImGui::Button(_("Delete save"), buttonDims)) {
+            deleteSaveState(found->first);
+        }
+    }
+
+    ImGui::End();
+}
+
+std::vector<std::pair<std::filesystem::path, std::string>> PCSX::Widgets::NamedSaveStates::getNamedSaveStates(GUI* gui) {
+    std::vector<std::pair<std::filesystem::path, std::string>> names;
+
+    // Get the filename prefix to use, which follows the typical save state format, with a separator between gameID and name
+    std::string prefix = gui->getSaveStatePrefix(true);
+    std::string postfix = gui->getSaveStatePostfix();
+
+    // Loop the root directory
+    std::error_code ec;
+    if (std::filesystem::exists(std::filesystem::current_path(), ec)) {
+        for (const auto& entry : std::filesystem::directory_iterator(std::filesystem::current_path(), ec)) {
+            if (entry.is_regular_file()) {
+                std::string filename = entry.path().filename().string();
+                if (filename.find(prefix) == 0 &&
+                    filename.rfind(postfix) == filename.length() - postfix.length()) {
+                    std::string niceName = filename.substr(prefix.length(), filename.length() - (prefix.length() + postfix.length()));
+                    names.emplace_back(entry.path(), niceName);
+                }
+            }
+        }
+    }
+
+    return names;
+}
+
+void PCSX::Widgets::NamedSaveStates::saveSaveState(GUI* gui, std::filesystem::path saveStatePath) {
+    g_system->log(LogClass::UI, "Saving named save state: %s\n", saveStatePath.filename().string().c_str());
+    gui->saveSaveState(saveStatePath);
+}
+
+void PCSX::Widgets::NamedSaveStates::loadSaveState(GUI* gui, std::filesystem::path saveStatePath) {
+    g_system->log(LogClass::UI, "Loading named save state: %s\n", saveStatePath.filename().string().c_str());
+    gui->loadSaveState(saveStatePath);
+}
+
+void PCSX::Widgets::NamedSaveStates::deleteSaveState(std::filesystem::path saveStatePath) {
+    g_system->log(LogClass::UI, "Deleting named save state: %s\n", saveStatePath.filename().string().c_str());
+    std::remove(saveStatePath.string().c_str());
+}

--- a/src/gui/widgets/named_savestates.h
+++ b/src/gui/widgets/named_savestates.h
@@ -1,0 +1,31 @@
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <filesystem>
+
+namespace PCSX {
+
+class GUI;
+namespace Widgets {
+
+class NamedSaveStates {
+  public:
+    NamedSaveStates(bool& show) : m_show(show) {}
+    void draw(GUI* gui, const char* title);
+    bool& m_show;
+
+    std::vector<std::pair<std::filesystem::path, std::string>> getNamedSaveStates(GUI* gui);
+
+  private:
+    void saveSaveState(GUI* gui, std::filesystem::path saveStatePath);
+    void loadSaveState(GUI* gui, std::filesystem::path saveStatePath);
+    void deleteSaveState(std::filesystem::path saveStatePath);
+
+    char m_namedSaveNameString[128] = "";
+};
+
+}  // namespace Widgets
+
+}  // namespace PCSX

--- a/src/gui/widgets/named_savestates.h
+++ b/src/gui/widgets/named_savestates.h
@@ -19,11 +19,14 @@ class NamedSaveStates {
     std::vector<std::pair<std::filesystem::path, std::string>> getNamedSaveStates(GUI* gui);
 
   private:
+
+      static constexpr int NAMED_SAVE_STATE_LENGTH_MAX = 128;
+
     void saveSaveState(GUI* gui, std::filesystem::path saveStatePath);
     void loadSaveState(GUI* gui, std::filesystem::path saveStatePath);
     void deleteSaveState(std::filesystem::path saveStatePath);
 
-    char m_namedSaveNameString[128] = "";
+    char m_namedSaveNameString[NAMED_SAVE_STATE_LENGTH_MAX] = "";
 };
 
 }  // namespace Widgets

--- a/vsprojects/gui/gui.vcxproj
+++ b/vsprojects/gui/gui.vcxproj
@@ -258,6 +258,7 @@
     <ClCompile Include="..\..\src\gui\widgets\luainspector.cc" />
     <ClCompile Include="..\..\src\gui\widgets\memcard_manager.cc" />
     <ClCompile Include="..\..\src\gui\widgets\memory_observer.cc" />
+	<ClCompile Include="..\..\src\gui\widgets\named_savestates.cc" />
     <ClCompile Include="..\..\src\gui\widgets\pio-cart.cc" />
     <ClCompile Include="..\..\src\gui\widgets\typed_debugger.cc" />
     <ClCompile Include="..\..\src\gui\widgets\registers.cc" />
@@ -290,6 +291,7 @@
     <ClInclude Include="..\..\src\gui\widgets\luainspector.h" />
     <ClInclude Include="..\..\src\gui\widgets\memcard_manager.h" />
     <ClInclude Include="..\..\src\gui\widgets\memory_observer.h" />
+    <ClInclude Include="..\..\src\gui\widgets\named_savestates.h" />
     <ClInclude Include="..\..\src\gui\widgets\pio-cart.h" />
     <ClInclude Include="..\..\src\gui\widgets\typed_debugger.h" />
     <ClInclude Include="..\..\src\gui\widgets\registers.h" />

--- a/vsprojects/gui/gui.vcxproj.filters
+++ b/vsprojects/gui/gui.vcxproj.filters
@@ -94,6 +94,9 @@
     <ClCompile Include="..\..\src\gui\widgets\typed_debugger.cc">
       <Filter>Source Files\widgets</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\gui\widgets\named_savestates.cc">
+      <Filter>Source Files\widgets</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\gui\luanvg.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -187,6 +190,9 @@
       <Filter>Header Files\widgets</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\gui\widgets\typed_debugger.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\gui\widgets\named_savestates.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\gui\luanvg.h">


### PR DESCRIPTION
Allows for save states to be given names (beyond appending 0-9) and be created, overwritten, loaded & deleted within a bespoke widget

The naming format is `[GAMEID]_[NAME_OF_SAVE_STATE].sstate`

These named save states are also listed in the `File->Load save slots` menu

This PR also disables menu items for save states that don't have an existing file to load, helping to indicate at a glance which are currently in use