### PR TITLE
Allow memory editors to export directly to a file

### DIFF
--- a/src/gui/gui.cc
+++ b/src/gui/gui.cc
@@ -733,6 +733,28 @@ void PCSX::GUI::init(std::function<void()> applyArguments) {
         g_emulator->m_gpu->partialUpdateVRAM(x, y, 1, 1, &newPixel);
     };
 
+    auto exportFn = [](ImU8* data, size_t len, size_t base_addr, std::string postfixName) {
+        std::filesystem::path writeFilepath =
+            g_system->getPersistentDir() / (s_gui->getSaveStatePrefix(true) + "mem_" + postfixName + ".bin");
+        IO<File> f(new PosixFile(writeFilepath.string(), FileOps::TRUNCATE));
+        if (!f->failed()) {
+            f->write(data, len);
+            f->close();
+            g_system->log(LogClass::UI, "Memory exported to: %s\n", writeFilepath.string().c_str());
+        } else {
+            g_system->log(LogClass::UI, "Failed to export memory to: %s\n", writeFilepath.string().c_str());
+        }
+    };
+#define EXPORT_FUNC(name) [=](ImU8* data, size_t len, size_t base_addr) { exportFn(data, len, base_addr, name); }
+    for (auto& editor : m_mainMemEditors) {
+        editor.editor.ExportFn = EXPORT_FUNC("wram");
+    }
+    m_parallelPortEditor.editor.ExportFn = EXPORT_FUNC("parallel");
+    m_scratchPadEditor.editor.ExportFn = EXPORT_FUNC("scratch");
+    m_hwrEditor.editor.ExportFn = EXPORT_FUNC("hwr");
+    m_biosEditor.editor.ExportFn = EXPORT_FUNC("bios");
+    m_vramEditor.editor.ExportFn = EXPORT_FUNC("vram");
+
     m_offscreenShaderEditor.init();
     m_outputShaderEditor.init();
 

--- a/third_party/imgui_memory_editor/imgui_memory_editor.cpp
+++ b/third_party/imgui_memory_editor/imgui_memory_editor.cpp
@@ -361,9 +361,9 @@ void MemoryEditor::DrawContents(void* mem_data_void, size_t mem_size)
 	}
 }
 
-void MemoryEditor::DrawOptionsLine(const Sizes& s, void* mem_data, size_t mem_size)
+void MemoryEditor::DrawOptionsLine(const Sizes& s, void* mem_data_void, size_t mem_size)
 {
-	IM_UNUSED(mem_data);
+	ImU8* mem_data = (ImU8*)mem_data_void;
 	ImGuiStyle& style = ImGui::GetStyle();
 	const char* format_range = OptUpperCaseHex ? "Range %0*" _PRISizeT "X..%0*" _PRISizeT "X" : "Range %0*" _PRISizeT "x..%0*" _PRISizeT "x";
 
@@ -422,6 +422,14 @@ void MemoryEditor::DrawOptionsLine(const Sizes& s, void* mem_data, size_t mem_si
                 AddrInputBuf.clear();
                 GotoAddr = 0;
                 OffsetAddr = 0;
+    }
+
+    // Export memory via a function, if available
+    if (ExportFn) {
+        ImGui::SameLine();
+        if (ImGui::Button("Export Memory")) {
+            ExportFn(mem_data, mem_size, BaseAddr);
+        }
     }
 }
 

--- a/third_party/imgui_memory_editor/imgui_memory_editor.h
+++ b/third_party/imgui_memory_editor/imgui_memory_editor.h
@@ -85,6 +85,7 @@ struct MemoryEditor
     bool            (*HighlightFn)(const ImU8* data, size_t off);//= 0      // optional handler to return Highlight property (to support non-contiguous highlighting).
     std::function<void()> PushMonoFont = nullptr;
     size_t&          OffsetAddr; // referenced from PCSX-Redux Settings
+    std::function<void(ImU8* data, size_t len, size_t base)> ExportFn = nullptr; // optional handler to export all memory data.
 
 private:
     // [Internal State]
@@ -129,7 +130,7 @@ public:
     void DrawWindow(const char* title, void* mem_data, size_t mem_size);
     // Memory Editor contents only
     void DrawContents(void* mem_data_void, size_t mem_size);
-    void DrawOptionsLine(const Sizes& s, void* mem_data, size_t mem_size);
+    void DrawOptionsLine(const Sizes& s, void* mem_data_void, size_t mem_size);
     void DrawPreviewLine(const Sizes& s, void* mem_data_void, size_t mem_size);
     // Utilities for Data Preview
     const char* DataTypeGetDesc(ImGuiDataType data_type) const;


### PR DESCRIPTION
Adds an `Export Memory` button to all CPU memory editors, which will write all memory visible to that editor to a file.

Filename format is:

`[titleID]_mem_[editorname].bin`

`editorname` is one of the following, depending on the context:
- wram
- vram
- bios
- hwr
- scratch
- parallel