### PR TITLE
Make pause key unpause as well

### DIFF
--- a/src/gui/gui.cc
+++ b/src/gui/gui.cc
@@ -980,7 +980,7 @@ void PCSX::GUI::startFrame() {
             } else {
                 g_emulator->m_debug->stepIn();
             }
-        } else if (ImGui::IsKeyPressed(ImGuiKey_F5)) {
+        } else if (ImGui::IsKeyPressed(ImGuiKey_Pause) || ImGui::IsKeyPressed(ImGuiKey_F5)) {
             g_system->resume();
         }
     } else {


### PR DESCRIPTION
Having separate keys for pausing and unpausing the emulator felt unintuitive and tripped me up a few times whilst debugging, so I changed the keybinds. Now the pause key can be used for unpausing as well, which feels much better.