### PR TITLE
allow version info file without updateInfo

### DIFF
--- a/src/gui/gui.cc
+++ b/src/gui/gui.cc
@@ -598,7 +598,7 @@ void PCSX::GUI::init(std::function<void()> applyArguments) {
         finishLoadSettings();
 
         if (!g_system->getArgs().isUpdateDisabled() && emuSettings.get<PCSX::Emulator::SettingAutoUpdate>() &&
-            !g_system->getVersion().failed()) {
+            !g_system->getVersion().failed() && g_system->getVersion().hasUpdateInfo()) {
             m_update.downloadUpdateInfo(
                 g_system->getVersion(),
                 [this](bool success) {
@@ -1646,7 +1646,7 @@ their TV set to match the aspect ratio of the game.)"));
     }
 
     if (!g_system->getArgs().isUpdateDisabled() && !g_system->getVersion().failed() &&
-        !emuSettings.get<Emulator::SettingShownAutoUpdateConfig>().value) {
+        g_system->getVersion().hasUpdateInfo() && !emuSettings.get<Emulator::SettingShownAutoUpdateConfig>().value) {
         if (ImGui::Begin(_("Update configuration"), nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
             ImGui::TextUnformatted((_(R"(PCSX-Redux can automatically update itself.
 

--- a/src/support/version.cc
+++ b/src/support/version.cc
@@ -42,16 +42,22 @@ void PCSX::VersionInfo::loadFromFile(IO<File> file) {
         version = json["version"].template get<std::string>();
         changeset = json["changeset"].template get<std::string>();
         timestamp = json["timestamp"].template get<std::time_t>();
+    } catch (...) {
+        clear();
+        return;
+    }
+    try {
         updateCatalog = json["updateInfo"][0]["updateCatalog"].template get<std::string>();
         updateInfoBase = json["updateInfo"][0]["updateInfoBase"].template get<std::string>();
     } catch (...) {
-        clear();
+        updateCatalog.clear();
+        updateInfoBase.clear();
     }
 }
 
 bool PCSX::Update::downloadUpdateInfo(const VersionInfo& versionInfo, std::function<void(bool)> callback,
                                       uv_loop_t* loop) {
-    if (versionInfo.failed()) return false;
+    if (versionInfo.failed() || !versionInfo.hasUpdateInfo()) return false;
     m_hasUpdate = false;
     m_download = new UvFile(
         versionInfo.updateCatalog,
@@ -89,7 +95,7 @@ bool PCSX::Update::downloadUpdateInfo(const VersionInfo& versionInfo, std::funct
 
 bool PCSX::Update::downloadAndApplyUpdate(const VersionInfo& versionInfo, std::function<void(bool)> callback,
                                           uv_loop_t* loop) {
-    if (versionInfo.failed()) return false;
+    if (versionInfo.failed() || !versionInfo.hasUpdateInfo()) return false;
     m_hasUpdate = false;
     m_download = new UvFile(
         versionInfo.updateInfoBase + std::to_string(m_updateId),
@@ -124,7 +130,7 @@ bool PCSX::Update::downloadAndApplyUpdate(const VersionInfo& versionInfo, std::f
 
 bool PCSX::Update::getDownloadUrl(const VersionInfo& versionInfo, std::function<void(std::string)> callback,
                                   uv_loop_t* loop) {
-    if (versionInfo.failed()) return false;
+    if (versionInfo.failed() || !versionInfo.hasUpdateInfo()) return false;
     m_hasUpdate = false;
     m_download = new UvFile(
         versionInfo.updateInfoBase + std::to_string(m_updateId),

--- a/src/support/version.h
+++ b/src/support/version.h
@@ -47,6 +47,7 @@ struct VersionInfo {
     std::string updateInfoBase;
     void loadFromFile(IO<File> file);
     bool failed() const { return version.empty(); }
+    bool hasUpdateInfo() const { return !updateInfoBase.empty(); }
     void clear() {
         version.clear();
         changeset.clear();


### PR DESCRIPTION
Currently, parsing the `version.json` fails if there is no `updateInfo` key.
When packaging for nix, I want to disable update checks but still show some version information in the "About" window.
Putting broken URLs in there feels too hacky for my taste, and it looks easy enough to differentiate between "failed parsing" and "successful parsing without the update info".

I'm not sure if this counts as trivial, please let me know if I should open an issue for discussion instead.
