### PR TITLE
Remove unneeded coroutines flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,10 +62,7 @@ CPPFLAGS_lto += -O3 -flto=auto -fno-fat-lto-objects -flto-partition=one
 CPPFLAGS_ReleaseWithTracy += -O3 -DTRACY_ENABLE
 
 ifeq ($(CC_IS_CLANG),true)
-    CXXFLAGS += -fcoroutines-ts
     LUAJIT_CFLAGS = -fno-stack-check
-else
-    CXXFLAGS += -fcoroutines
 endif
 
 ifeq ($(UNAME_S),Darwin)


### PR DESCRIPTION
clang and gcc appear to have both enabled coroutines by default, and the removal of the `-fcoroutines-ts` flag in clang was causing compilation errors. This PR simply removes the coroutines CXX flags as they're no longer needed and cause errors in some configurations.

The following systems and compilers were tested and found to work with this change:

**Arch Linux**
* gcc 14
* clang 18

**Ubuntu 24.04**
* gcc 13
* gcc 12
* gcc 11
* clang 17
* clang 16
* clang 15