### PR TITLE
Fix for Lua assembler implementation of la, trim() now removes comments

### DIFF
--- a/src/supportpsx/assembler/assembler.lua
+++ b/src/supportpsx/assembler/assembler.lua
@@ -90,7 +90,7 @@ PCSX.Assembler.New = function()
                 if not symbol then error('Unknown symbol: ' .. lo16) end
                 lo16 = symbol.address
             end
-            ret = bit.bor(ret, bit.band(lo16, 16))
+            ret = bit.bor(ret, bit.band(lo16, 0xffff))
         end
         local imm26 = code.imm26
         if imm26 then
@@ -138,7 +138,7 @@ PCSX.Assembler.New = function()
         for str in string.gmatch(str, '([^' .. sep .. ']+)') do table.insert(ret, str) end
         return ret
     end
-    local function trim(str) return string.gsub(str, '^%s*(.-)%s*$', '%1') end
+    local function trim(str) return string.gsub(string.gsub(str, '^(.-)#.*$', '%1'), '^%s*(.-)%s*$', '%1') end
     local function parseOneString(self, line)
         local parts = split(line, ' \\(\\),')
         local args = {}

--- a/src/supportpsx/assembler/pseudo.lua
+++ b/src/supportpsx/assembler/pseudo.lua
@@ -53,10 +53,9 @@ PCSX.Assembler.Internals.pseudoInstructions = {
 
     la = function(args)
         if #args ~= 2 then error('la takes two arguments') end
-        if type(args[2]) ~= 'string' then error('la second argument must be a string') end
         return {
             { base = 0x3c000000, rt = checkGPR(args[1]), hi16 = args[2] },
-            { base = 0x24000000, rt = checkGPR(args[1]), lo16 = args[2] },
+            { base = 0x24000000, rt = checkGPR(args[1]), rs = checkGPR(args[1]), lo16 = args[2] },
         }
     end,
 


### PR DESCRIPTION
'la' lo16 was incorrectly masked, and was replacing the hi16 instead of or'ing with it

Tested with `la $a0, 0x800e239c` and didn't test with a symbol

Code parsing now also strips # comments as well as whitespace