### PR TITLE
modconv: add missing source in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ ifeq ($(CROSS),arm64)
         CPPFLAGS += -Ithird_party/vixl/src -Ithird_party/vixl/src/aarch64
 endif
 SUPPORT_SRCS := src/support/file.cc src/support/mem4g.cc src/support/zfile.cc
-SUPPORT_SRCS += src/supportpsx/binloader.cc src/supportpsx/ps1-packer.cc
+SUPPORT_SRCS += src/supportpsx/adpcm.cc src/supportpsx/binloader.cc src/supportpsx/ps1-packer.cc
 SUPPORT_SRCS += third_party/fmt/src/os.cc third_party/fmt/src/format.cc
 SUPPORT_SRCS += third_party/ucl/src/n2e_99.c third_party/ucl/src/alloc.c
 SUPPORT_SRCS += $(wildcard third_party/iec-60908b/*.c)


### PR DESCRIPTION
Linking `modconv` fails for me because `adpcm.cc` is not in `SUPPORT_SRCS` (and by extension `SUPPORT_OBJ`):

```
/project/tools/modconv/modconv.cc:144:(.text.startup+0xc10): undefined reference to `PCSX::ADPCM::Encoder::reset(PCSX::ADPCM::Encoder::Mode)'
/usr/bin/ld: /project/tools/modconv/modconv.cc:169:(.text.startup+0xd48): undefined reference to `PCSX::ADPCM::Encoder::processSPUBlock(short const*, unsigned char*, PCSX::ADPCM::Encoder::BlockAttribute)'
/usr/bin/ld: /project/tools/modconv/modconv.cc:192:(.text.startup+0x120c): undefined reference to `PCSX::ADPCM::Encoder::processSPUBlock(short const*, unsigned char*, PCSX::ADPCM::Encoder::BlockAttribute)'
collect2: error: ld returned 1 exit status
make: *** [Makefile:308: modconv] Error 1
```

I am using the docker container so I assume it's not an error unique to my build environment