### PR TITLE
Add optional labels to describe breakpoints

### DIFF
--- a/src/core/debug.h
+++ b/src/core/debug.h
@@ -68,8 +68,8 @@ class Debug {
 
     class Breakpoint : public BreakpointTreeType::Node, public BreakpointUserListType::Node {
       public:
-        Breakpoint(BreakpointType type, const std::string& source, BreakpointInvoker invoker, uint32_t base)
-            : m_type(type), m_source(source), m_invoker(invoker), m_base(base) {}
+        Breakpoint(BreakpointType type, const std::string& source, BreakpointInvoker invoker, uint32_t base, std::string label = "")
+            : m_type(type), m_source(source), m_invoker(invoker), m_base(base), m_label(label) {}
         std::string name() const;
         BreakpointType type() const { return m_type; }
         unsigned width() const { return getHigh() - getLow() + 1; }
@@ -78,6 +78,8 @@ class Debug {
         void enable() const { m_enabled = true; }
         void disable() const { m_enabled = false; }
         const std::string& source() const { return m_source; }
+        const std::string& label() const { return m_label; }
+        void label(const std::string& label) { m_label = label; }
         uint32_t base() const { return m_base; }
 
       private:
@@ -89,6 +91,7 @@ class Debug {
         const BreakpointType m_type;
         const std::string m_source;
         const BreakpointInvoker m_invoker;
+        mutable std::string m_label;
         uint32_t m_base;
         mutable bool m_enabled = true;
 
@@ -131,6 +134,16 @@ class Debug {
         uint32_t base = address & 0xe0000000;
         address &= ~0xe0000000;
         return &*m_breakpoints.insert(address, address + width - 1, new Breakpoint(type, source, invoker, base));
+    }
+    inline Breakpoint* addBreakpoint(
+        uint32_t address, BreakpointType type, unsigned width, const std::string& source, std::string label,
+        BreakpointInvoker invoker = [](const Breakpoint* self, uint32_t address, unsigned width, const char* cause) {
+            g_system->pause();
+            return true;
+        }) {
+        uint32_t base = address & 0xe0000000;
+        address &= ~0xe0000000;
+        return &*m_breakpoints.insert(address, address + width - 1, new Breakpoint(type, source, invoker, base, label));
     }
     const BreakpointTreeType& getTree() { return m_breakpoints; }
     const Breakpoint* lastBP() { return m_lastBP; }

--- a/src/core/debug.h
+++ b/src/core/debug.h
@@ -79,7 +79,7 @@ class Debug {
         void disable() const { m_enabled = false; }
         const std::string& source() const { return m_source; }
         const std::string& label() const { return m_label; }
-        void label(const std::string& label) { m_label = label; }
+        void label(const std::string& label) const { m_label = label; }
         uint32_t base() const { return m_base; }
 
       private:

--- a/src/core/pcsxffi.lua
+++ b/src/core/pcsxffi.lua
@@ -57,7 +57,7 @@ uint8_t* getScratchPtr();
 psxRegisters* getRegisters();
 uint8_t** getReadLUT();
 uint8_t** getWriteLUT();
-Breakpoint* addBreakpoint(uint32_t address, enum BreakpointType type, unsigned width, const char* cause, bool (*invoker)(uint32_t address, unsigned width, const char* cause));
+Breakpoint* addBreakpoint(uint32_t address, enum BreakpointType type, unsigned width, const char* cause, bool (*invoker)(uint32_t address, unsigned width, const char* cause), const char* label);
 void enableBreakpoint(Breakpoint*);
 void disableBreakpoint(Breakpoint*);
 bool breakpointEnabled(Breakpoint*);
@@ -109,7 +109,7 @@ end
 
 local validBpTypes = { Exec = true, Read = true, Write = true }
 
-local function addBreakpoint(address, bptype, width, cause, invoker)
+local function addBreakpoint(address, bptype, width, cause, invoker, label)
     if type(address) ~= 'number' then error 'PCSX.addBreakpoint needs an address' end
     if bptype == nil then bptype = 'Exec' end
     if not validBpTypes[bptype] then error 'PCSX.addBreakpoint needs a valid breakpoint type' end
@@ -134,8 +134,10 @@ local function addBreakpoint(address, bptype, width, cause, invoker)
             end
         end
     end
+    if label == nil then label = '' end
+    if type(label) ~= 'string' then error 'PCSX.addBreakpoint needs a label that is a string' end
     invokercb = ffi.cast('bool (*)(uint32_t address, unsigned width, const char* cause)', invokercb)
-    local wrapper = C.addBreakpoint(address, bptype, width, cause, invokercb)
+    local wrapper = C.addBreakpoint(address, bptype, width, cause, invokercb, label)
     local bp = {
         _wrapper = wrapper,
         _proxy = newproxy(),

--- a/src/core/pcsxlua.cc
+++ b/src/core/pcsxlua.cc
@@ -43,10 +43,10 @@ void* getReadLUT() { return PCSX::g_emulator->m_mem->m_readLUT; }
 void* getWriteLUT() { return PCSX::g_emulator->m_mem->m_writeLUT; }
 
 LuaBreakpoint* addBreakpoint(uint32_t address, PCSX::Debug::BreakpointType type, unsigned width, const char* cause,
-                             bool (*invoker)(uint32_t address, unsigned width, const char* cause)) {
+                             bool (*invoker)(uint32_t address, unsigned width, const char* cause), const char* label) {
     LuaBreakpoint* ret = new LuaBreakpoint();
     auto* bp = PCSX::g_emulator->m_debug->addBreakpoint(
-        address, type, width, std::string("Lua Breakpoint ") + cause,
+        address, type, width, std::string("Lua Breakpoint ") + cause, label,
         [invoker](const PCSX::Debug::Breakpoint* self, uint32_t address, unsigned width, const char* cause) {
             try {
                 return invoker(address, width, cause);

--- a/src/gui/widgets/breakpoints.cc
+++ b/src/gui/widgets/breakpoints.cc
@@ -19,11 +19,26 @@
 
 #include "gui/widgets/breakpoints.h"
 
-#include "core/debug.h"
+#include "fmt/format.h"
 #include "imgui.h"
 #include "support/imgui-helpers.h"
 
 static ImVec4 s_currentColor = ImColor(0xff, 0xeb, 0x3b);
+
+void PCSX::Widgets::Breakpoints::showEditLabelPopup(const Debug::Breakpoint* bp, int counter) {
+    std::string name = bp->name();
+    std::string title = fmt::format(f_("Edit label of breakpoint {}##{}"), name, counter);
+    if (ImGui::BeginPopupModal(title.c_str(), nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+        ImGui::Text(_("Change the label of breakpoint %s:"), name.c_str());
+        if (ImGui::InputText(_("Label"), m_bpEditPopupLabel, sizeof(m_bpEditPopupLabel),
+                             ImGuiInputTextFlags_EnterReturnsTrue)) {
+            bp->label(m_bpEditPopupLabel);
+            ImGui::CloseCurrentPopup();
+        }
+        if (ImGui::Button(_("Cancel"))) ImGui::CloseCurrentPopup();
+        ImGui::EndPopup();
+    }
+}
 
 void PCSX::Widgets::Breakpoints::draw(const char* title) {
     ImGui::SetNextWindowPos(ImVec2(520, 30), ImGuiCond_FirstUseEver);
@@ -68,14 +83,16 @@ void PCSX::Widgets::Breakpoints::draw(const char* title) {
     ImGuiStyle& style = ImGui::GetStyle();
     const float heightSeparator = style.ItemSpacing.y;
     float footerHeight = 0;
-    footerHeight += (heightSeparator * 2 + ImGui::GetTextLineHeightWithSpacing()) * 5; // 5 footer rows
+    footerHeight += (heightSeparator * 2 + ImGui::GetTextLineHeightWithSpacing()) * 5;  // 5 footer rows
     float glyphWidth = ImGui::GetFontSize();
     ImDrawList* drawList = ImGui::GetWindowDrawList();
 
     ImGui::BeginChild("BreakpointsList", ImVec2(0, -footerHeight), true);
     const Debug::Breakpoint* toErase = nullptr;
+    std::string editorToOpen = "";
     auto& tree = debugger->getTree();
-    for (auto bp = tree.begin(); bp != tree.end(); bp++) {
+    int counter = 0;
+    for (auto bp = tree.begin(); bp != tree.end(); bp++, counter++) {
         ImVec2 pos = ImGui::GetCursorScreenPos();
         std::string name = bp->name();
         if (bp->enabled()) {
@@ -83,24 +100,37 @@ void PCSX::Widgets::Breakpoints::draw(const char* title) {
         } else {
             ImGui::TextDisabled("  %s", name.c_str());
         }
+        // there can be multiple breakpoints with the same name, so we need the counter
+        // to make widget IDs unique
+        std::string uniqueId = fmt::format("{}{}", name, counter);
         ImGui::SameLine();
-        std::string buttonLabel = _("Remove##") + name;
+        std::string buttonLabel = _("Remove##") + uniqueId;
         if (ImGui::Button(buttonLabel.c_str())) toErase = &*bp;
         ImGui::SameLine();
         if (bp->enabled()) {
-            buttonLabel = _("Disable##") + name;
+            buttonLabel = _("Disable##") + uniqueId;
             if (ImGui::Button(buttonLabel.c_str())) bp->disable();
         } else {
-            buttonLabel = _("Enable##") + name;
+            buttonLabel = _("Enable##") + uniqueId;
             if (ImGui::Button(buttonLabel.c_str())) bp->enable();
         }
+
         ImGui::SameLine();
         const std::string& label = bp->label();
-        if (bp->enabled()) {
-            ImGui::Text(" %s", label.c_str());
-        } else {
-            ImGui::TextDisabled(" %s", label.c_str());
+        const std::string uniqueLabel = label + "##" + uniqueId;
+
+        // make the label edit button look like normal text until the user hovers over it
+        ImGui::PushStyleColor(ImGuiCol_Button, ImGui::GetColorU32(ImGuiCol_WindowBg));
+        if (!bp->enabled()) {
+            ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetColorU32(ImGuiCol_TextDisabled));
         }
+        if (ImGui::Button(uniqueLabel.c_str())) {
+            editorToOpen = fmt::format(f_("Edit label of breakpoint {}##{}"), name, counter);
+            strncpy(m_bpEditPopupLabel, label.c_str(), sizeof(m_bpEditPopupLabel));
+            m_bpEditPopupLabel[sizeof(m_bpEditPopupLabel) - 1] = 0;
+        }
+        ImGui::PopStyleColor(bp->enabled() ? 1 : 2);
+
         if (debugger->lastBP() != &*bp) continue;
         ImVec2 a, b, c, d, e;
         const float dist = glyphWidth / 2;
@@ -120,7 +150,8 @@ void PCSX::Widgets::Breakpoints::draw(const char* title) {
     }
     ImGui::EndChild();
     if (toErase) g_emulator->m_debug->removeBreakpoint(toErase);
-    ImGui::InputText(_("Address"), m_bpAddressString, 20, ImGuiInputTextFlags_CharsHexadecimal);
+    bool addBreakpoint = ImGui::InputText(_("Address"), m_bpAddressString, 20,
+                                          ImGuiInputTextFlags_CharsHexadecimal | ImGuiInputTextFlags_EnterReturnsTrue);
     if (ImGui::BeginCombo(_("Breakpoint Type"), Debug::s_breakpoint_type_names[m_breakpointType]())) {
         for (int i = 0; i < 3; i++) {
             if (ImGui::Selectable(Debug::s_breakpoint_type_names[i](), m_breakpointType == i)) {
@@ -130,8 +161,9 @@ void PCSX::Widgets::Breakpoints::draw(const char* title) {
         ImGui::EndCombo();
     }
     ImGui::SliderInt(_("Breakpoint Width"), &m_breakpointWidth, 1, 4);
-    ImGui::InputText(_("Label"), m_bpLabelString, 100);
-    if (ImGui::Button(_("Add Breakpoint"))) {
+    addBreakpoint = addBreakpoint || ImGui::InputText(_("Label"), m_bpLabelString, sizeof(m_bpLabelString),
+                                                      ImGuiInputTextFlags_EnterReturnsTrue);
+    if (ImGui::Button(_("Add Breakpoint")) || addBreakpoint) {
         char* endPtr;
         uint32_t breakpointAddress = strtoul(m_bpAddressString, &endPtr, 16);
         if (*m_bpAddressString && !*endPtr) {
@@ -143,4 +175,13 @@ void PCSX::Widgets::Breakpoints::draw(const char* title) {
         }
     }
     ImGui::End();
+
+    if (!editorToOpen.empty()) {
+        ImGui::OpenPopup(editorToOpen.c_str());
+        editorToOpen = "";
+    }
+    counter = 0;
+    for (auto bp = tree.begin(); bp != tree.end(); bp++, counter++) {
+        showEditLabelPopup(&*bp, counter);
+    }
 }

--- a/src/gui/widgets/breakpoints.cc
+++ b/src/gui/widgets/breakpoints.cc
@@ -68,7 +68,7 @@ void PCSX::Widgets::Breakpoints::draw(const char* title) {
     ImGuiStyle& style = ImGui::GetStyle();
     const float heightSeparator = style.ItemSpacing.y;
     float footerHeight = 0;
-    footerHeight += (heightSeparator * 2 + ImGui::GetTextLineHeightWithSpacing()) * 4;
+    footerHeight += (heightSeparator * 2 + ImGui::GetTextLineHeightWithSpacing()) * 5; // 5 footer rows
     float glyphWidth = ImGui::GetFontSize();
     ImDrawList* drawList = ImGui::GetWindowDrawList();
 
@@ -93,6 +93,13 @@ void PCSX::Widgets::Breakpoints::draw(const char* title) {
         } else {
             buttonLabel = _("Enable##") + name;
             if (ImGui::Button(buttonLabel.c_str())) bp->enable();
+        }
+        ImGui::SameLine();
+        const std::string& label = bp->label();
+        if (bp->enabled()) {
+            ImGui::Text(" %s", label.c_str());
+        } else {
+            ImGui::TextDisabled(" %s", label.c_str());
         }
         if (debugger->lastBP() != &*bp) continue;
         ImVec2 a, b, c, d, e;
@@ -123,12 +130,16 @@ void PCSX::Widgets::Breakpoints::draw(const char* title) {
         ImGui::EndCombo();
     }
     ImGui::SliderInt(_("Breakpoint Width"), &m_breakpointWidth, 1, 4);
+    ImGui::InputText(_("Label"), m_bpLabelString, 100);
     if (ImGui::Button(_("Add Breakpoint"))) {
         char* endPtr;
         uint32_t breakpointAddress = strtoul(m_bpAddressString, &endPtr, 16);
         if (*m_bpAddressString && !*endPtr) {
             debugger->addBreakpoint(breakpointAddress, Debug::BreakpointType(m_breakpointType), m_breakpointWidth,
-                                    _("GUI"));
+                                    _("GUI"), m_bpLabelString);
+            // we clear the label string because it seems more likely that the user would forget to clear the field
+            // than that they want to use the same label twice
+            m_bpLabelString[0] = 0;
         }
     }
     ImGui::End();

--- a/src/gui/widgets/breakpoints.cc
+++ b/src/gui/widgets/breakpoints.cc
@@ -89,7 +89,7 @@ void PCSX::Widgets::Breakpoints::draw(const char* title) {
 
     ImGui::BeginChild("BreakpointsList", ImVec2(0, -footerHeight), true);
     const Debug::Breakpoint* toErase = nullptr;
-    std::string editorToOpen = "";
+    std::string editorToOpen;
     auto& tree = debugger->getTree();
     int counter = 0;
     for (auto bp = tree.begin(); bp != tree.end(); bp++, counter++) {

--- a/src/gui/widgets/breakpoints.cc
+++ b/src/gui/widgets/breakpoints.cc
@@ -178,7 +178,6 @@ void PCSX::Widgets::Breakpoints::draw(const char* title) {
 
     if (!editorToOpen.empty()) {
         ImGui::OpenPopup(editorToOpen.c_str());
-        editorToOpen = "";
     }
     counter = 0;
     for (auto bp = tree.begin(); bp != tree.end(); bp++, counter++) {

--- a/src/gui/widgets/breakpoints.h
+++ b/src/gui/widgets/breakpoints.h
@@ -40,6 +40,7 @@ class Breakpoints {
     char m_bpAddressString[20] = "";
     int m_breakpointType = 0;
     int m_breakpointWidth = 1;
+    char m_bpLabelString[100] = "";
 };
 
 }  // namespace Widgets

--- a/src/gui/widgets/breakpoints.h
+++ b/src/gui/widgets/breakpoints.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "core/debug.h"
+
 namespace PCSX {
 
 namespace Widgets {
@@ -30,6 +32,8 @@ class Breakpoints {
     bool& m_show;
 
   private:
+    void showEditLabelPopup(const Debug::Breakpoint* bp, int counter);
+
     bool m_filterE = true;
     bool m_filterR1 = true;
     bool m_filterR2 = true;
@@ -41,6 +45,7 @@ class Breakpoints {
     int m_breakpointType = 0;
     int m_breakpointWidth = 1;
     char m_bpLabelString[100] = "";
+    char m_bpEditPopupLabel[100] = "";
 };
 
 }  // namespace Widgets


### PR DESCRIPTION
Per #1502 . My C++ is pretty rusty, so let me know if anything looks weird. In particular, I don't like duplicating `addBreakpoint`, but if I put the new parameter at the end, breakpoints.cc has to duplicate the default invoker, and if I put it before invoker without the overload, all the other usages of the function have to change.

As for the feature itself, I put the label to the right of the buttons instead of adding it to the name. I feel like, if the window isn't wide enough to show everything, it's better for it to start by cutting off the end of the label than the Remove and Disable buttons. I also prefer to keep the buttons of each row aligned roughly in the same columns.