### PR TITLE
Fix LuaJIT build when LDFLAGS is defined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ ifeq ($(UNAME_S),Darwin)
     CPPFLAGS += -stdlib=libc++
 endif
 
+LUAJIT_LDFLAGS := $(LDFLAGS)
 LDFLAGS += `pkg-config --libs $(PACKAGES)`
 
 ifeq ($(UNAME_S),Darwin)
@@ -235,10 +236,10 @@ appimage:
 
 ifeq ($(CROSS),arm64)
 third_party/luajit/src/libluajit.a:
-	$(MAKE) $(MAKEOPTS) -C third_party/luajit/src amalg HOST_CC=cc CROSS=aarch64-linux-gnu- TARGET_CFLAGS=--sysroot=/opt/cross/sysroot BUILDMODE=static CFLAGS=$(LUAJIT_CFLAGS) XCFLAGS="-DLUAJIT_ENABLE_GC64 -DLUAJIT_ENABLE_LUA52COMPAT" MACOSX_DEPLOYMENT_TARGET=10.15
+	$(MAKE) $(MAKEOPTS) -C third_party/luajit/src amalg HOST_CC=cc CROSS=aarch64-linux-gnu- TARGET_CFLAGS=--sysroot=/opt/cross/sysroot BUILDMODE=static CFLAGS=$(LUAJIT_CFLAGS) LDFLAGS=$(LUAJIT_LDFLAGS) XCFLAGS="-DLUAJIT_ENABLE_GC64 -DLUAJIT_ENABLE_LUA52COMPAT" MACOSX_DEPLOYMENT_TARGET=10.15
 else
 third_party/luajit/src/libluajit.a:
-	$(MAKE) $(MAKEOPTS) -C third_party/luajit/src amalg CC=$(CC) BUILDMODE=static CFLAGS=$(LUAJIT_CFLAGS) XCFLAGS="-DLUAJIT_ENABLE_GC64 -DLUAJIT_ENABLE_LUA52COMPAT" MACOSX_DEPLOYMENT_TARGET=10.15
+	$(MAKE) $(MAKEOPTS) -C third_party/luajit/src amalg CC=$(CC) BUILDMODE=static CFLAGS=$(LUAJIT_CFLAGS) LDFLAGS=$(LUAJIT_LDFLAGS) XCFLAGS="-DLUAJIT_ENABLE_GC64 -DLUAJIT_ENABLE_LUA52COMPAT" MACOSX_DEPLOYMENT_TARGET=10.15
 endif
 
 $(TARGET): $(OBJECTS)


### PR DESCRIPTION
The LuaJIT dependency was failing to compile when `LDFLAGS` was defined in the command line. This was uncovered in the AUR package when changes to makepkg flags caused LDFLAGS to be set when building the package without explicitly disabling `buildoptions`.

My understanding is that when LDFLAGS is set, the incorrect options (`pkgconfig --libraries ...`) were being picked up by the LuaJIT Makefile. This PR defines a separate `LUAJIT_LDFLAGS` variable, initialized to `LDFLAGS`, but without the additional options added by the pcsx-redux build, which allows any host options (like the security flags set by Arch's makepkg) to still be passed to LuaJIT without breaking it.

Please let me know if you have any feedback.

Thanks!