### PR TITLE
Adding interpolateColors to gouraud primitives.

### DIFF
--- a/src/mips/psyqo/primitives/common.hh
+++ b/src/mips/psyqo/primitives/common.hh
@@ -101,6 +101,10 @@ enum SemiTrans { HalfBackAndHalfFront, FullBackAndFullFront, FullBackSubFullFron
 enum ColorMode { Tex4Bits, Tex8Bits, Tex16Bits };
 }  // namespace Prim::TPageAttr
 
+namespace Prim {
+    enum class Transparency { Auto, Opaque, SemiTransparent };
+}
+
 namespace PrimPieces {
 
 /**

--- a/src/mips/psyqo/primitives/quads.hh
+++ b/src/mips/psyqo/primitives/quads.hh
@@ -28,6 +28,8 @@ SOFTWARE.
 
 #include <stdint.h>
 
+#include "psyqo/gte-kernels.hh"
+#include "psyqo/gte-registers.hh"
 #include "psyqo/primitives/common.hh"
 
 namespace psyqo {
@@ -188,6 +190,48 @@ struct GouraudQuad {
         pointD = v;
         return *this;
     }
+    template <Transparency transparency = Transparency::Auto>
+    void interpolateColors(const Color* a, const Color* b, const Color* c, const Color* d) {
+        uint32_t rgb;
+        if constexpr (transparency == Transparency::Auto) {
+            rgb = (a->packed & 0xffffff) | (command & 0xff000000);
+        } else if constexpr (transparency == Transparency::Opaque) {
+            rgb = (a->packed & 0xffffff) | 0x38000000;
+        } else if constexpr (transparency == Transparency::SemiTransparent) {
+            rgb = (a->packed & 0xffffff) | 0x3a000000;
+        }
+        GTE::write<GTE::Register::RGB, GTE::Safe>(rgb);
+        GTE::Kernels::dpcs();
+        GTE::read<GTE::Register::RGB2>(&command);
+        GTE::write<GTE::Register::RGB0, GTE::Unsafe>(&b->packed);
+        GTE::write<GTE::Register::RGB1, GTE::Unsafe>(&c->packed);
+        GTE::write<GTE::Register::RGB2, GTE::Unsafe>(&d->packed);
+        GTE::Kernels::dpct();
+        GTE::read<GTE::Register::RGB0>(&colorB.packed);
+        GTE::read<GTE::Register::RGB1>(&colorC.packed);
+        GTE::read<GTE::Register::RGB2>(&colorD.packed);
+    }
+    template <Transparency transparency = Transparency::Auto>
+    void interpolateColors(Color a, Color b, Color c, Color d) {
+        uint32_t rgb;
+        if constexpr (transparency == Transparency::Auto) {
+            rgb = (a.packed & 0xffffff) | (command & 0xff000000);
+        } else if constexpr (transparency == Transparency::Opaque) {
+            rgb = (a.packed & 0xffffff) | 0x38000000;
+        } else if constexpr (transparency == Transparency::SemiTransparent) {
+            rgb = (a.packed & 0xffffff) | 0x3a000000;
+        }
+        GTE::write<GTE::Register::RGB, GTE::Safe>(rgb);
+        GTE::Kernels::dpcs();
+        GTE::read<GTE::Register::RGB2>(&command);
+        GTE::write<GTE::Register::RGB0, GTE::Unsafe>(b.packed);
+        GTE::write<GTE::Register::RGB1, GTE::Unsafe>(c.packed);
+        GTE::write<GTE::Register::RGB2, GTE::Unsafe>(d.packed);
+        GTE::Kernels::dpct();
+        GTE::read<GTE::Register::RGB0>(&colorB.packed);
+        GTE::read<GTE::Register::RGB1>(&colorC.packed);
+        GTE::read<GTE::Register::RGB2>(&colorD.packed);
+    }
 
   private:
     uint32_t command;
@@ -245,6 +289,48 @@ struct GouraudTexturedQuad {
     GouraudTexturedQuad& setSemiTrans() {
         command |= 0x02000000;
         return *this;
+    }
+    template <Transparency transparency = Transparency::Auto>
+    void interpolateColors(const Color* a, const Color* b, const Color* c, const Color* d) {
+        uint32_t rgb;
+        if constexpr (transparency == Transparency::Auto) {
+            rgb = (a->packed & 0xffffff) | (command & 0xff000000);
+        } else if constexpr (transparency == Transparency::Opaque) {
+            rgb = (a->packed & 0xffffff) | 0x3c000000;
+        } else if constexpr (transparency == Transparency::SemiTransparent) {
+            rgb = (a->packed & 0xffffff) | 0x3e000000;
+        }
+        GTE::write<GTE::Register::RGB, GTE::Safe>(rgb);
+        GTE::Kernels::dpcs();
+        GTE::read<GTE::Register::RGB2>(&command);
+        GTE::write<GTE::Register::RGB0, GTE::Unsafe>(&b->packed);
+        GTE::write<GTE::Register::RGB1, GTE::Unsafe>(&c->packed);
+        GTE::write<GTE::Register::RGB2, GTE::Unsafe>(&d->packed);
+        GTE::Kernels::dpct();
+        GTE::read<GTE::Register::RGB0>(&colorB.packed);
+        GTE::read<GTE::Register::RGB1>(&colorC.packed);
+        GTE::read<GTE::Register::RGB2>(&colorD.packed);
+    }
+    template <Transparency transparency = Transparency::Auto>
+    void interpolateColors(Color a, Color b, Color c, Color d) {
+        uint32_t rgb;
+        if constexpr (transparency == Transparency::Auto) {
+            rgb = (a.packed & 0xffffff) | (command & 0xff000000);
+        } else if constexpr (transparency == Transparency::Opaque) {
+            rgb = (a.packed & 0xffffff) | 0x3c000000;
+        } else if constexpr (transparency == Transparency::SemiTransparent) {
+            rgb = (a.packed & 0xffffff) | 0x3e000000;
+        }
+        GTE::write<GTE::Register::RGB, GTE::Safe>(rgb);
+        GTE::Kernels::dpcs();
+        GTE::read<GTE::Register::RGB2>(&command);
+        GTE::write<GTE::Register::RGB0, GTE::Unsafe>(b.packed);
+        GTE::write<GTE::Register::RGB1, GTE::Unsafe>(c.packed);
+        GTE::write<GTE::Register::RGB2, GTE::Unsafe>(d.packed);
+        GTE::Kernels::dpct();
+        GTE::read<GTE::Register::RGB0>(&colorB.packed);
+        GTE::read<GTE::Register::RGB1>(&colorC.packed);
+        GTE::read<GTE::Register::RGB2>(&colorD.packed);
     }
 
   private:

--- a/src/mips/psyqo/primitives/triangles.hh
+++ b/src/mips/psyqo/primitives/triangles.hh
@@ -28,6 +28,8 @@ SOFTWARE.
 
 #include <stdint.h>
 
+#include "psyqo/gte-kernels.hh"
+#include "psyqo/gte-registers.hh"
 #include "psyqo/primitives/common.hh"
 
 namespace psyqo {
@@ -167,6 +169,40 @@ struct GouraudTriangle {
         pointC = v;
         return *this;
     }
+    template <Transparency transparency = Transparency::Auto>
+    void interpolateColors(const Color* a, const Color* b, const Color* c) {
+        GTE::write<GTE::Register::RGB0, GTE::Unsafe>(&a->packed);
+        GTE::write<GTE::Register::RGB1, GTE::Unsafe>(&b->packed);
+        GTE::write<GTE::Register::RGB2, GTE::Unsafe>(&c->packed);
+        if constexpr (transparency == Transparency::Auto) {
+            GTE::write<GTE::Register::RGB, GTE::Safe>(&command);
+        } else if constexpr (transparency == Transparency::Opaque) {
+            GTE::write<GTE::Register::RGB, GTE::Safe>(0x30000000);
+        } else if constexpr (transparency == Transparency::SemiTransparent) {
+            GTE::write<GTE::Register::RGB, GTE::Safe>(0x32000000);
+        }
+        GTE::Kernels::dpct();
+        GTE::read<GTE::Register::RGB0>(&command);
+        GTE::read<GTE::Register::RGB1>(&colorB.packed);
+        GTE::read<GTE::Register::RGB2>(&colorC.packed);
+    }
+    template <Transparency transparency = Transparency::Auto>
+    void interpolateColors(Color a, Color b, Color c) {
+        GTE::write<GTE::Register::RGB0, GTE::Unsafe>(a.packed);
+        GTE::write<GTE::Register::RGB1, GTE::Unsafe>(b.packed);
+        GTE::write<GTE::Register::RGB2, GTE::Unsafe>(c.packed);
+        if constexpr (transparency == Transparency::Auto) {
+            GTE::write<GTE::Register::RGB, GTE::Safe>(&command);
+        } else if constexpr (transparency == Transparency::Opaque) {
+            GTE::write<GTE::Register::RGB, GTE::Safe>(0x30000000);
+        } else if constexpr (transparency == Transparency::SemiTransparent) {
+            GTE::write<GTE::Register::RGB, GTE::Safe>(0x32000000);
+        }
+        GTE::Kernels::dpct();
+        GTE::read<GTE::Register::RGB0>(&command);
+        GTE::read<GTE::Register::RGB1>(&colorB.packed);
+        GTE::read<GTE::Register::RGB2>(&colorC.packed);
+    }
 
   private:
     uint32_t command;
@@ -217,6 +253,40 @@ struct GouraudTexturedTriangle {
     GouraudTexturedTriangle& setSemiTrans() {
         command |= 0x02000000;
         return *this;
+    }
+    template <Transparency transparency = Transparency::Auto>
+    void interpolateColors(const Color* a, const Color* b, const Color* c) {
+        GTE::write<GTE::Register::RGB0, GTE::Unsafe>(&a->packed);
+        GTE::write<GTE::Register::RGB1, GTE::Unsafe>(&b->packed);
+        GTE::write<GTE::Register::RGB2, GTE::Unsafe>(&c->packed);
+        if constexpr (transparency == Transparency::Auto) {
+            GTE::write<GTE::Register::RGB, GTE::Safe>(&command);
+        } else if constexpr (transparency == Transparency::Opaque) {
+            GTE::write<GTE::Register::RGB, GTE::Safe>(0x34000000);
+        } else if constexpr (transparency == Transparency::SemiTransparent) {
+            GTE::write<GTE::Register::RGB, GTE::Safe>(0x36000000);
+        }
+        GTE::Kernels::dpct();
+        GTE::read<GTE::Register::RGB0>(&command);
+        GTE::read<GTE::Register::RGB1>(&colorB.packed);
+        GTE::read<GTE::Register::RGB2>(&colorC.packed);
+    }
+    template <Transparency transparency = Transparency::Auto>
+    void interpolateColors(Color a, Color b, Color c) {
+        GTE::write<GTE::Register::RGB0, GTE::Unsafe>(a.packed);
+        GTE::write<GTE::Register::RGB1, GTE::Unsafe>(b.packed);
+        GTE::write<GTE::Register::RGB2, GTE::Unsafe>(c.packed);
+        if constexpr (transparency == Transparency::Auto) {
+            GTE::write<GTE::Register::RGB, GTE::Safe>(&command);
+        } else if constexpr (transparency == Transparency::Opaque) {
+            GTE::write<GTE::Register::RGB, GTE::Safe>(0x34000000);
+        } else if constexpr (transparency == Transparency::SemiTransparent) {
+            GTE::write<GTE::Register::RGB, GTE::Safe>(0x36000000);
+        }
+        GTE::Kernels::dpct();
+        GTE::read<GTE::Register::RGB0>(&command);
+        GTE::read<GTE::Register::RGB1>(&colorB.packed);
+        GTE::read<GTE::Register::RGB2>(&colorC.packed);
     }
 
   private:


### PR DESCRIPTION
This needs to be used with the GTE pre-loaded with IR0 and the far color registers.