### PR TITLE
makefile: Add absolute path for bios link scripts

### DIFF
--- a/src/mips/openbios/Makefile
+++ b/src/mips/openbios/Makefile
@@ -86,10 +86,10 @@ uC-sdk-glue/init.c \
 ../../../third_party/uC-sdk/os/src/osdebug.c \
 
 ifeq ($(BOOT),rom)
-LDSCRIPT = psx-bios.ld
+LDSCRIPT = $(ROOTDIR)openbios/psx-bios.ld
 SRCS += font1.o font2.o
 else
-LDSCRIPT = psx-bios-as-cart.ld
+LDSCRIPT = $(ROOTDIR)openbios/psx-bios-as-cart.ld
 endif
 
 CPPFLAGS = -DNOFLOATINGPOINT -DXPRINTFNOALLOC -DXPRINTFNOSTDIO


### PR DESCRIPTION
I'm not sure what the difference is between my laptop and the CI, but locally this was resulting in build errors saying the link scripts can't be found