### PR TITLE
Breakpoint usability improvements

### DIFF
--- a/src/core/debug.cc
+++ b/src/core/debug.cc
@@ -288,6 +288,7 @@ bool PCSX::Debug::triggerBP(Breakpoint* bp, uint32_t address, unsigned width, co
     if (g_system->running()) return keepBP;
     m_step = STEP_NONE;
     g_system->printf(_("Breakpoint triggered: PC=0x%08x - Cause: %s %s\n"), pc, name, cause);
+    g_system->m_eventBus->signal(Events::GUI::JumpToPC{pc});
     return keepBP;
 }
 

--- a/src/gui/widgets/assembly.h
+++ b/src/gui/widgets/assembly.h
@@ -45,7 +45,10 @@ class Assembly : private Disasm {
   public:
     Assembly(bool& show, std::vector<std::string>& favorites)
         : m_show(show), m_listener(g_system->m_eventBus), m_symbolsFileDialog(l_("Load Symbols"), favorites) {
-        m_listener.listen<Events::GUI::JumpToPC>([this](const auto& event) { m_jumpToPC = event.pc; });
+        m_listener.listen<Events::GUI::JumpToPC>([this](const auto& event) {
+            m_jumpToPC = event.pc;
+            m_show = true;
+        });
         memset(m_jumpAddressString, 0, sizeof(m_jumpAddressString));
     }
     bool draw(GUI* gui, psxRegisters* registers, Memory* memory, const char* title);


### PR DESCRIPTION
I've made two usability improvements to the behavior when a breakpoint is triggered:
- open and focus the assembly view if none was open
- the assembly view will now jump to the current PC

I think it makes sense to jump to the current PC in the assembly view upon hitting a breakpoint. Most debuggers I've used behaved in this fashion. And opening the assembly view if none was present also seems like a sensible change.