### PR TITLE
Set Terminal to false in desktop entry

### DIFF
--- a/resources/pcsx-redux.desktop
+++ b/resources/pcsx-redux.desktop
@@ -2,7 +2,7 @@
 Name=PCSX-Redux
 Exec=/usr/bin/pcsx-redux
 Icon=pcsx-redux
-Terminal=true
+Terminal=false
 Type=Application
 Categories=Game;Emulator
 X-KDE-RunOnDiscreteGpu=true


### PR DESCRIPTION
Simple change, ran into this issue as AppImageLauncher would not pop up to integrate the AppImage into the system if Terminal is set to true