### PR TITLE
Fixed compile_flags.txt in vscode-extension template for psyqo

### DIFF
--- a/tools/vscode-extension/templates/psyqo/hello/compile_flags.txt
+++ b/tools/vscode-extension/templates/psyqo/hello/compile_flags.txt
@@ -3,5 +3,5 @@
 -fcoroutines-ts
 -I.
 -Ithird_party/nugget
--Ithird_party/EASTL/include
--Ithird_party/EABase/include/Common
+-Ithird_party/nugget/third_party/EASTL/include
+-Ithird_party/nugget/third_party/EABase/include/Common


### PR DESCRIPTION
The vscode extension incorrectly presumes that EASTL and EABase are located in the project's third_party directory, while they're located in nugget's.