### PR TITLE
psyq-obj-parser: add `INC_SLD_LINENUM_BY_WORD` opcode

### DIFF
--- a/tools/psyq-obj-parser/psyq-obj-parser.cc
+++ b/tools/psyq-obj-parser/psyq-obj-parser.cc
@@ -55,6 +55,7 @@ enum class PsyqOpcode : uint8_t {
     UNINITIALIZED = 48,
     INC_SLD_LINENUM = 50,
     INC_SLD_LINENUM_BY_BYTE = 52,
+    INC_SLD_LINENUM_BY_WORD = 54,
     SET_SLD_LINENUM = 56,
     SET_SLD_LINENUM_FILE = 58,
     END_SLD = 60,
@@ -477,6 +478,13 @@ std::unique_ptr<PsyqLnkFile> PsyqLnkFile::parse(PCSX::IO<PCSX::File> file, bool 
                 uint16_t offset = file->read<uint16_t>();
                 uint8_t _byte = file->read<uint8_t>();
                 vprint("INC_SLD_LINENUM_BY_BYTE offset {}, _byte {}\n", offset, _byte);
+
+                break;
+            }
+            case (uint8_t)PsyqOpcode::INC_SLD_LINENUM_BY_WORD: {
+                uint16_t offset = file->read<uint16_t>();
+                uint16_t _word = file->read<uint16_t>();
+                vprint("INC_SLD_LINENUM_BY_WORD offset {}, _word {}\n", offset, _word);
 
                 break;
             }


### PR DESCRIPTION
Name from https://github.com/banyaszvonat/psyq_kaitai/blob/ca95b68151e98ebb7dda0e69fa86cfbebb594ba0/psyq_obj.ksy#L204

Opcode is needed to parse some obj files included with beatmania 5thmix, reading as uint16_t allows obj to parse fine while uint32_t failed.