### PR TITLE
Fix VSCode Extension installing MIPS Toolchain as Homebrew formulae instead of casks

### DIFF
--- a/tools/vscode-extension/tools.js
+++ b/tools/vscode-extension/tools.js
@@ -109,6 +109,7 @@ async function installToolchain () {
           ).fsPath
           await terminal.run('brew', [
             'install',
+            '--formula',
             binutilsScriptPath,
             gccScriptPath
           ])
@@ -140,6 +141,7 @@ async function installToolchain () {
           ).fsPath
           await terminal.run('brew', [
             'install',
+            '--formula',
             binutilsScriptPath,
             gccScriptPath
           ])


### PR DESCRIPTION
Fix #1796 