### PR TITLE
Bump to MacOS 12.

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -39,7 +39,7 @@ jobs:
         path: '**/*.ps-exe'
 
   macos-build-and-test:
-    runs-on: macos-11
+    runs-on: macos-12
     needs: build-openbios
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
It looks like we finally can't build with MacOS 11 anymore.