### PR TITLE
Fix null pointer error in a psyqo cube template

### DIFF
--- a/tools/vscode-extension/templates/psyqo/cube/main.cpp
+++ b/tools/vscode-extension/templates/psyqo/cube/main.cpp
@@ -125,7 +125,7 @@ void CubeScene::frame() {
     psyqo::SoftMath::multiplyMatrix33(transform, rot, &transform);
 
     // Generate a Z-axis rotation matrix (Empty, but it's here for your use)
-    psyqo::SoftMath::generateRotationMatrix33(0, 0, psyqo::SoftMath::Axis::Z, cube.m_trig);
+    psyqo::SoftMath::generateRotationMatrix33(&rot, 0, psyqo::SoftMath::Axis::Z, cube.m_trig);
 
     // Apply the combined rotation and write it to the pseudo register for the cube's rotation
     psyqo::SoftMath::multiplyMatrix33(transform, rot, &transform);


### PR DESCRIPTION
The first parameter of four parameter method `generateRotationMatrix33` expects a pointer to a `Matrix33`. When a 0 is passed, it is interpreted as a null pointer that is later dereferenced to set the matrix and that causes an error.