### PR TITLE
Open Assembly widget addresses in different Memory Editors

### DIFF
--- a/src/core/system.h
+++ b/src/core/system.h
@@ -88,6 +88,8 @@ struct JumpToPC {
 struct JumpToMemory {
     uint32_t address;
     unsigned size;
+    unsigned editorNum;
+    bool forceShowEditor;
 };
 struct SelectClut {
     unsigned x, y;

--- a/src/gui/gui.cc
+++ b/src/gui/gui.cc
@@ -740,6 +740,8 @@ void PCSX::GUI::init(std::function<void()> applyArguments) {
         const uint32_t base = (event.address >> 20) & 0xff8;
         const uint32_t real = event.address & 0x7fffff;
         const uint32_t size = event.size;
+        const uint32_t editorNum = event.editorNum;
+        const bool forceShowEditor = event.forceShowEditor;
         auto changeDataType = [](MemoryEditor* editor, int size) {
             bool isSigned = false;
             switch (editor->PreviewDataType) {
@@ -764,11 +766,13 @@ void PCSX::GUI::init(std::function<void()> applyArguments) {
         };
         if ((base == 0x000) || (base == 0x800) || (base == 0xa00)) {
             if (real < 0x00800000) {
-                m_mainMemEditors[0].editor.GotoAddrAndHighlight(real, real + size);
-                changeDataType(&m_mainMemEditors[0].editor, size);
+                if (forceShowEditor) m_mainMemEditors[editorNum].m_show = true;
+                m_mainMemEditors[editorNum].editor.GotoAddrAndHighlight(real, real + size);
+                changeDataType(&m_mainMemEditors[editorNum].editor, size);
             }
         } else if (base == 0x1f8) {
             if (real >= 0x1000 && real < 0x3000) {
+                if (forceShowEditor) m_hwrEditor.m_show = true;
                 m_hwrEditor.editor.GotoAddrAndHighlight(real - 0x1000, real - 0x1000 + size);
                 changeDataType(&m_hwrEditor.editor, size);
             }

--- a/src/gui/widgets/assembly.h
+++ b/src/gui/widgets/assembly.h
@@ -67,7 +67,7 @@ class Assembly : private Disasm {
     void sameLine();
     void comma();
     const uint8_t* ptr(uint32_t addr);
-    void jumpToMemory(uint32_t addr, unsigned size);
+    void jumpToMemory(uint32_t addr, unsigned size, unsigned editorIndex = 0, bool forceShowEditor = false);
     uint8_t mem8(uint32_t addr);
     uint16_t mem16(uint32_t addr);
     uint32_t mem32(uint32_t addr);
@@ -111,6 +111,8 @@ class Assembly : private Disasm {
     bool m_symbolsCachesValid = false;
 
     void rebuildSymbolsCaches();
+    void addMemoryEditorContext(uint32_t addr, int size);
+    void addMemoryEditorSubMenu(uint32_t addr, int size);
 
     bool m_showSymbols = false;
     std::string m_symbolFilter;


### PR DESCRIPTION
By default, the various Assembly widget 'Go to in Memory Editor' address shortcuts reveal the address in Memory Editor #&#x2060;1

This PR adds:
- context menu options to target a specific editor instead
- address shortcut clicks can be modified with Shift or Ctrl to target editors #&#x2060;2 and #&#x2060;3 respectively
- address value tooltips are expanded to indicate which editor they will shortcut to