### PR TITLE
Workarounding gdb failure on connect.

### DIFF
--- a/src/core/gdb-server.cc
+++ b/src/core/gdb-server.cc
@@ -126,6 +126,7 @@ PCSX::GdbClient::GdbClient(uv_tcp_t* srv) : m_listener(g_system->m_eventBus) {
         write("OK");
     });
     m_listener.listen<Events::LogMessage>([this](const auto& event) {
+        if (!m_canReceiveLogs) return;
         auto& emuSettings = PCSX::g_emulator->settings;
         auto& debugSettings = emuSettings.get<Emulator::SettingDebugSettings>();
         auto gdbLog = debugSettings.get<Emulator::DebugSettings::GdbLogSetting>().value;
@@ -535,6 +536,7 @@ void PCSX::GdbClient::processCommand() {
         write("OK");
     } else if (m_cmd == "c") {
         // continue - this doesn't technically have a reply, only when the target stops later, using T05.
+        m_canReceiveLogs = true;
         g_system->resume();
         m_waitingForTrap = true;
     } else if (m_cmd[0] == 'M') {

--- a/src/core/gdb-server.h
+++ b/src/core/gdb-server.h
@@ -238,6 +238,9 @@ class GdbClient : public Intrusive::List<GdbClient>::Node {
     bool m_waitingForTrap = false;
     bool m_waitingForShell = false;
     bool m_exception = false;
+    // Not sure about the logic here; we need to keep an eye on when
+    // gdb complains about invalid responses, and toggle this accordingly.
+    bool m_canReceiveLogs = false;
     std::string m_cmd;
     uint8_t m_crc;
     EventBus::Listener m_listener;


### PR DESCRIPTION
If gdb connects while the emulator is running and printing lots of logs, the gdb client might get confused about getting messages when it's not supposed to. We're trying to avoid this situation by preventing messages to be sent until gdb may potentially be in a state where it's ready to accept them.