### PR TITLE
Open VRAM viewer on focus event

### DIFF
--- a/src/gui/widgets/vram-viewer.cc
+++ b/src/gui/widgets/vram-viewer.cc
@@ -358,6 +358,7 @@ PCSX::Widgets::VRAMViewer::VRAMViewer(bool &show) : m_show(show), m_listener(g_s
     m_listener.listen<PCSX::Events::GUI::VRAMFocus>([this](auto event) {
         if (!m_isMain) return;
         bool changed = false;
+        m_show = true;
         switch (event.vramMode) {
             case PCSX::Events::GUI::VRAM_4BITS:
                 if (m_vramMode != VRAM_4BITS) {


### PR DESCRIPTION
Currently nothing happens when clicking the "Go to texture/CLUT/primitive" buttons in the GPU logger if there is no VRAM viewer open, which might be confusing to fresh users.

This PR makes the VRAM viewer open automatically on a focus event, which is probably more intuitive than having no reaction when said buttons are clicked with no VRAM viewer open.