### PR TITLE
OpenBIOS/nugget: fix section alignment for binary includes

### DIFF
--- a/src/mips/openbios/Makefile
+++ b/src/mips/openbios/Makefile
@@ -116,13 +116,13 @@ include ../common.mk
 
 ./psexe_data.o: $(EMBED_PSEXE)
 	cp $(EMBED_PSEXE) psexe.bin
-	$(PREFIX)-objcopy -I binary --rename-section .data=.rodata,alloc,load,readonly,data,contents -O $(FORMAT) -B mips psexe.bin psexe_data.o
+	$(PREFIX)-objcopy -I binary --set-section-alignment .data=4 --rename-section .data=.rodata,alloc,load,readonly,data,contents -O $(FORMAT) -B mips psexe.bin psexe_data.o
 
 ./font1.o: charset/font1.raw
-	$(PREFIX)-objcopy -I binary --rename-section .data=.font1,alloc,load,readonly,data,contents -O $(FORMAT) -B mips charset/font1.raw font1.o
+	$(PREFIX)-objcopy -I binary --set-section-alignment .data=4 --rename-section .data=.font1,alloc,load,readonly,data,contents -O $(FORMAT) -B mips charset/font1.raw font1.o
 
 ./font2.o: charset/font2.raw
-	$(PREFIX)-objcopy -I binary --rename-section .data=.font2,alloc,load,readonly,data,contents -O $(FORMAT) -B mips charset/font2.raw font2.o
+	$(PREFIX)-objcopy -I binary --set-section-alignment .data=4 --rename-section .data=.font2,alloc,load,readonly,data,contents -O $(FORMAT) -B mips charset/font2.raw font2.o
 
 shell:
 	$(MAKE) -C ../shell shell_data.o

--- a/src/mips/shell/Makefile
+++ b/src/mips/shell/Makefile
@@ -25,7 +25,7 @@ spu.c \
 include ../common.mk
 
 shell_data.o: shell.bin
-	$(PREFIX)-objcopy -I binary --rename-section .data=.rodata,alloc,load,readonly,data,contents -O $(FORMAT) -B mips $< $@
+	$(PREFIX)-objcopy -I binary --set-section-alignment .data=4 --rename-section .data=.rodata,alloc,load,readonly,data,contents -O $(FORMAT) -B mips $< $@
 
 blip.o: blip.hit
-	$(PREFIX)-objcopy -I binary --rename-section .data=.rodata,alloc,load,readonly,data,contents -O $(FORMAT) -B mips $< $@
+	$(PREFIX)-objcopy -I binary --set-section-alignment .data=4 --rename-section .data=.rodata,alloc,load,readonly,data,contents -O $(FORMAT) -B mips $< $@


### PR DESCRIPTION
This PR adds `--set-section-alignment .data=4` to all invocations of `objcopy` in the build scripts under `src/mips`, fixing OpenBIOS crashing on startup when an executable is embedded into it through the `EMBED_PSEXE` option due to unaligned pointers.