### PR TITLE
Forgot -fdata-sections

### DIFF
--- a/src/mips/common.mk
+++ b/src/mips/common.mk
@@ -35,7 +35,7 @@ ARCHFLAGS += -fno-stack-protector -nostdlib -ffreestanding
 ifeq ($(USE_FUNCTION_SECTIONS),true)
 CPPFLAGS += -ffunction-sections
 endif
-CPPFLAGS += -mno-gpopt -fomit-frame-pointer
+CPPFLAGS += -fdata-sections -mno-gpopt -fomit-frame-pointer
 CPPFLAGS += -fno-builtin -fno-strict-aliasing -Wno-attributes
 CPPFLAGS += $(ARCHFLAGS)
 CPPFLAGS += -I$(ROOTDIR)


### PR DESCRIPTION
The mips' `common.mk` missed `-fdata-sections`. Fixing this.