### PR TITLE
makefile: include .c sources in DEPS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,7 +312,7 @@ tools: $(TOOLS)
 .PHONY: all dep clean gitclean regen-i18n runtests openbios install strip appimage tools
 
 DEPS += $(patsubst %.c,%.dep,$(filter %.c,$(SRCS)))
-DEPS := $(patsubst %.cc,%.dep,$(filter %.cc,$(SRCS)))
+DEPS += $(patsubst %.cc,%.dep,$(filter %.cc,$(SRCS)))
 DEPS += $(patsubst %.cpp,%.dep,$(filter %.cpp,$(SRCS)))
 
 dep: $(DEPS)


### PR DESCRIPTION
Assigning instead of appending seems unintentional here and no `.dep` files are created for `.c` source files when running `make dep` because of it .

This has not caused any problems for me, it just caught my eye.

I'm sorry for the barrage of micro-PRs, this is the last one :smile: