### PR TITLE
Fix missing template arguments in eastl::forward calls

### DIFF
--- a/src/mips/psyqo/bump-allocator.h
+++ b/src/mips/psyqo/bump-allocator.h
@@ -60,7 +60,7 @@ class BumpAllocator {
         psyqo::Kernel::assert(remaining() >= size, "BumpAllocator: Out of memory");
         uint8_t *ptr = m_current;
         m_current += size;
-        return *new (ptr) Fragments::SimpleFragment<P>(eastl::forward(args)...);
+        return *new (ptr) Fragments::SimpleFragment<P>(eastl::forward<Args>(args)...);
     }
     template <typename T, typename... Args>
     T &allocate(Args &&...args) {
@@ -74,7 +74,7 @@ class BumpAllocator {
         }
         psyqo::Kernel::assert(remaining() >= size, "BumpAllocator: Out of memory");
         m_current += size;
-        return *new (ptr) T(eastl::forward(args)...);
+        return *new (ptr) T(eastl::forward<Args>(args)...);
     }
     void reset() { m_current = m_memory; }
     size_t remaining() const { return N - (m_current - m_memory); }


### PR DESCRIPTION
Getting stuff like this otherwise:

```
/home/eliasdaler/work/ps1dev/cmake/../third_party/nugget/psyqo/../psyqo/bump-allocator.h: In instantiation of ‘psyqo::Fragments::SimpleFragment<P>& psyqo::BumpAllocator<N>::allocateFragment(Args&& ...) [with P = psyqo::Prim::MaskControl; Args = {psyqo::Prim::MaskControl::Set, psyqo::Prim::MaskControl::Test}; unsigned int N = 327680]’:
/home/eliasdaler/work/ps1dev/games/cat_adventure/src/GameplayScene.cpp:652:78:   required from here
  652 |         auto& maskBit = primBuffer.allocateFragment<psyqo::Prim::MaskControl>(
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
  653 |             psyqo::Prim::MaskControl::Set::FromSource, psyqo::Prim::MaskControl::Test::No);
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/eliasdaler/work/ps1dev/cmake/../third_party/nugget/psyqo/../psyqo/bump-allocator.h:65:70: error: no matching function for call to ‘forward(psyqo::Prim::MaskControl::Set&)’
   65 |         return *new (ptr) Fragments::SimpleFragment<P>(eastl::forward(args)...);
      |                                                        ~~~~~~~~~~~~~~^~~~~~
In file included from /home/eliasdaler/work/ps1dev/cmake/../third_party/nugget/third_party/EASTL/include/EASTL/iterator.h:11,
                 from /home/eliasdaler/work/ps1dev/cmake/../third_party/nugget/third_party/EASTL/include/EASTL/vector.h:39,
                 from /home/eliasdaler/work/ps1dev/cmake/../third_party/nugget/third_party/EASTL/include/EASTL/fixed_vector.h:16,
                 from /home/eliasdaler/work/ps1dev/cmake/../third_party/nugget/psyqo/../psyqo/application.hh:29,
                 from /home/eliasdaler/work/ps1dev/cmake/../third_party/nugget/psyqo/../psyqo/scene.hh:29,
                 from /home/eliasdaler/work/ps1dev/games/cat_adventure/src/GameplayScene.h:3:
/home/eliasdaler/work/ps1dev/cmake/../third_party/nugget/third_party/EASTL/include/EASTL/internal/move_help.h:88:32: note: candidate: ‘template<class T> constexpr T&& eastl::forward(typename remove_reference<T>::type&)’
   88 |         EA_CPP14_CONSTEXPR T&& forward(typename eastl::remove_reference<T>::type& x) EA_NOEXCEPT
      |                                ^~~~~~~
/home/eliasdaler/work/ps1dev/cmake/../third_party/nugget/third_party/EASTL/include/EASTL/internal/move_help.h:88:32: note:   template argument deduction/substitution failed:
/home/eliasdaler/work/ps1dev/cmake/../third_party/nugget/psyqo/../psyqo/bump-allocator.h:65:70: note:   couldn’t deduce template parameter ‘T’
   65 |         return *new (ptr) Fragments::SimpleFragment<P>(eastl::forward(args)...);
      |                                                        ~~~~~~~~~~~~~~^~~~~~
/home/eliasdaler/work/ps1dev/cmake/../third_party/nugget/third_party/EASTL/include/EASTL/internal/move_help.h:95:32: note: candidate: ‘template<class T> constexpr T&& eastl::forward(typename remove_reference<T>::type&&)’
   95 |         EA_CPP14_CONSTEXPR T&& forward(typename eastl::remove_reference<T>::type&& x) EA_NOEXCEPT
      |                                ^~~~~~~
/home/eliasdaler/work/ps1dev/cmake/../third_party/nugget/third_party/EASTL/include/EASTL/internal/move_help.h:95:32: note:   template argument deduction/substitution failed:
/home/eliasdaler/work/ps1dev/cmake/../third_party/nugget/psyqo/../psyqo/bump-allocator.h:65:70: note:   couldn’t deduce template parameter ‘T’
   65 |         return *new (ptr) Fragments::SimpleFragment<P>(eastl::forward(args)...);
      |                                                        ~~~~~~~~~~~~~~^~~~~~
[14/18] Building CXX object cat_adventure/CMakeFiles/game.dir/src/Game.cpp.obj
```