### PR TITLE
psyq-obj-parser: fix HI16 relocations with large addends

### DIFF
--- a/tools/psyq-obj-parser/psyq-obj-parser.cc
+++ b/tools/psyq-obj-parser/psyq-obj-parser.cc
@@ -1214,8 +1214,8 @@ bool PsyqLnkFile::Relocation::generateElf(ElfRelocationPass pass, const std::str
                 if (symbolOffset & 0x8000) {
                     hi += 1;
                 }
-                sectionData[offset + 0] = (uint8_t)(hi >> 8);
-                sectionData[offset + 1] = (uint8_t)(hi >> 0);
+                sectionData[offset + 0] = (uint8_t)(hi >> 0);
+                sectionData[offset + 1] = (uint8_t)(hi >> 8);
                 break;
             }
             case PsyqRelocType::LO16: {


### PR DESCRIPTION
There's a HI16/LO16 relocation pair with a large addend (>32767) inside the `KanjiFntOpen()` function within `LIBGPU.LIB` that isn't converted correctly by `psyq-obj-parser`, due to a bad serialization of the addend in the converted ELF object file.

Relocation with a large addend:
```
$ psyq-obj-parser KPRINTF.OBJ -o kprintf.o
    :: Generating relocation     HI16              .text::000001b8  .bss__base + 43024
      :: Skipped for this pass
    :: Generating relocation     LO16              .text::000001bc  .bss__base + 43024
      :: Skipped for this pass
```

Before fix:
```
$ mipsel-linux-gnu-objdump -dr kprintf.o
 1b8:   3c110100        lui     s1,0x100
                        1b8: R_MIPS_HI16        .bss
 1bc:   2631a810        addiu   s1,s1,-22512
                        1bc: R_MIPS_LO16        .bss
```

After fix:
```
$ mipsel-linux-gnu-objdump -dr kprintf.o
 1b8:   3c110001        lui     s1,0x1
                        1b8: R_MIPS_HI16        .bss
 1bc:   2631a810        addiu   s1,s1,-22512
                        1bc: R_MIPS_LO16        .bss
```