### PR TITLE
Make clicks in assembly view open the memory editor

### DIFF
--- a/src/core/system.h
+++ b/src/core/system.h
@@ -89,7 +89,6 @@ struct JumpToMemory {
     uint32_t address;
     unsigned size;
     unsigned editorNum;
-    bool forceShowEditor;
 };
 struct SelectClut {
     unsigned x, y;

--- a/src/gui/gui.cc
+++ b/src/gui/gui.cc
@@ -834,7 +834,6 @@ void PCSX::GUI::init(std::function<void()> applyArguments) {
         const uint32_t real = event.address & 0x7fffff;
         const uint32_t size = event.size;
         const uint32_t editorNum = event.editorNum;
-        const bool forceShowEditor = event.forceShowEditor;
         auto changeDataType = [](MemoryEditor* editor, int size) {
             bool isSigned = false;
             switch (editor->PreviewDataType) {
@@ -859,13 +858,13 @@ void PCSX::GUI::init(std::function<void()> applyArguments) {
         };
         if ((base == 0x000) || (base == 0x800) || (base == 0xa00)) {
             if (real < 0x00800000) {
-                if (forceShowEditor) m_mainMemEditors[editorNum].m_show = true;
+                m_mainMemEditors[editorNum].m_show = true;
                 m_mainMemEditors[editorNum].editor.GotoAddrAndHighlight(real, real + size);
                 changeDataType(&m_mainMemEditors[editorNum].editor, size);
             }
         } else if (base == 0x1f8) {
             if (real >= 0x1000 && real < 0x3000) {
-                if (forceShowEditor) m_hwrEditor.m_show = true;
+                m_hwrEditor.m_show = true;
                 m_hwrEditor.editor.GotoAddrAndHighlight(real - 0x1000, real - 0x1000 + size);
                 changeDataType(&m_hwrEditor.editor, size);
             }

--- a/src/gui/widgets/assembly.cc
+++ b/src/gui/widgets/assembly.cc
@@ -326,19 +326,18 @@ const uint8_t* PCSX::Widgets::Assembly::ptr(uint32_t addr) {
         return dummy;
     }
 }
-void PCSX::Widgets::Assembly::jumpToMemory(uint32_t addr, unsigned size, unsigned editorIndex /* = 0*/,
-                                           bool forceShowEditor /* = false*/) {
-    g_system->m_eventBus->signal(PCSX::Events::GUI::JumpToMemory{addr, size, editorIndex, forceShowEditor});
+void PCSX::Widgets::Assembly::jumpToMemory(uint32_t addr, unsigned size, unsigned editorIndex /* = 0*/) {
+    g_system->m_eventBus->signal(PCSX::Events::GUI::JumpToMemory{addr, size, editorIndex});
 }
 void PCSX::Widgets::Assembly::addMemoryEditorContext(uint32_t addr, int size) {
     if (ImGui::BeginPopupContextItem()) {
-        if (ImGui::MenuItem(_("Go to in Memory Editor #1 (Default Click)"))) jumpToMemory(addr, size, 0, true);
-        if (ImGui::MenuItem(_("Go to in Memory Editor #2 (Shift+Click)"))) jumpToMemory(addr, size, 1, true);
-        if (ImGui::MenuItem(_("Go to in Memory Editor #3 (Ctrl+Click)"))) jumpToMemory(addr, size, 2, true);
+        if (ImGui::MenuItem(_("Go to in Memory Editor #1 (Default Click)"))) jumpToMemory(addr, size, 0);
+        if (ImGui::MenuItem(_("Go to in Memory Editor #2 (Shift+Click)"))) jumpToMemory(addr, size, 1);
+        if (ImGui::MenuItem(_("Go to in Memory Editor #3 (Ctrl+Click)"))) jumpToMemory(addr, size, 2);
         std::string itemLabel;
         for (unsigned i = 3; i < 8; ++i) {
             itemLabel = fmt::format(f_("Go to in Memory Editor #{}"), i + 1);
-            if (ImGui::MenuItem(itemLabel.c_str())) jumpToMemory(addr, size, i, true);
+            if (ImGui::MenuItem(itemLabel.c_str())) jumpToMemory(addr, size, i);
         }
         if (ImGui::MenuItem(_("Create Memory Read Breakpoint"))) {
             g_emulator->m_debug->addBreakpoint(addr, Debug::BreakpointType::Read, size, _("GUI"));
@@ -354,7 +353,7 @@ void PCSX::Widgets::Assembly::addMemoryEditorSubMenu(uint32_t addr, int size) {
         std::string itemLabel;
         for (unsigned i = 0; i < 8; ++i) {
             itemLabel = fmt::format("#{}", i + 1);
-            if (ImGui::MenuItem(itemLabel.c_str())) jumpToMemory(addr, size, i, true);
+            if (ImGui::MenuItem(itemLabel.c_str())) jumpToMemory(addr, size, i);
         }
         ImGui::EndMenu();
     }
@@ -381,7 +380,7 @@ void PCSX::Widgets::Assembly::OfB(int16_t offset, uint8_t reg, int size) {
     ImGui::TextUnformatted(" ");
     ImGui::SameLine(0.0f, 0.0f);
     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
-    if (ImGui::Button(label)) jumpToMemory(addr, size, targetEditorIndex, false);
+    if (ImGui::Button(label)) jumpToMemory(addr, size, targetEditorIndex);
     ImGui::PopStyleVar();
     addMemoryEditorContext(addr, size);
     if (ImGui::IsItemHovered()) {
@@ -442,7 +441,7 @@ void PCSX::Widgets::Assembly::Offset(uint32_t addr, int size) {
     ImGui::TextUnformatted(" ");
     sameLine();
     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
-    if (ImGui::Button(longLabel.c_str())) jumpToMemory(addr, size, targetEditorIndex, false);
+    if (ImGui::Button(longLabel.c_str())) jumpToMemory(addr, size, targetEditorIndex);
     ImGui::PopStyleVar();
     addMemoryEditorContext(addr, size);
     if (ImGui::IsItemHovered()) {

--- a/src/gui/widgets/assembly.h
+++ b/src/gui/widgets/assembly.h
@@ -72,7 +72,7 @@ class Assembly : private Disasm {
     void sameLine();
     void comma();
     const uint8_t* ptr(uint32_t addr);
-    void jumpToMemory(uint32_t addr, unsigned size, unsigned editorIndex = 0, bool forceShowEditor = false);
+    void jumpToMemory(uint32_t addr, unsigned size, unsigned editorIndex = 0);
     uint8_t mem8(uint32_t addr);
     uint16_t mem16(uint32_t addr);
     uint32_t mem32(uint32_t addr);

--- a/src/gui/widgets/breakpoints.cc
+++ b/src/gui/widgets/breakpoints.cc
@@ -122,7 +122,7 @@ void PCSX::Widgets::Breakpoints::draw(const char* title) {
                         g_system->m_eventBus->signal(PCSX::Events::GUI::JumpToPC{bp->address() | bp->base()});
                     } else {
                         g_system->m_eventBus->signal(
-                            PCSX::Events::GUI::JumpToMemory{bp->address() | bp->base(), bp->width(), 0, true});
+                            PCSX::Events::GUI::JumpToMemory{bp->address() | bp->base(), bp->width(), 0});
                     }
                 }
                 if (ImGui::BeginPopupContextItem()) {


### PR DESCRIPTION
This changes the behavior when clicking highlighted offsets in the assembly view. We open a memory editor if there was none to avoid some possible user confusion as to why the buttons do nothing. The new behavior is also consistent with how the context menu "Go to in memory editor" actions work.