### PR TITLE
Add CI for AUR Package

### DIFF
--- a/.github/workflows/linux-aur.yml
+++ b/.github/workflows/linux-aur.yml
@@ -1,0 +1,19 @@
+name: Linux CI AUR
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: arch-latest
+    container:
+      image: archlinux:latest
+    steps:
+      - name: Build AUR package
+      - run: |
+          pacman -S capstone curl ffmpeg freetype2 glfw libuv sdl2 zlib git make pkg-config
+          git clone https://aur.archlinux.org/pcsx-redux-git.git
+          cd pcsx-redux-git && makepkg

--- a/.github/workflows/linux-aur.yml
+++ b/.github/workflows/linux-aur.yml
@@ -22,6 +22,7 @@ jobs:
           passwd -d builduser
       - name: Build AUR Package
         run: |
-          sudo -u builduser git clone https://aur.archlinux.org/pcsx-redux-git.git
+          git clone https://aur.archlinux.org/pcsx-redux-git.git
+          chown -R builduser:builduser pcsx-redux-git
           cd pcsx-redux-git
-          sudo -u makepkg
+          sudo -u builduser makepkg

--- a/.github/workflows/linux-aur.yml
+++ b/.github/workflows/linux-aur.yml
@@ -9,12 +9,12 @@ on:
 
 jobs:
   build:
-    runs-on: arch-latest
+    runs-on: ubuntu-latest
     container:
       image: archlinux:latest
     steps:
       - name: Build AUR Package
         run: |
-          pacman -S capstone curl ffmpeg freetype2 glfw libuv sdl2 zlib git make pkg-config
+          pacman -S --noconfirm pcapstone curl ffmpeg freetype2 glfw libuv sdl2 zlib git make pkg-config
           git clone https://aur.archlinux.org/pcsx-redux-git.git
           cd pcsx-redux-git && makepkg

--- a/.github/workflows/linux-aur.yml
+++ b/.github/workflows/linux-aur.yml
@@ -15,6 +15,6 @@ jobs:
     steps:
       - name: Build AUR Package
         run: |
-          pacman -S --noconfirm pcapstone curl ffmpeg freetype2 glfw libuv sdl2 zlib git make pkg-config
+          pacman -Syu --noconfirm pcapstone curl ffmpeg freetype2 glfw libuv sdl2 zlib git make pkg-config
           git clone https://aur.archlinux.org/pcsx-redux-git.git
           cd pcsx-redux-git && makepkg

--- a/.github/workflows/linux-aur.yml
+++ b/.github/workflows/linux-aur.yml
@@ -15,6 +15,6 @@ jobs:
     steps:
       - name: Build AUR Package
         run: |
-          pacman -Syu --noconfirm pcapstone curl ffmpeg freetype2 glfw libuv sdl2 zlib git make pkg-config
+          pacman -Syu --noconfirm capstone curl ffmpeg freetype2 glfw libuv sdl2 zlib git make pkg-config
           git clone https://aur.archlinux.org/pcsx-redux-git.git
           cd pcsx-redux-git && makepkg

--- a/.github/workflows/linux-aur.yml
+++ b/.github/workflows/linux-aur.yml
@@ -13,8 +13,15 @@ jobs:
     container:
       image: archlinux:latest
     steps:
+      - name: Install dependencies
+        run: | 
+          pacman -Syu --noconfirm --needed capstone curl ffmpeg freetype2 glfw libuv sdl2 zlib git make pkg-config sudo
+      - name: Create builduser
+        run: |
+          useradd builduser -m
+          passwd -d builduser
       - name: Build AUR Package
         run: |
-          pacman -Syu --noconfirm capstone curl ffmpeg freetype2 glfw libuv sdl2 zlib git make pkg-config
-          git clone https://aur.archlinux.org/pcsx-redux-git.git
-          cd pcsx-redux-git && makepkg
+          sudo -u builduser git clone https://aur.archlinux.org/pcsx-redux-git.git
+          cd pcsx-redux-git
+          sudo -u makepkg

--- a/.github/workflows/linux-aur.yml
+++ b/.github/workflows/linux-aur.yml
@@ -12,8 +12,8 @@ jobs:
     container:
       image: archlinux:latest
     steps:
-      - name: Build AUR package
-      - run: |
+      - name: Build AUR Package
+        run: |
           pacman -S capstone curl ffmpeg freetype2 glfw libuv sdl2 zlib git make pkg-config
           git clone https://aur.archlinux.org/pcsx-redux-git.git
           cd pcsx-redux-git && makepkg

--- a/.github/workflows/linux-aur.yml
+++ b/.github/workflows/linux-aur.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: | 
-          pacman -Syu --noconfirm --needed capstone curl ffmpeg freetype2 glfw libuv sdl2 zlib git make pkg-config sudo
+          pacman -Syu --noconfirm --needed capstone curl ffmpeg freetype2 glfw libuv sdl2 zlib git make pkg-config sudo base-devel pacman-contrib
       - name: Create builduser
         run: |
           useradd builduser -m

--- a/.github/workflows/linux-aur.yml
+++ b/.github/workflows/linux-aur.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - aur-package-ci
   pull_request:
 
 jobs:

--- a/.github/workflows/linux-aur.yml
+++ b/.github/workflows/linux-aur.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - aur-package-ci
   pull_request:
 
 jobs:


### PR DESCRIPTION
This PR adds a CI task for building the [pcsx-redux AUR Package](https://aur.archlinux.org/packages/pcsx-redux-git), which will hopefully alert us when things break and the PKGBUILD needs to be updated (e.g., new submodules, makepkg flags, etc.).