### PR TITLE
Allowing psyqo to optionally take over the kernel.

### DIFF
--- a/src/mips/common/hardware/flushcache.s
+++ b/src/mips/common/hardware/flushcache.s
@@ -38,9 +38,12 @@ SOFTWARE.
     .section .text.flushCache, "ax", @progbits
     .align 2
     .set noreorder
+    .global _ZN5psyqo6Kernel10flushCacheEv
+    .type _ZN5psyqo6Kernel10flushCacheEv, @function
     .global flushCache
     .type flushCache, @function
 
+_ZN5psyqo6Kernel10flushCacheEv:
 flushCache:
     /* Saves $ra to $t6, and the current cop0 Status register to $t0, and ensure we
        are running from uncached ram. */

--- a/src/mips/common/syscalls/syscalls.h
+++ b/src/mips/common/syscalls/syscalls.h
@@ -57,6 +57,12 @@ static __attribute__((always_inline)) int changeThreadSubFunction(uint32_t addre
 }
 
 /* A0 table */
+static __attribute__((always_inline)) size_t syscall_write(int fd, const void *buf, size_t size) {
+    register int n asm("t1") = 0x03;
+    __asm__ volatile("" : "=r"(n) : "r"(n));
+    return ((size_t (*)(int, const void *, size_t))0xa0)(fd, buf, size);
+}
+
 static __attribute__((always_inline)) int syscall_setjmp(struct JmpBuf *buf) {
     register int n asm("t1") = 0x13;
     __asm__ volatile("" : "=r"(n) : "r"(n));
@@ -177,6 +183,12 @@ static __attribute__((always_inline)) void syscall__exit(int code) {
     register int n asm("t1") = 0x3a;
     __asm__ volatile("" : "=r"(n) : "r"(n));
     ((void (*)(int))0xa0)(code);
+}
+
+static __attribute__((always_inline)) void syscall_puts(const char *msg) {
+    register int n asm("t1") = 0x3e;
+    __asm__ volatile("" : "=r"(n) : "r"(n));
+    ((void (*)(const char *))0xa0)(msg);
 }
 
 // doing this one in raw inline assembly would prove tricky,
@@ -438,12 +450,6 @@ static __attribute__((always_inline)) void syscall_putchar(int c) {
     register int n asm("t1") = 0x3d;
     __asm__ volatile("" : "=r"(n) : "r"(n));
     ((void (*)(int))0xb0)(c);
-}
-
-static __attribute__((always_inline)) void syscall_puts(const char *msg) {
-    register int n asm("t1") = 0x3f;
-    __asm__ volatile("" : "=r"(n) : "r"(n));
-    ((void (*)(const char *))0xb0)(msg);
 }
 
 static __attribute__((always_inline)) int syscall_addDevice(const struct Device *device) {

--- a/src/mips/psyqo/Makefile
+++ b/src/mips/psyqo/Makefile
@@ -9,10 +9,12 @@ SRCS = \
 ../common/crt0/cxxglue.c \
 ../common/crt0/memory-c.c \
 ../common/crt0/memory-s.s \
+../common/hardware/flushcache.s \
 ../common/syscalls/printf.s \
 $(wildcard src/hardware/*.cpp) \
 $(wildcard src/*.cpp) \
 $(wildcard src/*.c) \
+$(wildcard src/*.s) \
 
 CPPFLAGS = -I../../../third_party/EASTL/include -I../../../third_party/EABase/include/Common
 CXXFLAGS = -std=c++20

--- a/src/mips/psyqo/application.hh
+++ b/src/mips/psyqo/application.hh
@@ -118,6 +118,7 @@ class Application {
     eastl::fixed_vector<Scene*, 16> m_scenesStack;
 
     friend class Scene;
+    friend void Kernel::takeOverKernel();
 };
 
 }  // namespace psyqo

--- a/src/mips/psyqo/examples/hello-nokernel/Makefile
+++ b/src/mips/psyqo/examples/hello-nokernel/Makefile
@@ -1,0 +1,14 @@
+TARGET = hello
+TYPE = ps-exe
+
+SRCS = \
+hello.cpp \
+
+LDFLAGS += -Xlinker --defsym=TLOAD_ADDR=0x80001000
+
+ifeq ($(TEST),true)
+CPPFLAGS = -Werror
+endif
+CXXFLAGS = -std=c++20
+
+include ../../psyqo.mk

--- a/src/mips/psyqo/font.hh
+++ b/src/mips/psyqo/font.hh
@@ -78,7 +78,8 @@ class FontBase {
      * method, you should not call initialize() afterwards. The Kernel rom font is a 16x15 font created
      * by Sony, and built into the PSX rom chip. Its appearance is variable, depending on the version
      * of the PSX bios. It may not be available on all PSX models. The footprint for this font is 192
-     * bytes of read-only data, and a 256x90x4bpp texture.
+     * bytes of read-only data, and a 256x90x4bpp texture. This font isn't going to work if psyqo
+     * took over the kernel. See the `Kernel` namespace for more information.
      */
     void uploadKromFont(GPU& gpu, Vertex location = {{.x = 960, .y = 422}});
 

--- a/src/mips/psyqo/gpu.hh
+++ b/src/mips/psyqo/gpu.hh
@@ -502,6 +502,7 @@ class GPU {
     void chain(uint32_t *first, uint32_t *last, size_t count);
     void scheduleOTC(uint32_t *start, uint32_t count);
     void checkOTCAndTriggerCallback();
+    void prepareForTakeover();
 
     eastl::function<void(void)> m_dmaCallback = nullptr;
     unsigned m_refreshRate = 0;
@@ -538,6 +539,7 @@ class GPU {
 
     void flip();
     friend class Application;
+    friend void psyqo::Kernel::takeOverKernel();
 };
 
 }  // namespace psyqo

--- a/src/mips/psyqo/simplepad.hh
+++ b/src/mips/psyqo/simplepad.hh
@@ -39,7 +39,9 @@ namespace psyqo {
  * PAD interface, and has the same caveats, namely that it should be
  * initialized prior using the BIOS' memory card functions, and that
  * polling will alternate between the two pads at each frame when two
- * pads are connected, which can introduce input lags.
+ * pads are connected, which can introduce input lags. This class
+ * will not be able to be used if the kernel is taken over. See the
+ * `Kernel` namespace for more information.
  */
 
 class SimplePad {

--- a/src/mips/psyqo/src/application.cpp
+++ b/src/mips/psyqo/src/application.cpp
@@ -33,11 +33,11 @@ SOFTWARE.
 
 int psyqo::Application::run() {
     Kernel::fastEnterCriticalSection();
+    Kernel::Internal::prepare(*this);
     syscall_puts("*** PSYQo Application - starting ***\n");
     psyqo_free(psyqo_malloc(1));
     ramsyscall_printf("Current heap start: %p\n", psyqo_heap_start());
     ramsyscall_printf("Current heap end: %p\n", psyqo_heap_end());
-    Kernel::Internal::prepare();
     prepare();
     Kernel::fastLeaveCriticalSection();
     while (true) {

--- a/src/mips/psyqo/src/font.cpp
+++ b/src/mips/psyqo/src/font.cpp
@@ -35,13 +35,13 @@ SOFTWARE.
 #include "psyqo/gpu.hh"
 #include "system-font.inc"
 
-
 void psyqo::FontBase::uploadSystemFont(psyqo::GPU& gpu, psyqo::Vertex location) {
     initialize(gpu, location, {{.w = 8, .h = 16}});
     unpackFont(gpu, s_systemFont, location, {{.w = 256, .h = 48}});
 }
 
 void psyqo::FontBase::uploadKromFont(psyqo::GPU& gpu, psyqo::Vertex location) {
+    Kernel::assert(!Kernel::isKernelTakenOver(), "uploadKromFont can't be used after kernel takeover");
     static constexpr uint16_t sjisLookup[] = {
         0x0000,  // space
         0x8149,  // !

--- a/src/mips/psyqo/src/gpu.cpp
+++ b/src/mips/psyqo/src/gpu.cpp
@@ -110,13 +110,21 @@ void psyqo::GPU::initialize(const psyqo::GPU::Configuration &config) {
     }
 
     // Install VBlank interrupt handler
-    uint32_t event = Kernel::openEvent(0xf2000003, 2, EVENT_MODE_CALLBACK, [this]() {
-        m_frameCount++;
-        eastl::atomic_signal_fence(eastl::memory_order_release);
-    });
-    syscall_enableEvent(event);
-    syscall_enableTimerIRQ(3);
-    syscall_setTimerAutoAck(3, 1);
+    if (Kernel::isKernelTakenOver()) {
+        // In this case, psyqo's assembly code will handle the VBlank interrupt and
+        // increment the frame counter. But we need to adjust the assembly code to
+        // own the frame counter pointer, and that'll be done before. All we need to
+        // do here is to enable the VBlank interrupt.
+        Hardware::CPU::IMask.set(Hardware::CPU::IRQ::VBlank);
+    } else {
+        uint32_t event = Kernel::openEvent(0xf2000003, 2, EVENT_MODE_CALLBACK, [this]() {
+            m_frameCount++;
+            eastl::atomic_signal_fence(eastl::memory_order_release);
+        });
+        syscall_enableEvent(event);
+        syscall_enableTimerIRQ(3);
+        syscall_setTimerAutoAck(3, 1);
+    }
     if (config.clearVRAM) {
         Prim::FastFill ff;
         ff.rect = Rect{0, 0, 1024, 512};
@@ -355,8 +363,7 @@ void psyqo::GPU::uploadToVRAM(const uint16_t *data, Rect region, eastl::function
 
     // Activating VRAM DMA upload mode
     Hardware::GPU::Ctrl = 0x04000002;
-    while ((Hardware::GPU::Ctrl & uint32_t(0x10000000)) == 0)
-        ;
+    while ((Hardware::GPU::Ctrl & uint32_t(0x10000000)) == 0);
     DMA_CTRL[DMA_GPU].MADR = ptr;
     DMA_CTRL[DMA_GPU].BCR = bcr;
     eastl::atomic_signal_fence(eastl::memory_order_release);
@@ -407,8 +414,7 @@ void psyqo::GPU::scheduleNormalDMA(uintptr_t data, size_t count) {
     bcr <<= 16;
     bcr |= bs;
 
-    while ((Hardware::GPU::Ctrl & uint32_t(0x10000000)) == 0)
-        ;
+    while ((Hardware::GPU::Ctrl & uint32_t(0x10000000)) == 0);
     DMA_CTRL[DMA_GPU].MADR = data;
     DMA_CTRL[DMA_GPU].BCR = bcr;
     eastl::atomic_signal_fence(eastl::memory_order_release);
@@ -466,8 +472,7 @@ void psyqo::GPU::sendChain(eastl::function<void()> &&callback, DMA::DmaCallback 
 
 void psyqo::GPU::scheduleChainedDMA(uintptr_t head) {
     Kernel::assert((DMA_CTRL[DMA_GPU].CHCR & 0x01000000) == 0, "GPU DMA busy");
-    while ((Hardware::GPU::Ctrl & uint32_t(0x10000000)) == 0)
-        ;
+    while ((Hardware::GPU::Ctrl & uint32_t(0x10000000)) == 0);
     DMA_CTRL[DMA_GPU].MADR = head;
     eastl::atomic_signal_fence(eastl::memory_order_release);
     DMA_CTRL[DMA_GPU].CHCR = 0x01000401;
@@ -573,3 +578,15 @@ void psyqo::GPU::pumpCallbacks() {
 }
 
 void psyqo::GPU::scheduleOTC(uint32_t *start, uint32_t count) { m_OTCs[m_parity].emplace_back(start, count); }
+
+extern uint16_t psyqoExceptionHandlerAdjustFrameCount[];
+
+void psyqo::GPU::prepareForTakeover() {
+    uintptr_t frameCountPtr = reinterpret_cast<uintptr_t>(&m_frameCount);
+    uint16_t hi = frameCountPtr >> 16;
+    uint16_t lo = frameCountPtr & 0xffff;
+    if (lo >= 0x8000) hi++;
+    psyqoExceptionHandlerAdjustFrameCount[0] = hi;
+    psyqoExceptionHandlerAdjustFrameCount[2] = lo;
+    psyqoExceptionHandlerAdjustFrameCount[8] = lo;
+}

--- a/src/mips/psyqo/src/kernel.cpp
+++ b/src/mips/psyqo/src/kernel.cpp
@@ -26,6 +26,7 @@ SOFTWARE.
 
 #include "psyqo/kernel.hh"
 
+#include <EASTL/array.h>
 #include <EASTL/atomic.h>
 #include <EASTL/bonus/fixed_ring_buffer.h>
 #include <EASTL/fixed_vector.h>
@@ -36,13 +37,21 @@ SOFTWARE.
 #include "common/kernel/events.h"
 #include "common/syscalls/syscalls.h"
 #include "common/util/encoder.hh"
+#include "psyqo/application.hh"
 #include "psyqo/hardware/cpu.hh"
 #include "psyqo/spu.hh"
+#include "psyqo/xprintf.h"
 
 namespace {
 
-typedef void (*KernelEventFunction)();
+bool s_tookOverKernel = false;
 
+eastl::array<eastl::fixed_vector<eastl::function<void()>, 12>, static_cast<size_t>(psyqo::Kernel::IRQ::Max) - 1>*
+    s_irqHandlers = nullptr;
+eastl::array<eastl::fixed_vector<eastl::function<void()>, 12>, static_cast<size_t>(psyqo::Kernel::IRQ::Max) - 1>
+    s_irqHandlersStorage;
+
+typedef void (*KernelEventFunction)();
 struct Function {
     uint32_t code[2] = {0, 0};
     eastl::function<void()> lambda = nullptr;
@@ -51,14 +60,12 @@ struct Function {
         return reinterpret_cast<KernelEventFunction>(p);
     }
 };
-
 constexpr unsigned SLOTS = 16;
-
 Function s_functions[SLOTS];
-
 void trampoline(int slot) { s_functions[slot].lambda(); }
 
 KernelEventFunction allocateEventFunction(eastl::function<void()>&& lambda) {
+    psyqo::Kernel::assert(!s_tookOverKernel, "allocateEventFunction: kernel has been taken over");
     for (unsigned slot = 0; slot < SLOTS; slot++) {
         if (!s_functions[slot].lambda) {
             s_functions[slot].lambda = eastl::move(lambda);
@@ -69,7 +76,74 @@ KernelEventFunction allocateEventFunction(eastl::function<void()>&& lambda) {
     __builtin_unreachable();
 }
 
+int printfStub(const char* fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    int r = vxprintf([](const char* data, int size, void*) { syscall_write(1, data, size); }, nullptr, fmt, args);
+    va_end(args);
+    return r;
+}
+
 }  // namespace
+
+bool psyqo::Kernel::isKernelTakenOver() { return s_tookOverKernel; }
+
+extern "C" {
+void psyqoExceptionHandler(uint32_t ireg) {
+    constexpr uint32_t start = static_cast<uint32_t>(psyqo::Kernel::IRQ::GPU) - 1;
+    constexpr uint32_t end = static_cast<uint32_t>(psyqo::Kernel::IRQ::Max) - 1;
+    uint32_t mask = 1 << (start + 1);
+    for (uint32_t irq = start; irq < end; irq++, mask <<= 1) {
+        if ((ireg & mask) == 0) continue;
+        auto& handlers = s_irqHandlersStorage[irq];
+        for (auto& handler : handlers) handler();
+    }
+    psyqo::Hardware::CPU::IReg.clear();
+}
+void psyqoAssemblyExceptionHandler();
+}
+
+void psyqo::Kernel::takeOverKernel() {
+    if (s_tookOverKernel) return;
+    s_irqHandlers = &s_irqHandlersStorage;
+    s_tookOverKernel = true;
+    Internal::addInitializer([](Application& application) {
+        __builtin_memset(nullptr, 0, 0x1000);
+        application.gpu().prepareForTakeover();
+        uint32_t* const exceptionHandler = reinterpret_cast<uint32_t*>(0x80);
+        exceptionHandler[0] = Mips::Encoder::j(reinterpret_cast<uint32_t>(psyqoAssemblyExceptionHandler));
+        exceptionHandler[1] = Mips::Encoder::nop();
+        uint32_t* const handlers = reinterpret_cast<uint32_t*>(0xa0);
+        // We want to redirect printf, but nothing else.
+        uintptr_t printfAddr = reinterpret_cast<uintptr_t>(printfStub);
+        uint16_t hi = printfAddr >> 16;
+        uint16_t lo = printfAddr & 0xffff;
+        if (lo >= 0x8000) hi++;
+        // a0
+        handlers[0] = Mips::Encoder::addiu(Mips::Encoder::Reg::T0, Mips::Encoder::Reg::R0, 0x3f);
+        handlers[1] = Mips::Encoder::beq(Mips::Encoder::Reg::T1, Mips::Encoder::Reg::T0, 12);
+        handlers[2] = Mips::Encoder::lui(Mips::Encoder::Reg::T0, hi);
+        handlers[3] = Mips::Encoder::nop();
+        // b0
+        handlers[4] = Mips::Encoder::jr(Mips::Encoder::Reg::RA);
+        handlers[5] = Mips::Encoder::addiu(Mips::Encoder::Reg::T0, Mips::Encoder::Reg::T0, lo);
+        handlers[6] = Mips::Encoder::jr(Mips::Encoder::Reg::T0);
+        handlers[7] = Mips::Encoder::nop();
+        // c0
+        handlers[8] = Mips::Encoder::jr(Mips::Encoder::Reg::RA);
+        handlers[9] = Mips::Encoder::nop();
+        flushCache();
+    });
+}
+
+void psyqo::Kernel::queueIRQHandler(IRQ irq, eastl::function<void()>&& lambda) {
+    Kernel::assert(irq != IRQ::VBlank, "queueIRQHandler: VBlank cannot be queued");
+    auto& handlers = *s_irqHandlers;
+    size_t index = static_cast<size_t>(irq) - 1;
+    Kernel::assert(index < handlers.size(), "queueIRQHandler: invalid irq");
+    Kernel::assert(s_tookOverKernel, "queueIRQHandler: kernel not taken over");
+    handlers[index].push_back(eastl::move(lambda));
+}
 
 [[noreturn]] void psyqo::Kernel::abort(const char* msg, std::source_location loc) {
     fastEnterCriticalSection();
@@ -151,16 +225,46 @@ void psyqo::Kernel::unregisterDmaEvent(unsigned slot) {
 
 namespace {
 auto& getInitializers() {
-    static eastl::fixed_vector<eastl::function<void()>, 12> initializers;
+    static eastl::fixed_vector<eastl::function<void(psyqo::Application&)>, 12> initializers;
     return initializers;
 }
 }  // namespace
 
-void psyqo::Kernel::Internal::addInitializer(eastl::function<void()>&& lambda) {
+void psyqo::Kernel::Internal::addInitializer(eastl::function<void(Application&)>&& lambda) {
     getInitializers().push_back(eastl::move(lambda));
 }
 
-void psyqo::Kernel::Internal::prepare() {
+namespace {
+void dmaIRQ() {
+    psyqo::Hardware::CPU::IReg.clear(psyqo::Hardware::CPU::IRQ::DMA);
+    uint32_t dicr = psyqo::Hardware::CPU::DICR;
+    uint32_t dirqs = dicr >> 24;
+    dicr &= 0xff7fff;
+    uint32_t ack = 0x80;
+
+    for (unsigned irq = 0; irq < static_cast<unsigned>(psyqo::Kernel::DMA::Max); irq++) {
+        uint32_t mask = 1 << irq;
+        if (dirqs & mask) {
+            ack |= mask;
+        }
+    }
+
+    ack <<= 24;
+    dicr |= ack;
+    psyqo::Hardware::CPU::DICR = dicr;
+
+    for (unsigned irq = 0; irq < static_cast<unsigned>(psyqo::Kernel::DMA::Max); irq++) {
+        uint32_t mask = 1 << irq;
+        if (dirqs & mask) {
+            for (auto& lambda : s_dmaCallbacks[irq]) {
+                if (lambda) lambda();
+            }
+        }
+    }
+}
+}  // namespace
+
+void psyqo::Kernel::Internal::prepare(Application& application) {
     SPU::reset();
     Hardware::CPU::IMask.clear();
     Hardware::CPU::IReg.clear();
@@ -177,53 +281,37 @@ void psyqo::Kernel::Internal::prepare() {
         s_functions[slot].code[0] = Mips::Encoder::j(reinterpret_cast<uint32_t>(trampoline));
         s_functions[slot].code[1] = Mips::Encoder::addiu(Mips::Encoder::Reg::A0, Mips::Encoder::Reg::R0, slot);
     }
-    syscall_flushCache();
-    __builtin_memset(*(void**)0x100, 0, *(uint32_t*)0x104);
-    __builtin_memset(*(void**)0x120, 0, *(uint32_t*)0x124);
-    syscall_setDefaultExceptionJmpBuf();
-    syscall_enqueueSyscallHandler(0);
-    syscall_enqueueIrqHandler(3);
-    syscall_enqueueRCntIrqs(1);
-    uint32_t event = syscall_openEvent(EVENT_DMA, 0x1000, EVENT_MODE_CALLBACK, []() {
-        Hardware::CPU::IReg.clear(Hardware::CPU::IRQ::DMA);
-        uint32_t dicr = Hardware::CPU::DICR;
-        uint32_t dirqs = dicr >> 24;
-        dicr &= 0xff7fff;
-        uint32_t ack = 0x80;
-
-        for (unsigned irq = 0; irq < static_cast<unsigned>(DMA::Max); irq++) {
-            uint32_t mask = 1 << irq;
-            if (dirqs & mask) {
-                ack |= mask;
-            }
-        }
-
-        ack <<= 24;
-        dicr |= ack;
-        Hardware::CPU::DICR = dicr;
-
-        for (unsigned irq = 0; irq < static_cast<unsigned>(DMA::Max); irq++) {
-            uint32_t mask = 1 << irq;
-            if (dirqs & mask) {
-                for (auto& lambda : s_dmaCallbacks[irq]) {
-                    if (lambda) lambda();
-                }
-            }
-        }
-    });
-    syscall_enableEvent(event);
+    if (!s_tookOverKernel) {
+        syscall_flushCache();
+        struct KernelData {
+            void* data;
+            uint32_t size;
+        };
+        KernelData* const handlers = reinterpret_cast<KernelData*>(0x100);
+        KernelData* const events = reinterpret_cast<KernelData*>(0x120);
+        __builtin_memset(handlers->data, 0, handlers->size);
+        __builtin_memset(events->data, 0, events->size);
+        syscall_setDefaultExceptionJmpBuf();
+        syscall_enqueueSyscallHandler(0);
+        syscall_enqueueIrqHandler(3);
+        syscall_enqueueRCntIrqs(1);
+        uint32_t event = syscall_openEvent(EVENT_DMA, 0x1000, EVENT_MODE_CALLBACK, dmaIRQ);
+        syscall_enableEvent(event);
+    } else {
+        queueIRQHandler(IRQ::DMA, dmaIRQ);
+    }
     Hardware::CPU::IMask.set(Hardware::CPU::IRQ::DMA);
     dicr = Hardware::CPU::DICR;
     dicr &= 0xffffff;
     dicr |= 0x800000;
     Hardware::CPU::DICR = dicr;
 
-    for (auto& i : getInitializers()) i();
+    for (auto& i : getInitializers()) i(application);
 }
 
 namespace {
 uint32_t s_flag = 0;
-eastl::fixed_ring_buffer<eastl::function<void()>, 128> s_callbacks(128);
+eastl::fixed_ring_buffer<eastl::function<void()>, 32> s_callbacks(32);
 }  // namespace
 
 void psyqo::Kernel::queueCallback(eastl::function<void()>&& lambda) {
@@ -255,18 +343,15 @@ void psyqo::Kernel::Internal::pumpCallbacks() {
 }
 
 namespace {
-auto& getBeginFrameEvents() {
-    static eastl::fixed_vector<eastl::function<void()>, 128> beginFrameEvents;
-    return beginFrameEvents;
-}
+eastl::fixed_vector<eastl::function<void()>, 32> s_beginFrameEvents;
 }  // namespace
 
 void psyqo::Kernel::Internal::addOnFrame(eastl::function<void()>&& lambda) {
-    getBeginFrameEvents().push_back(eastl::move(lambda));
+    s_beginFrameEvents.push_back(eastl::move(lambda));
 }
 
 void psyqo::Kernel::Internal::beginFrame() {
-    for (auto& f : getBeginFrameEvents()) {
+    for (auto& f : s_beginFrameEvents) {
         f();
     }
 }

--- a/src/mips/psyqo/src/simplepad.cpp
+++ b/src/mips/psyqo/src/simplepad.cpp
@@ -30,6 +30,7 @@ SOFTWARE.
 #include "psyqo/kernel.hh"
 
 void psyqo::SimplePad::initialize() {
+    Kernel::assert(!Kernel::isKernelTakenOver(), "SimplePad can't be used after kernel takeover");
     syscall_initPad(m_padData[0], sizeof(m_padData[0]), m_padData[1], sizeof(m_padData[1]));
     syscall_startPad();
     __builtin_memset(m_padData[0], 0xff, sizeof(m_padData[0]));

--- a/src/mips/psyqo/src/vector.s
+++ b/src/mips/psyqo/src/vector.s
@@ -1,0 +1,133 @@
+/*
+
+MIT License
+
+Copyright (c) 2024 PCSX-Redux authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+    .section .text.exceptionHandler, "ax", @progbits
+    .set push
+    .set noreorder
+    .set noat
+    .align 2
+    .global psyqoAssemblyExceptionHandler
+    .global psyqoExceptionHandler
+    .global psyqoExceptionHandlerAdjustFrameCount
+    .type psyqoAssemblyExceptionHandler, @function
+
+psyqoAssemblyExceptionHandler:
+    sw    $at, 0x100($0)
+    sw    $v0, 0x104($0)
+    sw    $v1, 0x108($0)
+    sw    $a0, 0x10c($0)
+
+    mfc0  $v0, $13         /* $v0 = Cause */
+    mfc0  $k1, $14         /* $k1 = EPC */
+    lui   $k0, 0x1f80      /* $k0 = hardware registers base */
+    lw    $v1, 0($k1)      /* $v1 = instruction that caused the exception */
+    andi  $v0, 0x7c        /* Test for what kind of exception */
+.Lstop:                    /* psyqo will only support IRQs, aka 0 */
+    bnez  $v0, .Lstop      /* Anything else and we just stop - $v0 available again */
+    srl   $v1, 24          /* \                                      */
+    andi  $v1, 0xfe        /*  | Test if we were in a cop2 operation */
+    li    $at, 0x4a        /* /                                      */
+    lw    $a0, 0x1070($k0) /* $a0 = IREG */
+    bne   $v1, $at, .LnoCOP2adjustmentNeeded
+    nop
+    addiu $k1, 4           /* If we were in cop2, we need to adjust the EPC */
+.LnoCOP2adjustmentNeeded:
+    andi  $v1, $a0, 1      /* Is it VBlank ? */
+    beqz  $v1, .LnotVBlank
+    andi  $v1, $a0, 0xfffe
+    sw    $v1, 0x1070($k0) /* ACK VBlank IRQ, $k0 not needed anymore */
+psyqoExceptionHandlerAdjustFrameCount:
+    lui   $k0, 0
+    lw    $v0, 0($k0)      /* $v0 = m_frameCount */
+    lw    $at, 0x100($0)   /* Load the old at */
+    addiu $v0, 1           /* Increment m_frameCount */
+    sw    $v0, 0($k0)      /* Store m_frameCount */
+    lw    $v0, 0x104($0)   /* Load the old v0 */
+    lw    $v1, 0x108($0)   /* Load the old v1 */
+    lw    $a0, 0x10c($0)   /* Load the old a0 */
+    jr    $k1              /* Exit the exception handler */
+    rfe
+
+.LnotVBlank:
+    /* We want to call into C++ now, so we need to save the rest of the registers */
+    sw    $a1, 0x110($0)
+    sw    $a2, 0x114($0)
+    sw    $a3, 0x118($0)
+    sw    $t0, 0x11c($0)
+    sw    $t1, 0x120($0)
+    sw    $t2, 0x124($0)
+    sw    $t3, 0x128($0)
+    sw    $t4, 0x12c($0)
+    sw    $t5, 0x130($0)
+    sw    $t6, 0x134($0)
+    sw    $t7, 0x138($0)
+    sw    $s0, 0x13c($0)
+    sw    $s1, 0x140($0)
+    sw    $s2, 0x144($0)
+    sw    $s3, 0x148($0)
+    sw    $s4, 0x14c($0)
+    sw    $s5, 0x150($0)
+    sw    $s6, 0x154($0)
+    sw    $s7, 0x158($0)
+    sw    $t8, 0x15c($0)
+    sw    $t9, 0x160($0)
+    sw    $gp, 0x164($0)
+    sw    $sp, 0x168($0)
+    sw    $fp, 0x16c($0)
+    sw    $ra, 0x170($0)
+
+    /* Call the C++ exception handler while adjusting the stack */
+    jal   psyqoExceptionHandler
+    li    $sp, 0x1000 - 16
+
+    /* Restore the registers and exit */
+    lw    $a1, 0x110($0)
+    lw    $a2, 0x114($0)
+    lw    $a3, 0x118($0)
+    lw    $t0, 0x11c($0)
+    lw    $t1, 0x120($0)
+    lw    $t2, 0x124($0)
+    lw    $t3, 0x128($0)
+    lw    $t4, 0x12c($0)
+    lw    $t5, 0x130($0)
+    lw    $t6, 0x134($0)
+    lw    $t7, 0x138($0)
+    lw    $s0, 0x13c($0)
+    lw    $s1, 0x140($0)
+    lw    $s2, 0x144($0)
+    lw    $s3, 0x148($0)
+    lw    $s4, 0x14c($0)
+    lw    $s5, 0x150($0)
+    lw    $s6, 0x154($0)
+    lw    $s7, 0x158($0)
+    lw    $t8, 0x15c($0)
+    lw    $t9, 0x160($0)
+    lw    $gp, 0x164($0)
+    lw    $sp, 0x168($0)
+    lw    $fp, 0x16c($0)
+    lw    $ra, 0x170($0)
+    jr    $k1
+    rfe


### PR DESCRIPTION
This adds the call `psyqo::Kernel::takeOverKernel()`, which allows psyqo to optionally wipe the kernel and install its own.