### PR TITLE
Doc: Update linux gdb-multiarch install instructions

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/coderabbit-overrides.v2.json
+language: "en" # English
+early_access: false
+reviews:
+  high_level_summary: false # Disable the high level summary because this feature modifies the original PR description. Ideally this feature would add a new comment to the PR instead of modifying the original PR description.
+  poem: false # Disable the poem feature because it adds noise and doesn't improve the review process.
+  review_status: false
+  collapse_walkthrough: true
+  path_filters: []
+  path_instructions: []
+  auto_review:
+    enabled: false
+    drafts: false
+    base_branches: []
+chat:
+  auto_reply: false

--- a/docs/Debugging/gdb-server.md
+++ b/docs/Debugging/gdb-server.md
@@ -22,14 +22,21 @@ Download a pre-compiled version from here : [https://static.grumpycoder.net/pixe
 
 ### GNU/Linux
 
+#### Debian based
+
 Install via your package manager :
 
 ```bash
 # Debian derivative; Ubuntu, Mint...
 sudo apt install gdb-multiarch
-# Arch derivative; Manjaro
-# 'gdb-multiarch' is available in aur : https://aur.archlinux.org/packages/gdb-multiarch/
-sudo trizen -S gdb-multiarch
+```
+
+#### Arch based
+
+On Arch based distributions, multiarch is now [enabled by default](https://gitlab.archlinux.org/archlinux/packaging/packages/gdb/-/blob/main/PKGBUILD?ref_type=heads#L50) in regular builds and you don't need to install a specific version anymore.  
+You can install the 'gdb' package with `pacman` :  
+```
+sudo pacman -S gdb
 ```
 
 ## IDE setup


### PR DESCRIPTION
On Arch based distributions, multiarch is now [enabled by default](https://gitlab.archlinux.org/archlinux/packaging/packages/gdb/-/blob/main/PKGBUILD?ref_type=heads#L50) in regular gdb builds and you don't need to install a specific version anymore.  

The doc was edited to reflect that.