### PR TITLE
Fix CDRomDevice nullptr access

### DIFF
--- a/src/mips/psyqo/cdrom-device.hh
+++ b/src/mips/psyqo/cdrom-device.hh
@@ -321,6 +321,15 @@ class CDRomDevice final : public CDRom {
         S getState() const { return static_cast<S>(m_device->m_state); }
     };
 
+    /**
+     * @brief Checks if the CDROM device is in idle state.
+     *
+     * @details This assumes that all CDRomDeviceStateEnum have a first enum member
+     * with value 0 which corresponds to the "idle" state
+     *
+     */
+    bool isIdle() const;
+
   private:
     void switchAction(ActionBase *action);
     void irq();

--- a/src/mips/psyqo/cdrom-device.hh
+++ b/src/mips/psyqo/cdrom-device.hh
@@ -324,11 +324,10 @@ class CDRomDevice final : public CDRom {
     /**
      * @brief Checks if the CDROM device is in idle state.
      *
-     * @details This assumes that all CDRomDeviceStateEnum have a first enum member
-     * with value 0 which corresponds to the "idle" state
-     *
      */
-    bool isIdle() const;
+    [[nodiscard]] bool isIdle() const {
+        return m_state == 0;
+    }
 
   private:
     void switchAction(ActionBase *action);

--- a/src/mips/psyqo/src/cdrom-device-cdda.cpp
+++ b/src/mips/psyqo/src/cdrom-device-cdda.cpp
@@ -53,7 +53,7 @@ class PlayCDDAAction : public psyqo::CDRomDevice::Action<PlayCDDAActionState> {
     PlayCDDAAction() : Action("PlayCDDAAction") {}
     void start(psyqo::CDRomDevice *device, unsigned track, bool stopAtEndOfTrack,
                eastl::function<void(bool)> &&callback) {
-        psyqo::Kernel::assert(getState() == PlayCDDAActionState::IDLE,
+        psyqo::Kernel::assert(device->isIdle(),
                               "CDRomDevice::playCDDA() called while another action is in progress");
         registerMe(device);
         setCallback(eastl::move(callback));
@@ -64,7 +64,7 @@ class PlayCDDAAction : public psyqo::CDRomDevice::Action<PlayCDDAActionState> {
     }
     void start(psyqo::CDRomDevice *device, psyqo::MSF msf, bool stopAtEndOfTrack,
                eastl::function<void(bool)> &&callback) {
-        psyqo::Kernel::assert(getState() == PlayCDDAActionState::IDLE,
+        psyqo::Kernel::assert(device->isIdle(),
                               "CDRomDevice::playCDDA() called while another action is in progress");
         registerMe(device);
         setCallback(eastl::move(callback));
@@ -74,7 +74,7 @@ class PlayCDDAAction : public psyqo::CDRomDevice::Action<PlayCDDAActionState> {
         psyqo::Hardware::CDRom::Command.send(psyqo::Hardware::CDRom::CDL::SETMODE, stopAtEndOfTrack ? 3 : 1);
     }
     void start(psyqo::CDRomDevice *device, eastl::function<void(bool)> &&callback) {
-        psyqo::Kernel::assert(getState() == PlayCDDAActionState::IDLE,
+        psyqo::Kernel::assert(device->isIdle(),
                               "CDRomDevice::playCDDA() called while another action is in progress");
         registerMe(device);
         setCallback(eastl::move(callback));

--- a/src/mips/psyqo/src/cdrom-device-muteunmute.cpp
+++ b/src/mips/psyqo/src/cdrom-device-muteunmute.cpp
@@ -41,7 +41,7 @@ class MuteAction : public psyqo::CDRomDevice::Action<MuteActionState> {
   public:
     MuteAction() : Action("MuteAction") {}
     void start(psyqo::CDRomDevice *device, eastl::function<void(bool)> &&callback) {
-        psyqo::Kernel::assert(getState() == MuteActionState::IDLE,
+        psyqo::Kernel::assert(device->isIdle(),
                               "CDRomDevice::mute() called while another action is in progress");
         registerMe(device);
         setCallback(eastl::move(callback));
@@ -79,7 +79,7 @@ class UnmuteAction : public psyqo::CDRomDevice::Action<UnmuteActionState> {
   public:
     UnmuteAction() : Action("UnmuteAction") {}
     void start(psyqo::CDRomDevice *device, eastl::function<void(bool)> &&callback) {
-        psyqo::Kernel::assert(getState() == UnmuteActionState::IDLE,
+        psyqo::Kernel::assert(device->isIdle(),
                               "CDRomDevice::unmute() called while another action is in progress");
         registerMe(device);
         setCallback(eastl::move(callback));

--- a/src/mips/psyqo/src/cdrom-device-readsectors.cpp
+++ b/src/mips/psyqo/src/cdrom-device-readsectors.cpp
@@ -50,7 +50,7 @@ class ReadSectorsAction : public psyqo::CDRomDevice::Action<ReadSectorsActionSta
     ReadSectorsAction() : Action("ReadSectorsAction") {}
     void start(psyqo::CDRomDevice *device, uint32_t sector, uint32_t count, void *buffer,
                eastl::function<void(bool)> &&callback) {
-        psyqo::Kernel::assert(getState() == ReadSectorsActionState::IDLE,
+        psyqo::Kernel::assert(device->isIdle(),
                               "CDRomDevice::readSectors() called while another action is in progress");
         registerMe(device);
         setCallback(eastl::move(callback));

--- a/src/mips/psyqo/src/cdrom-device-reset.cpp
+++ b/src/mips/psyqo/src/cdrom-device-reset.cpp
@@ -42,7 +42,7 @@ class ResetAction : public psyqo::CDRomDevice::Action<ResetActionState> {
   public:
     ResetAction() : Action("ResetAction") {}
     void start(psyqo::CDRomDevice *device, eastl::function<void(bool)> &&callback) {
-        psyqo::Kernel::assert(getState() == ResetActionState::IDLE,
+        psyqo::Kernel::assert(device->isIdle(),
                               "CDRomDevice::reset() called while another action is in progress");
         registerMe(device);
         setCallback(eastl::move(callback));

--- a/src/mips/psyqo/src/cdrom-device-toc.cpp
+++ b/src/mips/psyqo/src/cdrom-device-toc.cpp
@@ -43,7 +43,7 @@ class GetTNAction : public psyqo::CDRomDevice::Action<GetTNActionEnum> {
   public:
     GetTNAction() : Action("GetTNAction") {}
     void start(psyqo::CDRomDevice *device, unsigned *size, eastl::function<void(bool)> &&callback) {
-        psyqo::Kernel::assert(getState() == GetTNActionEnum::IDLE,
+        psyqo::Kernel::assert(device->isIdle(),
                               "CDRomDevice::getTOCSize() called while another action is in progress");
         registerMe(device);
         setCallback(eastl::move(callback));
@@ -100,7 +100,7 @@ class ReadTOCAction : public psyqo::CDRomDevice::Action<ReadTOCActionState> {
   public:
     ReadTOCAction() : Action("ReadTOCAction") {}
     void start(psyqo::CDRomDevice *device, psyqo::MSF *toc, unsigned size, eastl::function<void(bool)> &&callback) {
-        psyqo::Kernel::assert(getState() == ReadTOCActionState::IDLE,
+        psyqo::Kernel::assert(device->isIdle(),
                               "CDRomDevice::readTOC() called while another action is in progress");
         registerMe(device);
         setCallback(eastl::move(callback));

--- a/src/mips/psyqo/src/cdrom-device.cpp
+++ b/src/mips/psyqo/src/cdrom-device.cpp
@@ -198,3 +198,7 @@ bool psyqo::CDRomDevice::ActionBase::acknowledge(const Response &) {
 bool psyqo::CDRomDevice::ActionBase::end(const Response &) {
     Kernel::abort("Action::end() not implemented - spurious interrupt?");
 }
+
+bool psyqo::CDRomDevice::isIdle() const {
+    return m_state == 0;
+}

--- a/src/mips/psyqo/src/cdrom-device.cpp
+++ b/src/mips/psyqo/src/cdrom-device.cpp
@@ -198,4 +198,3 @@ bool psyqo::CDRomDevice::ActionBase::acknowledge(const Response &) {
 bool psyqo::CDRomDevice::ActionBase::end(const Response &) {
     Kernel::abort("Action::end() not implemented - spurious interrupt?");
 }
-

--- a/src/mips/psyqo/src/cdrom-device.cpp
+++ b/src/mips/psyqo/src/cdrom-device.cpp
@@ -199,6 +199,3 @@ bool psyqo::CDRomDevice::ActionBase::end(const Response &) {
     Kernel::abort("Action::end() not implemented - spurious interrupt?");
 }
 
-bool psyqo::CDRomDevice::isIdle() const {
-    return m_state == 0;
-}


### PR DESCRIPTION
Asserts were checking CDRom device state on m_device member which was not yet set via registerMe call.

Add isIdle method to check if CDRomDevice is idle instead.