### PR TITLE
Fix coroutine include for changes due to Xcode 15.3 command line tools

### DIFF
--- a/src/support/coroutine.h
+++ b/src/support/coroutine.h
@@ -26,7 +26,7 @@ SOFTWARE.
 
 #pragma once
 
-#ifdef __APPLE__
+#if defined (__APPLE__) && (__clang_major__ < 15)
 // Why has Apple become the Microsoft of Software Engineering?
 #include <experimental/coroutine>
 #else
@@ -38,7 +38,7 @@ namespace PCSX {
 
 template <typename T = void>
 struct Coroutine {
-#ifdef __APPLE__
+#if defined (__APPLE__) && (__clang_major__ < 15)
     template <typename U>
     using CoroutineHandle = std::experimental::coroutine_handle<U>;
     using CoroutineHandleVoid = std::experimental::coroutine_handle<void>;


### PR DESCRIPTION
https://developer.apple.com/documentation/xcode-release-notes/xcode-15_3-release-notes

Xcode 15.3 command line tools updated clang to version 15 on MacOS. In this change, the coroutine header was moved from `experimental/coroutine` to `coroutine`. This PR implements a check for older clang versions and acts accordingly.