### PR TITLE
fix trX, Y and Z not switching to fixed point representation

### DIFF
--- a/src/gui/widgets/registers.cc
+++ b/src/gui/widgets/registers.cc
@@ -295,9 +295,15 @@ void PCSX::Widgets::Registers::draw(PCSX::GUI* gui, PCSX::psxRegisters* register
                 z /= magnitude;
                 ImGui::Text(" :: axis : {%3.5f, %3.5f, %3.5f}", x, y, z);
             }
-            ImGui::Text("trX : %i", registers->CP2C.n.trX);
-            ImGui::Text("trY : %i", registers->CP2C.n.trY);
-            ImGui::Text("trZ : %i", registers->CP2C.n.trZ);
+            if (showFixed) {
+                ImGui::Text("trX : % 3.5f", fixedToFloat(registers->CP2C.n.trX));
+                ImGui::Text("trY : % 3.5f", fixedToFloat(registers->CP2C.n.trY));
+                ImGui::Text("trZ : % 3.5f", fixedToFloat(registers->CP2C.n.trZ));
+            } else {
+                ImGui::Text("trX : %i", registers->CP2C.n.trX);
+                ImGui::Text("trY : %i", registers->CP2C.n.trY);
+                ImGui::Text("trZ : %i", registers->CP2C.n.trZ);
+            }
             displayMatrix(registers->CP2C.n.lMatrix, "L");
             if (showFixed) {
                 ImGui::Text("rbk : % 3.5f", fixedToFloat(registers->CP2C.n.rbk));


### PR DESCRIPTION
I can't for the life of me write short commit messages 😅 

Previously the tr{X, Y, Z} Registers kept being shown as their raw representation despite the 'Show fixed point' checkbox being ticked:
<img width="335" alt="image" src="https://github.com/user-attachments/assets/bed46057-8933-46db-a941-87ba7fd4d063">

This PR fixes this minor issue.
