### PR TITLE
Fix interpolation issues on HW

### DIFF
--- a/src/mips/psyqo/primitives/lines.hh
+++ b/src/mips/psyqo/primitives/lines.hh
@@ -46,7 +46,7 @@ struct Line {
     Line(Color c) : command(0x40000000 | c.packed) {}
     Line& setColor(Color c) {
         uint32_t wasSemiTrans = command & 0x02000000;
-        command = 0x40000000 | c.packed | wasSemiTrans;
+        command = 0x40000000 | (c.packed & 0xffffff) | wasSemiTrans;
         return *this;
     }
     Line& setOpaque() {
@@ -81,7 +81,7 @@ struct GouraudLine {
     GouraudLine(Color c) : command(0x50000000 | c.packed) {}
     GouraudLine& setColorA(Color c) {
         uint32_t wasSemiTrans = command & 0x02000000;
-        command = 0x50000000 | c.packed | wasSemiTrans;
+        command = 0x50000000 | (c.packed & 0xffffff) | wasSemiTrans;
         return *this;
     }
     GouraudLine& setColorB(Color c) {
@@ -125,7 +125,7 @@ struct PolyLineBegin {
     PolyLineBegin(Color c) : command(0x48000000 | c.packed) {}
     PolyLineBegin& setColor(Color c) {
         uint32_t wasSemiTrans = command & 0x02000000;
-        command = 0x48000000 | c.packed | wasSemiTrans;
+        command = 0x48000000 | (c.packed & 0xffffff) | wasSemiTrans;
         return *this;
     }
     PolyLineBegin& setOpaque() {
@@ -166,7 +166,7 @@ struct PolyLine {
     PolyLine(Color c) : command(0x48000000 | c.packed) {}
     PolyLine& setColor(Color c) {
         uint32_t wasSemiTrans = command & 0x02000000;
-        command = 0x48000000 | c.packed | wasSemiTrans;
+        command = 0x48000000 | (c.packed & 0xffffff) | wasSemiTrans;
         return *this;
     }
     PolyLine& setOpaque() {

--- a/src/mips/psyqo/primitives/quads.hh
+++ b/src/mips/psyqo/primitives/quads.hh
@@ -54,7 +54,7 @@ struct Quad {
     Quad(Color c) : command(0x28000000 | c.packed) {}
     Quad& setColor(Color c) {
         uint32_t wasSemiTrans = command & 0x02000000;
-        command = 0x28000000 | c.packed | wasSemiTrans;
+        command = 0x28000000 | (c.packed & 0xffffff) | wasSemiTrans;
         return *this;
     }
     Quad& setOpaque() {
@@ -109,7 +109,7 @@ struct TexturedQuad {
     TexturedQuad(Color c) : command(0x2c000000 | c.packed) {}
     TexturedQuad& setColor(Color c) {
         uint32_t wasSemiTrans = command & 0x02000000;
-        command = 0x2c000000 | c.packed | wasSemiTrans;
+        command = 0x2c000000 | (c.packed & 0xffffff) | wasSemiTrans;
         return *this;
     }
     TexturedQuad& setOpaque() {
@@ -151,7 +151,7 @@ struct GouraudQuad {
     GouraudQuad(Color c) : command(0x38000000 | c.packed) {}
     GouraudQuad& setColorA(Color c) {
         uint32_t wasSemiTrans = command & 0x02000000;
-        command = 0x38000000 | c.packed | wasSemiTrans;
+        command = 0x38000000 | (c.packed & 0xffffff) | wasSemiTrans;
         return *this;
     }
     GouraudQuad& setColorB(Color c) {
@@ -205,7 +205,7 @@ struct GouraudQuad {
         GTE::read<GTE::Register::RGB2>(&command);
         GTE::write<GTE::Register::RGB0, GTE::Unsafe>(&b->packed);
         GTE::write<GTE::Register::RGB1, GTE::Unsafe>(&c->packed);
-        GTE::write<GTE::Register::RGB2, GTE::Unsafe>(&d->packed);
+        GTE::write<GTE::Register::RGB2, GTE::Safe>(&d->packed);
         GTE::Kernels::dpct();
         GTE::read<GTE::Register::RGB0>(&colorB.packed);
         GTE::read<GTE::Register::RGB1>(&colorC.packed);
@@ -226,7 +226,7 @@ struct GouraudQuad {
         GTE::read<GTE::Register::RGB2>(&command);
         GTE::write<GTE::Register::RGB0, GTE::Unsafe>(b.packed);
         GTE::write<GTE::Register::RGB1, GTE::Unsafe>(c.packed);
-        GTE::write<GTE::Register::RGB2, GTE::Unsafe>(d.packed);
+        GTE::write<GTE::Register::RGB2, GTE::Safe>(d.packed);
         GTE::Kernels::dpct();
         GTE::read<GTE::Register::RGB0>(&colorB.packed);
         GTE::read<GTE::Register::RGB1>(&colorC.packed);
@@ -267,7 +267,7 @@ struct GouraudTexturedQuad {
     GouraudTexturedQuad(Color c) : command(0x3c000000 | c.packed) {}
     GouraudTexturedQuad& setColorA(Color c) {
         uint32_t wasSemiTrans = command & 0x02000000;
-        command = 0x3c000000 | c.packed | wasSemiTrans;
+        command = 0x3c000000 | (c.packed & 0xffffff) | wasSemiTrans;
         return *this;
     }
     GouraudTexturedQuad& setColorB(Color c) {
@@ -305,7 +305,7 @@ struct GouraudTexturedQuad {
         GTE::read<GTE::Register::RGB2>(&command);
         GTE::write<GTE::Register::RGB0, GTE::Unsafe>(&b->packed);
         GTE::write<GTE::Register::RGB1, GTE::Unsafe>(&c->packed);
-        GTE::write<GTE::Register::RGB2, GTE::Unsafe>(&d->packed);
+        GTE::write<GTE::Register::RGB2, GTE::Safe>(&d->packed);
         GTE::Kernels::dpct();
         GTE::read<GTE::Register::RGB0>(&colorB.packed);
         GTE::read<GTE::Register::RGB1>(&colorC.packed);
@@ -326,7 +326,7 @@ struct GouraudTexturedQuad {
         GTE::read<GTE::Register::RGB2>(&command);
         GTE::write<GTE::Register::RGB0, GTE::Unsafe>(b.packed);
         GTE::write<GTE::Register::RGB1, GTE::Unsafe>(c.packed);
-        GTE::write<GTE::Register::RGB2, GTE::Unsafe>(d.packed);
+        GTE::write<GTE::Register::RGB2, GTE::Safe>(d.packed);
         GTE::Kernels::dpct();
         GTE::read<GTE::Register::RGB0>(&colorB.packed);
         GTE::read<GTE::Register::RGB1>(&colorC.packed);

--- a/src/mips/psyqo/primitives/rectangles.hh
+++ b/src/mips/psyqo/primitives/rectangles.hh
@@ -49,7 +49,7 @@ struct Rectangle {
     Rectangle(Color c) : command(BASE | c.packed) {}
     Rectangle& setColor(Color c) {
         uint32_t wasSemiTrans = command & 0x02000000;
-        command = BASE | c.packed | wasSemiTrans;
+        command = BASE | (c.packed & 0xffffff) | wasSemiTrans;
         return *this;
     }
     Rectangle& setOpaque() {
@@ -84,7 +84,7 @@ struct Pixel {
     Pixel(Color c) : command(BASE | c.packed) {}
     Pixel& setColor(Color c) {
         uint32_t wasSemiTrans = command & 0x02000000;
-        command = BASE | c.packed | wasSemiTrans;
+        command = BASE | (c.packed & 0xffffff) | wasSemiTrans;
         return *this;
     }
     Pixel& setOpaque() {
@@ -118,7 +118,7 @@ struct Rectangle8x8 {
     Rectangle8x8(Color c) : command(BASE | c.packed) {}
     Rectangle8x8& setColor(Color c) {
         uint32_t wasSemiTrans = command & 0x02000000;
-        command = BASE | c.packed | wasSemiTrans;
+        command = BASE | (c.packed & 0xffffff) | wasSemiTrans;
         return *this;
     }
     Rectangle8x8& setOpaque() {
@@ -152,7 +152,7 @@ struct Rectangle16x16 {
     Rectangle16x16(Color c) : command(BASE | c.packed) {}
     Rectangle16x16& setColor(Color c) {
         uint32_t wasSemiTrans = command & 0x02000000;
-        command = BASE | c.packed | wasSemiTrans;
+        command = BASE | (c.packed & 0xffffff) | wasSemiTrans;
         return *this;
     }
     Rectangle16x16& setOpaque() {

--- a/src/mips/psyqo/primitives/sprites.hh
+++ b/src/mips/psyqo/primitives/sprites.hh
@@ -50,7 +50,7 @@ struct Sprite {
     Sprite(Color c) : command(BASE | c.packed) {}
     Sprite& setColor(Color c) {
         uint32_t wasSemiTrans = command & 0x02000000;
-        command = BASE | c.packed | wasSemiTrans;
+        command = BASE | (c.packed & 0xffffff) | wasSemiTrans;
         return *this;
     }
     Sprite& setOpaque() {
@@ -87,7 +87,7 @@ struct Sprite1x1 {
     Sprite1x1(Color c) : command(BASE | c.packed) {}
     Sprite1x1& setColor(Color c) {
         uint32_t wasSemiTrans = command & 0x02000000;
-        command = BASE | c.packed | wasSemiTrans;
+        command = BASE | (c.packed & 0xffffff) | wasSemiTrans;
         return *this;
     }
     Sprite1x1& setOpaque() {
@@ -123,7 +123,7 @@ struct Sprite8x8 {
     Sprite8x8(Color c) : command(BASE | c.packed) {}
     Sprite8x8& setColor(Color c) {
         uint32_t wasSemiTrans = command & 0x02000000;
-        command = BASE | c.packed | wasSemiTrans;
+        command = BASE | (c.packed & 0xffffff) | wasSemiTrans;
         return *this;
     }
     Sprite8x8& setOpaque() {
@@ -159,7 +159,7 @@ struct Sprite16x16 {
     Sprite16x16(Color c) : command(BASE | c.packed) {}
     Sprite16x16& setColor(Color c) {
         uint32_t wasSemiTrans = command & 0x02000000;
-        command = BASE | c.packed | wasSemiTrans;
+        command = BASE | (c.packed & 0xffffff) | wasSemiTrans;
         return *this;
     }
     Sprite16x16& setOpaque() {

--- a/src/mips/psyqo/primitives/triangles.hh
+++ b/src/mips/psyqo/primitives/triangles.hh
@@ -47,7 +47,7 @@ struct Triangle {
     Triangle(Color c) : command(0x20000000 | c.packed) {}
     Triangle& setColor(Color c) {
         uint32_t wasSemiTrans = command & 0x02000000;
-        command = 0x20000000 | c.packed | wasSemiTrans;
+        command = 0x20000000 | (c.packed & 0xffffff) | wasSemiTrans;
         return *this;
     }
     Triangle& setOpaque() {
@@ -98,7 +98,7 @@ struct TexturedTriangle {
     TexturedTriangle(Color c) : command(0x24000000 | c.packed) {}
     TexturedTriangle& setColor(Color c) {
         uint32_t wasSemiTrans = command & 0x02000000;
-        command = 0x24000000 | c.packed | wasSemiTrans;
+        command = 0x24000000 | (c.packed & 0xffffff) | wasSemiTrans;
         return *this;
     }
     TexturedTriangle& setOpaque() {
@@ -138,7 +138,7 @@ struct GouraudTriangle {
     GouraudTriangle(Color c) : command(0x30000000 | c.packed) {}
     GouraudTriangle& setColorA(Color c) {
         uint32_t wasSemiTrans = command & 0x02000000;
-        command = 0x30000000 | c.packed | wasSemiTrans;
+        command = 0x30000000 | (c.packed & 0xffffff) | wasSemiTrans;
         return *this;
     }
     GouraudTriangle& setColorB(Color c) {
@@ -235,7 +235,7 @@ struct GouraudTexturedTriangle {
     GouraudTexturedTriangle(Color c) : command(0x34000000 | c.packed) {}
     GouraudTexturedTriangle& setColorA(Color c) {
         uint32_t wasSemiTrans = command & 0x02000000;
-        command = 0x34000000 | c.packed | wasSemiTrans;
+        command = 0x34000000 | (c.packed & 0xffffff) | wasSemiTrans;
         return *this;
     }
     GouraudTexturedTriangle& setColorB(Color c) {


### PR DESCRIPTION
Had an issue that only showed up on HW and now in emulators. Turns out it was caused by unsafe write before `dpct`.
https://github.com/user-attachments/assets/aec0b48b-a2d5-4cce-ae55-ec48a3939f64
(the flickering vertex colors when doing interpolation)

Also added some safeguards against bad psyqo::Color being passed into the primitives when it can potentially affect the command (e.g. in setColor/setColorA).
E.g. consider this case:

```cpp
psyqo::Color c;
c.r = 0xAB;
c.g = 0xCD;
c.b = 0xEF;
// the value of c.packed is <??>EFCDAB
```
Or you could possibly read the color from some RGB register and if it has the MSB set... you'd get tons of corruptions and crashes on HW. To prevent that, we need to mask away those potentially "dirty" bits in everything.