### PR TITLE
Fix compilation error for gpu.chain(ot)

### DIFF
--- a/src/mips/psyqo/gpu.hh
+++ b/src/mips/psyqo/gpu.hh
@@ -351,8 +351,8 @@ class GPU {
      *
      * @param table The ordering table to chain.
      */
-    template <size_t N>
-    void chain(OrderingTable<N> &table) {
+    template <size_t N, Safe safety = Safe::Yes>
+    void chain(OrderingTable<N, safety> &table) {
         chain(&table.m_table[N], &table.m_table[0], 0);
         scheduleOTC(&table.m_table[N], N + 1);
     }

--- a/src/mips/psyqo/gpu.hh
+++ b/src/mips/psyqo/gpu.hh
@@ -43,6 +43,7 @@ SOFTWARE.
 #include "psyqo/primitives/common.hh"
 #include "psyqo/primitives/control.hh"
 #include "psyqo/primitives/misc.hh"
+#include "psyqo/shared.hh"
 
 namespace psyqo {
 


### PR DESCRIPTION
Getting this error without it:
```
/home/eliasdaler/work/ps1dev/games/minimal/main.cpp: In member function ‘virtual void {anonymous}::Scene::frame()’:
/home/eliasdaler/work/ps1dev/games/minimal/main.cpp:201:16: error: no matching function for call to ‘psyqo::GPU::chain(psyqo::OrderingTable<1024, psyqo::Safe::No>&)’
  201 |     gpu().chain(ot);
      |     ~~~~~~~~~~~^~~~
In file included from /home/eliasdaler/work/ps1dev/cmake/../third_party/nugget/psyqo/../psyqo/application.hh:31,
                 from /home/eliasdaler/work/ps1dev/games/minimal/main.cpp:2:
/home/eliasdaler/work/ps1dev/cmake/../third_party/nugget/psyqo/../psyqo/gpu.hh:326:10: note: candidate: ‘template<class Frag>  requires  Fragment<Frag> void psyqo::GPU::chain(Frag&)’
  326 |     void chain(Frag &fragment) {
      |          ^~~~~
/home/eliasdaler/work/ps1dev/cmake/../third_party/nugget/psyqo/../psyqo/gpu.hh:326:10: note:   template argument deduction/substitution failed:
/home/eliasdaler/work/ps1dev/cmake/../third_party/nugget/psyqo/../psyqo/gpu.hh:326:10: note: constraints not satisfied
In file included from /home/eliasdaler/work/ps1dev/cmake/../third_party/nugget/psyqo/../psyqo/gpu.hh:38:
/home/eliasdaler/work/ps1dev/cmake/../third_party/nugget/psyqo/../psyqo/fragment-concept.hh: In substitution of ‘template<class Frag>  requires  Fragment<Frag> void psyqo::GPU::chain(Frag&) [with Frag = psyqo::OrderingTable<1024, psyqo::Safe::No>]’:
/home/eliasdaler/work/ps1dev/games/minimal/main.cpp:201:16:   required from here
  201 |     gpu().chain(ot);
      |     ~~~~~~~~~~~^~~~
/home/eliasdaler/work/ps1dev/cmake/../third_party/nugget/psyqo/../psyqo/fragment-concept.hh:51:9:   required for the satisfaction of ‘Fragment<Frag>’ [with Frag = psyqo::OrderingTable<1024, psyqo::Safe::No>]
/home/eliasdaler/work/ps1dev/cmake/../third_party/nugget/psyqo/../psyqo/fragment-concept.hh:51:20:   in requirements with ‘Frag frag’ [with Frag = psyqo::OrderingTable<1024, psyqo::Safe::No>]
/home/eliasdaler/work/ps1dev/cmake/../third_party/nugget/psyqo/../psyqo/fragment-concept.hh:54:27: note: the required expression ‘(sizeof (frag.head) == 4)’ is invalid
   54 |     { (sizeof(frag.head)) == 4 };
      |       ~~~~~~~~~~~~~~~~~~~~^~~~
/home/eliasdaler/work/ps1dev/cmake/../third_party/nugget/psyqo/../psyqo/fragment-concept.hh:55:36: note: the required expression ‘((offsetof(Frag, head) & 3) == 0)’ is invalid
   55 |     { ((offsetof(Frag, head)) & 3) == 0 };
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
/home/eliasdaler/work/ps1dev/cmake/../third_party/nugget/psyqo/../psyqo/fragment-concept.hh:58:33: note: the required expression ‘frag.getActualFragmentSize()’ is invalid
   58 |     { frag.getActualFragmentSize() } -> std::convertible_to<size_t>;
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~^~
cc1plus: note: set ‘-fconcepts-diagnostics-depth=’ to at least 2 for more detail
/home/eliasdaler/work/ps1dev/cmake/../third_party/nugget/psyqo/../psyqo/gpu.hh:340:10: note: candidate: ‘template<class Frag1, class Frag2>  requires (Fragment<Frag1>) && (Fragment<Frag2>) void psyqo::GPU::chain(Frag1*, Frag2*)’
  340 |     void chain(Frag1 *first, Frag2 *last) {
      |          ^~~~~
/home/eliasdaler/work/ps1dev/cmake/../third_party/nugget/psyqo/../psyqo/gpu.hh:340:10: note:   candidate expects 2 arguments, 1 provided
/home/eliasdaler/work/ps1dev/cmake/../third_party/nugget/psyqo/../psyqo/gpu.hh:355:10: note: candidate: ‘template<unsigned int N, psyqo::Safe safety> void psyqo::GPU::chain(psyqo::OrderingTable<N>&)’
  355 |     void chain(OrderingTable<N> &table) {
      |          ^~~~~
/home/eliasdaler/work/ps1dev/cmake/../third_party/nugget/psyqo/../psyqo/gpu.hh:355:10: note:   template argument deduction/substitution failed:
/home/eliasdaler/work/ps1dev/games/minimal/main.cpp:201:16: note:   template argument ‘psyqo::Safe::No’ does not match ‘psyqo::Safe::Yes’
  201 |     gpu().chain(ot);
      |     ~~~~~~~~~~~^~~~
```