### PR TITLE
Add Icache flush line on clear from memory

### DIFF
--- a/src/core/psxinterpreter.cc
+++ b/src/core/psxinterpreter.cc
@@ -1586,10 +1586,10 @@ void InterpretedCPU::Execute() {
 
 void InterpretedCPU::Clear(uint32_t Addr, uint32_t Size) 
 { 
-    for (auto i = 0; i < Size ; i ++)
+    for (auto i = 0; i < Size ; i+=4)
     {
         flushICacheLine(Addr);
-        Addr += 4;
+        Addr += 16;
     }
 }
 

--- a/src/core/psxinterpreter.cc
+++ b/src/core/psxinterpreter.cc
@@ -1583,7 +1583,16 @@ void InterpretedCPU::Execute() {
         }
     }
 }
-void InterpretedCPU::Clear(uint32_t Addr, uint32_t Size) {}
+
+void InterpretedCPU::Clear(uint32_t Addr, uint32_t Size) 
+{ 
+    for (auto i = 0; i < Size ; i ++)
+    {
+        flushICacheLine(Addr);
+        Addr += 4;
+    }
+}
+
 void InterpretedCPU::Shutdown() {}
 // interpreter execution
 template <bool debug, bool trace>


### PR DESCRIPTION
Hello,

I'm working on some hack on spyro 2 pal version, and like it's pointed in #650 the game crash before the main menu with interpreted mode.

It's seem to be the fault of the cache not updated correctly, here my solution to this problem.
If you have a better idea on how to avoid the cache outdated problem, i'm curious to have feeedback.

This code fix the problem spyro 2 pal version success to display the main menu.

PS: it's my first open source contribution, i have no idea of what i'm doing.