### PR TITLE
Relaxing psyqo's compilation rules outside CI

### DIFF
--- a/.github/workflows/linux-toolchain.yml
+++ b/.github/workflows/linux-toolchain.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Build OpenBIOS with it
         run: make -C src/mips/openbios -j 6 all
       - name: Build psyqo examples with it
-        run: for d in src/mips/psyqo/examples/* ; do make -C $d -j 6 all ; done
+        run: for d in src/mips/psyqo/examples/* ; do make -C $d -j 6 all TEST=true ; done

--- a/src/mips/psyqo-paths/examples/cdrom-loader/Makefile
+++ b/src/mips/psyqo-paths/examples/cdrom-loader/Makefile
@@ -4,7 +4,9 @@ TYPE = ps-exe
 SRCS = \
 cdrom-loader.cpp \
 
+ifeq ($(TEST),true)
 CPPFLAGS = -Werror
+endif
 CXXFLAGS = -std=c++20
 
 include ../../psyqo-paths.mk

--- a/src/mips/psyqo/Makefile
+++ b/src/mips/psyqo/Makefile
@@ -12,8 +12,12 @@ $(wildcard src/hardware/*.cpp) \
 $(wildcard src/*.cpp) \
 $(wildcard src/*.c) \
 
-CPPFLAGS = -Werror -I../../../third_party/EASTL/include -I../../../third_party/EABase/include/Common
+CPPFLAGS = -I../../../third_party/EASTL/include -I../../../third_party/EABase/include/Common
 CXXFLAGS = -std=c++20
+
+ifeq ($(TEST),true)
+CPPFLAGS += -Werror
+endif
 
 EXTRA_DEPS += $(PSYQODIR)Makefile
 

--- a/src/mips/psyqo/examples/bezier/Makefile
+++ b/src/mips/psyqo/examples/bezier/Makefile
@@ -4,7 +4,9 @@ TYPE = ps-exe
 SRCS = \
 bezier.cpp \
 
+ifeq ($(TEST),true)
 CPPFLAGS = -Werror
+endif
 CXXFLAGS = -std=c++20
 
 include ../../psyqo.mk

--- a/src/mips/psyqo/examples/cdrom-demo/Makefile
+++ b/src/mips/psyqo/examples/cdrom-demo/Makefile
@@ -4,7 +4,9 @@ TYPE = ps-exe
 SRCS = \
 cdrom-demo.cpp \
 
+ifeq ($(TEST),true)
 CPPFLAGS = -Werror
+endif
 CXXFLAGS = -std=c++20
 
 include ../../psyqo.mk

--- a/src/mips/psyqo/examples/coroutine-demo/Makefile
+++ b/src/mips/psyqo/examples/coroutine-demo/Makefile
@@ -4,7 +4,9 @@ TYPE = ps-exe
 SRCS = \
 coroutine-demo.cpp \
 
+ifeq ($(TEST),true)
 CPPFLAGS = -Werror
+endif
 CXXFLAGS = -std=c++20 -fcoroutines
 
 include ../../psyqo.mk

--- a/src/mips/psyqo/examples/gte/Makefile
+++ b/src/mips/psyqo/examples/gte/Makefile
@@ -4,7 +4,9 @@ TYPE = ps-exe
 SRCS = \
 gte.cpp \
 
+ifeq ($(TEST),true)
 CPPFLAGS = -Werror
+endif
 CXXFLAGS = -std=c++20
 
 include ../../psyqo.mk

--- a/src/mips/psyqo/examples/hello-alloc/Makefile
+++ b/src/mips/psyqo/examples/hello-alloc/Makefile
@@ -4,7 +4,9 @@ TYPE = ps-exe
 SRCS = \
 hello.cpp \
 
+ifeq ($(TEST),true)
 CPPFLAGS = -Werror
+endif
 CXXFLAGS = -std=c++20
 
 include ../../psyqo.mk

--- a/src/mips/psyqo/examples/hello/Makefile
+++ b/src/mips/psyqo/examples/hello/Makefile
@@ -4,7 +4,9 @@ TYPE = ps-exe
 SRCS = \
 hello.cpp \
 
+ifeq ($(TEST),true)
 CPPFLAGS = -Werror
+endif
 CXXFLAGS = -std=c++20
 
 include ../../psyqo.mk

--- a/src/mips/psyqo/examples/lines/Makefile
+++ b/src/mips/psyqo/examples/lines/Makefile
@@ -4,7 +4,9 @@ TYPE = ps-exe
 SRCS = \
 lines.cpp \
 
+ifeq ($(TEST),true)
 CPPFLAGS = -Werror
+endif
 CXXFLAGS = -std=c++20
 
 include ../../psyqo.mk

--- a/src/mips/psyqo/examples/math/Makefile
+++ b/src/mips/psyqo/examples/math/Makefile
@@ -4,7 +4,9 @@ TYPE = ps-exe
 SRCS = \
 math.cpp \
 
+ifeq ($(TEST),true)
 CPPFLAGS = -Werror
+endif
 CXXFLAGS = -std=c++20
 
 include ../../psyqo.mk

--- a/src/mips/psyqo/examples/padtest/Makefile
+++ b/src/mips/psyqo/examples/padtest/Makefile
@@ -4,7 +4,9 @@ TYPE = ps-exe
 SRCS = \
 padtest.cpp \
 
+ifeq ($(TEST),true)
 CPPFLAGS = -Werror
+endif
 CXXFLAGS = -std=c++20
 
 include ../../psyqo.mk

--- a/src/mips/psyqo/examples/task-demo/Makefile
+++ b/src/mips/psyqo/examples/task-demo/Makefile
@@ -4,7 +4,9 @@ TYPE = ps-exe
 SRCS = \
 task-demo.cpp \
 
+ifeq ($(TEST),true)
 CPPFLAGS = -Werror
+endif
 CXXFLAGS = -std=c++20
 
 include ../../psyqo.mk

--- a/src/mips/psyqo/examples/tetris/Makefile
+++ b/src/mips/psyqo/examples/tetris/Makefile
@@ -18,7 +18,9 @@ sound.cpp \
 splash.cpp \
 tetris.cpp \
 
+ifeq ($(TEST),true)
 CPPFLAGS = -Werror
+endif
 CXXFLAGS = -std=c++20
 
 include ../../psyqo.mk

--- a/src/mips/psyqo/examples/timers/Makefile
+++ b/src/mips/psyqo/examples/timers/Makefile
@@ -4,7 +4,9 @@ TYPE = ps-exe
 SRCS = \
 timers.cpp \
 
+ifeq ($(TEST),true)
 CPPFLAGS = -Werror
+endif
 CXXFLAGS = -std=c++20
 
 include ../../psyqo.mk


### PR DESCRIPTION
Some compilers may not agree on the same set of warnings.