### PR TITLE
Fixing runaway chained DMA

### DIFF
--- a/src/mips/psyqo/src/gpu.cpp
+++ b/src/mips/psyqo/src/gpu.cpp
@@ -147,6 +147,7 @@ void psyqo::GPU::initialize(const psyqo::GPU::Configuration &config) {
                 uint32_t count = head >> 24;
                 if (count > (c_chainThreshold / 4)) {
                     // next one still too big
+                    head &= 0xffffff;
                     m_chainNext = head == 0xff0000 ? nullptr : reinterpret_cast<uint32_t *>(head & 0x7fffff);
                     scheduleNormalDMA(reinterpret_cast<uintptr_t>(chainNext) + 4, count);
                 } else {


### PR DESCRIPTION
This fixes an interesting bug where the chained DMA can runaway if:
- Two or more big packets are chained together one after the other and
- They are at the end of the chain