### PR TITLE
Patch manager

### DIFF
--- a/src/core/patchmanager.cc
+++ b/src/core/patchmanager.cc
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (C) 2022 PCSX-Redux authors                                 *
+ *   Copyright (C) 2024 PCSX-Redux authors                                 *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/core/patchmanager.cc
+++ b/src/core/patchmanager.cc
@@ -1,0 +1,110 @@
+/***************************************************************************
+ *   Copyright (C) 2022 PCSX-Redux authors                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.           *
+ ***************************************************************************/
+
+#include "patchmanager.h"
+#include "core/psxmem.h"
+#include "core/psxemulator.h"
+
+extern PCSX::Emulator* g_emulator;
+
+int PCSX::PatchManager::registerPatch(uint32_t address, Patch::Type type) {
+    int index = (int)m_patches.size();
+    uint32_t org0 = g_emulator->m_mem->read32(address);
+    uint32_t org1 = (type == Patch::Type::Return) ? g_emulator->m_mem->read32(address + 4) : 0;
+    Patch patch = Patch(address, type, org0, org1);
+    doPatch(patch);
+    m_patches.push_back(patch);
+    std::sort(m_patches.begin(), m_patches.end(), [](Patch const& a, Patch const& b) { return a.addr < b.addr; });
+    return index;
+}
+
+void PCSX::PatchManager::doPatch(Patch& patch) {
+    switch (patch.type) {
+        case PatchManager::Patch::Type::Return:
+            g_emulator->m_mem->write32(patch.addr, 0x03e00008);
+            g_emulator->m_mem->write32(patch.addr + 4, 0);
+            break;
+
+        case PatchManager::Patch::Type::NOP:
+            g_emulator->m_mem->write32(patch.addr, 0);
+            break;
+
+        default:
+            return;
+    }
+    patch.active = true;
+}
+
+void PCSX::PatchManager::undoPatch(Patch& patch) {
+    switch (patch.type) {
+        case PatchManager::Patch::Type::Return:
+            g_emulator->m_mem->write32(patch.addr, patch.org0);
+            g_emulator->m_mem->write32(patch.addr + 4, patch.org1);
+            break;
+
+        case PatchManager::Patch::Type::NOP:
+            g_emulator->m_mem->write32(patch.addr, patch.org0);
+            break;
+
+        default:
+            return;
+    }
+    patch.active = false;
+}
+
+PCSX::PatchManager::Patch::Type PCSX::PatchManager::findPatch(uint32_t address) {
+    int idx = 0;
+    for (std::vector<Patch>::iterator it = m_patches.begin(); it != m_patches.end(); ++it) {
+        if (it->addr == address) {
+            return it->type;
+        }
+        idx++;
+    }
+    return PCSX::PatchManager::Patch::Type::None;
+}
+
+void PCSX::PatchManager::deletePatch(uint32_t index) {
+    undoPatch(m_patches[index]);
+    m_patches.erase(m_patches.begin() + index);
+}
+
+void PCSX::PatchManager::deleteAllPatches() {
+    deactivateAll();
+    m_patches.clear();
+}
+
+void PCSX::PatchManager::deactivateAll() {
+    int idx = 0;
+    for (std::vector<Patch>::iterator it = m_patches.begin(); it != m_patches.end(); ++it) {
+        if (it->active) {
+            undoPatch(m_patches[idx]);
+        }
+        idx++;
+    }
+}
+
+void PCSX::PatchManager::activateAll() {
+    int idx = 0;
+    for (std::vector<Patch>::iterator it = m_patches.begin(); it != m_patches.end(); ++it) {
+        if (!it->active) {
+            doPatch(m_patches[idx]);
+        }
+        idx++;
+    }
+}

--- a/src/core/patchmanager.h
+++ b/src/core/patchmanager.h
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (C) 2022 PCSX-Redux authors                                 *
+ *   Copyright (C) 2024 PCSX-Redux authors                                 *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/core/patchmanager.h
+++ b/src/core/patchmanager.h
@@ -1,0 +1,66 @@
+/***************************************************************************
+ *   Copyright (C) 2022 PCSX-Redux authors                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.           *
+ ***************************************************************************/
+
+#pragma once
+
+#include <stdint.h>
+#include <vector>
+
+namespace PCSX {
+
+class PatchManager {
+  public:
+    struct Patch {
+        enum class Type : uint8_t { None, Return, NOP };
+
+        Patch(uint32_t addr, Type type, uint32_t org0, uint32_t org1) {
+            this->addr = addr;
+            this->org0 = org0;
+            this->org1 = org1;
+            this->type = type;
+        }
+
+        uint32_t addr;
+        uint32_t org0;
+        uint32_t org1;
+        bool active = true;
+        Type type;
+    };
+
+    int getNumPatches() const { return (int)m_patches.size(); }
+    Patch& getPatch(int index) { return m_patches[index]; }
+
+    int registerPatch(uint32_t address, Patch::Type type);
+    PatchManager::Patch::Type findPatch(uint32_t address);
+    void deletePatch(uint32_t index);
+    void deleteAllPatches();
+    void deactivateAll();
+    void activateAll();
+
+    void doPatch(int index) { doPatch(m_patches[index]); }
+    void undoPatch(int index) { undoPatch(m_patches[index]); }
+
+  private:
+    void doPatch(Patch& patch);
+    void undoPatch(Patch& patch);
+
+    std::vector<Patch> m_patches;
+};
+
+}  // namespace PCSX

--- a/src/core/patchmanager.h
+++ b/src/core/patchmanager.h
@@ -47,7 +47,7 @@ class PatchManager {
     Patch& getPatch(int index) { return m_patches[index]; }
 
     int registerPatch(uint32_t address, Patch::Type type);
-    PatchManager::Patch::Type findPatch(uint32_t address);
+    PatchManager::Patch::Type findPatch(uint32_t address) const;
     void deletePatch(uint32_t index);
     void deleteAllPatches();
     void deactivateAll();

--- a/src/core/psxemulator.cc
+++ b/src/core/psxemulator.cc
@@ -37,6 +37,7 @@
 #include "core/sio1-server.h"
 #include "core/sio1.h"
 #include "core/web-server.h"
+#include "core/patchmanager.h"
 #include "gpu/soft/interface.h"
 #include "lua/extra.h"
 #include "lua/luafile.h"
@@ -66,6 +67,7 @@ PCSX::Emulator::Emulator()
       m_mdec(new PCSX::MDEC()),
       m_mem(new PCSX::Memory()),
       m_pads(PCSX::Pads::factory()),
+      m_patchManager(new PatchManager()),
       m_pioCart(new PCSX::PIOCart),
       m_sio(new PCSX::SIO()),
       m_sio1(new PCSX::SIO1()),

--- a/src/core/psxemulator.h
+++ b/src/core/psxemulator.h
@@ -76,6 +76,7 @@ class Lua;
 class MDEC;
 class Memory;
 class Pads;
+class PatchManager;
 class R3000Acpu;
 class SIO;
 class SPUInterface;
@@ -249,6 +250,7 @@ class Emulator {
     std::unique_ptr<MDEC> m_mdec;
     std::unique_ptr<Memory> m_mem;
     std::unique_ptr<Pads> m_pads;
+    std::unique_ptr<PatchManager> m_patchManager;
     std::unique_ptr<PIOCart> m_pioCart;
     std::unique_ptr<R3000Acpu> m_cpu;
     std::unique_ptr<SIO> m_sio;

--- a/src/gui/gui.cc
+++ b/src/gui/gui.cc
@@ -1297,6 +1297,7 @@ in Configuration->Emulation, restart PCSX-Redux, then try again.)"));
                     }
                     ImGui::MenuItem(_("Show Memory Observer"), nullptr, &m_memoryObserver.m_show);
                     ImGui::MenuItem(_("Show Typed Debugger"), nullptr, &m_typedDebugger.m_show);
+                    ImGui::MenuItem(_("Show Patches"), nullptr, &m_patches.m_show);
                     ImGui::MenuItem(_("Show Interrupts Scaler"), nullptr, &m_showInterruptsScaler);
                     if (ImGui::BeginMenu(_("First Chance Exceptions"))) {
                         ImGui::PushItemFlag(ImGuiItemFlags_AutoClosePopups, false);
@@ -1565,6 +1566,10 @@ in Configuration->Emulation, restart PCSX-Redux, then try again.)"));
 
     if (m_breakpoints.m_show) {
         m_breakpoints.draw(_("Breakpoints"));
+    }
+
+    if (m_patches.m_show) {
+        m_patches.draw(_("Patches"));
     }
 
     if (m_namedSaveStates.m_show) {

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -50,6 +50,7 @@
 #include "gui/widgets/luainspector.h"
 #include "gui/widgets/memcard_manager.h"
 #include "gui/widgets/named_savestates.h"
+#include "gui/widgets/patches.h"
 #include "gui/widgets/pio-cart.h"
 #include "gui/widgets/registers.h"
 #include "gui/widgets/shader-editor.h"
@@ -97,6 +98,7 @@ class GUI final : public UI {
     typedef Setting<bool, TYPESTRING("ShowVRAMViewer4")> ShowVRAMViewer4;
     typedef Setting<bool, TYPESTRING("ShowMemoryObserver")> ShowMemoryObserver;
     typedef Setting<bool, TYPESTRING("ShowTypedDebugger")> ShowTypedDebugger;
+    typedef Setting<bool, TYPESTRING("ShowPatches")> ShowPatches;
     typedef Setting<bool, TYPESTRING("ShowMemcardManager")> ShowMemcardManager;
     typedef Setting<bool, TYPESTRING("ShowRegisters")> ShowRegisters;
     typedef Setting<bool, TYPESTRING("ShowAssembly")> ShowAssembly;
@@ -151,7 +153,7 @@ class GUI final : public UI {
     Settings<Fullscreen, FullWindowRender, ShowMenu, ShowLog, WindowPosX, WindowPosY, WindowSizeX, WindowSizeY,
              IdleSwapInterval, ShowLuaConsole, ShowLuaInspector, ShowLuaEditor, ShowMainVRAMViewer, ShowCLUTVRAMViewer,
              ShowVRAMViewer1, ShowVRAMViewer2, ShowVRAMViewer3, ShowVRAMViewer4, ShowMemoryObserver, ShowTypedDebugger,
-             ShowMemcardManager, ShowRegisters, ShowAssembly, ShowDisassembly, ShowBreakpoints, ShowNamedSaveStates,
+             ShowPatches, ShowMemcardManager, ShowRegisters, ShowAssembly, ShowDisassembly, ShowBreakpoints, ShowNamedSaveStates,
              ShowEvents, ShowHandlers, ShowKernelLog, ShowCallstacks, ShowSIO1, ShowIsoBrowser, ShowGPULogger,
              MainFontSize, MonoFontSize, GUITheme, AllowMouseCaptureToggle, EnableRawMouseMotion, WidescreenRatio,
              ShowPIOCartConfig, ShowMemoryEditor1, ShowMemoryEditor2, ShowMemoryEditor3, ShowMemoryEditor4,
@@ -373,6 +375,7 @@ class GUI final : public UI {
                                         settings.get<VRAMEditorAddr>().value};
     Widgets::MemoryObserver m_memoryObserver = {settings.get<ShowMemoryObserver>().value};
     Widgets::TypedDebugger m_typedDebugger = {settings.get<ShowTypedDebugger>().value};
+    Widgets::Patches m_patches = {settings.get<ShowPatches>().value};
     Widgets::MemcardManager m_memcardManager = {settings.get<ShowMemcardManager>().value};
     Widgets::Registers m_registers = {settings.get<ShowRegisters>().value};
     Widgets::Assembly m_assembly = {settings.get<ShowAssembly>().value};

--- a/src/gui/widgets/assembly.cc
+++ b/src/gui/widgets/assembly.cc
@@ -30,6 +30,7 @@
 
 #include "core/debug.h"
 #include "core/disr3000a.h"
+#include "core/patchmanager.h"
 #include "core/psxmem.h"
 #include "core/r3000a.h"
 #include "core/system.h"
@@ -787,6 +788,31 @@ settings, otherwise debugging features may not work.)");
                         ImGui::PopStyleColor();
                     }
                     if (absAddr < 0x00800000) {
+                        PatchManager& pm = *g_emulator->m_patchManager;
+                        PatchManager::Patch::Type patchType = pm.findPatch(dispAddr);
+                        switch (patchType) {
+                            case PatchManager::Patch::Type::None:
+                                if (ImGui::MenuItem(_("Patch in Return"))) {
+                                    pm.registerPatch(dispAddr, PatchManager::Patch::Type::Return);
+                                }
+                                if (ImGui::MenuItem(_("Patch in NOP"))) {
+                                    pm.registerPatch(dispAddr, PatchManager::Patch::Type::NOP);
+                                }
+                                break;
+
+                            case PatchManager::Patch::Type::Return:
+                                if (ImGui::MenuItem(_("Remove Return Patch"))) {
+                                    pm.undoPatch(dispAddr);
+                                }
+                                break;
+
+                            case PatchManager::Patch::Type::NOP:
+                                if (ImGui::MenuItem(_("Remove NOP Patch"))) {
+                                    pm.undoPatch(dispAddr);
+                                }
+                                break;
+                        }
+
                         if (ImGui::MenuItem(_("Assemble"))) {
                             openAssembler = true;
                             m_assembleAddress = dispAddr;

--- a/src/gui/widgets/patches.cc
+++ b/src/gui/widgets/patches.cc
@@ -1,0 +1,118 @@
+/***************************************************************************
+ *   Copyright (C) 2019 PCSX-Redux authors                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.           *
+ ***************************************************************************/
+
+#include "core/patchmanager.h"
+#include "core/r3000a.h"
+#include "gui/widgets/patches.h"
+#include "imgui.h"
+
+void PCSX::Widgets::Patches::draw(const char* title) {
+    ImGui::SetNextWindowPos(ImVec2(520, 30), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(600, 500), ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin(title, &m_show)) {
+        ImGui::End();
+        return;
+    }
+
+    if (PCSX::g_emulator->m_cpu->isDynarec()) {
+        ImGui::TextUnformatted(_("Patching is only available in Interpreted CPU mode"));
+        ImGui::End();
+        return;
+    }
+
+    static ImGuiTableFlags flags = ImGuiTableFlags_SizingFixedFit | ImGuiTableFlags_Resizable |
+                            ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersV |
+                            ImGuiTableFlags_ContextMenuInBody;
+
+    if (ImGui::BeginTable("Patches", 4, flags)) {
+        ImGui::TableSetupColumn("#");
+        ImGui::TableSetupColumn("Address");
+        ImGui::TableSetupColumn("Active");
+        ImGui::TableSetupColumn("Type");
+        ImGui::TableHeadersRow();
+
+        PatchManager& patchManager = *PCSX::g_emulator->m_patchManager;
+
+        int deleteIndex = -1;
+        int numPatches = patchManager.getNumPatches();
+        for (int row = 0; row < numPatches; row++) {
+            PCSX::PatchManager::Patch& patch = patchManager.getPatch(row);
+            ImGui::TableNextRow();
+
+            ImGui::TableSetColumnIndex(0);
+            char buf[256];
+            sprintf(buf, "%d", row);
+            ImGui::TextUnformatted(buf);
+
+            ImGui::TableSetColumnIndex(1);
+            sprintf(buf, "%08x", patch.addr);
+
+            if (ImGui::Button(buf, ImVec2(-FLT_MIN, 0.0f))) {
+                g_system->m_eventBus->signal(PCSX::Events::GUI::JumpToPC{patch.addr});
+            }
+            if (ImGui::BeginPopupContextItem()) {
+                ImGui::TextUnformatted("Delete Patch?");
+                if (ImGui::Button("Delete")) {
+                    deleteIndex = row;
+                    ImGui::CloseCurrentPopup();
+                }
+                ImGui::EndPopup();
+            }
+
+            ImGui::TableSetColumnIndex(2);
+            ImGui::PushID(row);
+            if (ImGui::Checkbox("", &patch.active))
+            {
+                if (patch.active)
+                {
+                    patchManager.doPatch(row);
+                }
+                else
+                {
+                    patchManager.undoPatch(row);
+                }
+            }
+            ImGui::PopID();
+
+            ImGui::TableSetColumnIndex(3);
+            ImGui::TextUnformatted(patch.type == PCSX::PatchManager::Patch::Type::Return ? "Return" : "NOP");
+        }
+        ImGui::EndTable();
+
+        if (deleteIndex != -1) {
+            patchManager.deletePatch(deleteIndex);
+        }
+
+        if (ImGui::Button("Activate All")) {
+            patchManager.activateAll();
+        }
+
+        ImGui::SameLine();
+        if (ImGui::Button("Deactivate All")) {
+            patchManager.deactivateAll();
+        }
+
+        ImGui::SameLine();
+        if (ImGui::Button("Delete All")) {
+            patchManager.deleteAllPatches();
+        }
+    }
+   
+    ImGui::End();
+}

--- a/src/gui/widgets/patches.cc
+++ b/src/gui/widgets/patches.cc
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (C) 2019 PCSX-Redux authors                                 *
+ *   Copyright (C) 2024 PCSX-Redux authors                                 *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/gui/widgets/patches.cc
+++ b/src/gui/widgets/patches.cc
@@ -56,19 +56,16 @@ void PCSX::Widgets::Patches::draw(const char* title) {
             ImGui::TableNextRow();
 
             ImGui::TableSetColumnIndex(0);
-            char buf[256];
-            sprintf(buf, "%d", row);
-            ImGui::TextUnformatted(buf);
+            ImGui::Text("%d", row);
 
             ImGui::TableSetColumnIndex(1);
-            sprintf(buf, "%08x", patch.addr);
-
-            if (ImGui::Button(buf, ImVec2(-FLT_MIN, 0.0f))) {
+            std::string buttonStr = fmt::format("{:08x}", patch.addr);
+            if (ImGui::Button(buttonStr.c_str(), ImVec2(-FLT_MIN, 0.0f))) {
                 g_system->m_eventBus->signal(PCSX::Events::GUI::JumpToPC{patch.addr});
             }
             if (ImGui::BeginPopupContextItem()) {
-                ImGui::TextUnformatted("Delete Patch?");
-                if (ImGui::Button("Delete")) {
+                ImGui::TextUnformatted(_("Delete Patch?"));
+                if (ImGui::Button(_("Delete"))) {
                     deleteIndex = row;
                     ImGui::CloseCurrentPopup();
                 }
@@ -91,7 +88,7 @@ void PCSX::Widgets::Patches::draw(const char* title) {
             ImGui::PopID();
 
             ImGui::TableSetColumnIndex(3);
-            ImGui::TextUnformatted(patch.type == PCSX::PatchManager::Patch::Type::Return ? "Return" : "NOP");
+            ImGui::TextUnformatted(patch.type == PCSX::PatchManager::Patch::Type::Return ? _("Return") : _("NOP"));
         }
         ImGui::EndTable();
 
@@ -99,17 +96,17 @@ void PCSX::Widgets::Patches::draw(const char* title) {
             patchManager.deletePatch(deleteIndex);
         }
 
-        if (ImGui::Button("Activate All")) {
+        if (ImGui::Button(_("Activate All"))) {
             patchManager.activateAll();
         }
 
         ImGui::SameLine();
-        if (ImGui::Button("Deactivate All")) {
+        if (ImGui::Button(_("Deactivate All"))) {
             patchManager.deactivateAll();
         }
 
         ImGui::SameLine();
-        if (ImGui::Button("Delete All")) {
+        if (ImGui::Button(_("Delete All"))) {
             patchManager.deleteAllPatches();
         }
     }

--- a/src/gui/widgets/patches.h
+++ b/src/gui/widgets/patches.h
@@ -1,0 +1,37 @@
+/***************************************************************************
+ *   Copyright (C) 2019 PCSX-Redux authors                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.           *
+ ***************************************************************************/
+
+#pragma once
+
+#include "core/debug.h"
+
+namespace PCSX {
+
+namespace Widgets {
+
+class Patches {
+  public:
+    Patches(bool& show) : m_show(show) {}
+    void draw(const char* title);
+    bool& m_show;
+};
+
+}  // namespace Widgets
+
+}  // namespace PCSX

--- a/src/gui/widgets/patches.h
+++ b/src/gui/widgets/patches.h
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (C) 2019 PCSX-Redux authors                                 *
+ *   Copyright (C) 2024 PCSX-Redux authors                                 *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/vsprojects/core/core.vcxproj
+++ b/vsprojects/core/core.vcxproj
@@ -139,6 +139,7 @@
     <ClCompile Include="..\..\src\core\DynaRec_x64\regAllocation.cc" />
     <ClCompile Include="..\..\src\core\DynaRec_x64\symbols.cc" />
     <ClCompile Include="..\..\src\core\eventslua.cc" />
+    <ClCompile Include="..\..\src\core\patchmanager.cc" />
     <ClCompile Include="..\..\src\core\pio-cart.cc" />
     <ClCompile Include="..\..\src\core\gdb-server.cc" />
     <ClCompile Include="..\..\src\core\gpu.cc" />
@@ -190,6 +191,7 @@
     <ClInclude Include="..\..\src\core\DynaRec_x64\recompiler.h" />
     <ClInclude Include="..\..\src\core\DynaRec_x64\regAllocation.h" />
     <ClInclude Include="..\..\src\core\eventslua.h" />
+    <ClInclude Include="..\..\src\core\patchmanager.h" />
     <ClInclude Include="..\..\src\core\pio-cart.h" />
     <ClInclude Include="..\..\src\core\gdb-server.h" />
     <ClInclude Include="..\..\src\core\gpu.h" />

--- a/vsprojects/core/core.vcxproj.filters
+++ b/vsprojects/core/core.vcxproj.filters
@@ -142,6 +142,9 @@
     <ClCompile Include="..\..\src\core\arguments.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\core\patchmanager.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\core\web-server.h">
@@ -290,6 +293,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\core\DynaRec_aa64\regAllocation.h">
       <Filter>Header Files\Dynarec Aarch64</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\core\patchmanager.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/vsprojects/gui/gui.vcxproj
+++ b/vsprojects/gui/gui.vcxproj
@@ -149,6 +149,7 @@
     <ClCompile Include="..\..\src\gui\widgets\memcard_manager.cc" />
     <ClCompile Include="..\..\src\gui\widgets\memory_observer.cc" />
     <ClCompile Include="..\..\src\gui\widgets\named_savestates.cc" />
+    <ClCompile Include="..\..\src\gui\widgets\patches.cc" />
     <ClCompile Include="..\..\src\gui\widgets\pio-cart.cc" />
     <ClCompile Include="..\..\src\gui\widgets\typed_debugger.cc" />
     <ClCompile Include="..\..\src\gui\widgets\registers.cc" />
@@ -182,6 +183,7 @@
     <ClInclude Include="..\..\src\gui\widgets\memcard_manager.h" />
     <ClInclude Include="..\..\src\gui\widgets\memory_observer.h" />
     <ClInclude Include="..\..\src\gui\widgets\named_savestates.h" />
+    <ClInclude Include="..\..\src\gui\widgets\patches.h" />
     <ClInclude Include="..\..\src\gui\widgets\pio-cart.h" />
     <ClInclude Include="..\..\src\gui\widgets\typed_debugger.h" />
     <ClInclude Include="..\..\src\gui\widgets\registers.h" />

--- a/vsprojects/gui/gui.vcxproj.filters
+++ b/vsprojects/gui/gui.vcxproj.filters
@@ -103,6 +103,9 @@
     <ClCompile Include="..\..\src\gui\luaimguiextra.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\gui\widgets\patches.cc">
+      <Filter>Source Files\widgets</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\gui\gui.h">
@@ -200,6 +203,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\gui\luaimguiextra.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\gui\widgets\patches.h">
+      <Filter>Header Files\widgets</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
PatchManager is an easy way to patch in return instructions (with nop delay slot) and also just a single NOP.

There is a window where you can see your patches and chose to activate/deactive and delete them.

Clicking on the address in this window will take you there in the Assembly window.
