### PR TITLE
Implement DMA-msan compatibility

### DIFF
--- a/src/core/gpu.cc
+++ b/src/core/gpu.cc
@@ -446,7 +446,7 @@ uint32_t PCSX::GPU::gpuDmaChainSize(uint32_t addr) {
 
     do {
         uint32_t header;
-        if (usingMsan && addr >= PCSX::Memory::c_msanStart && addr < PCSX::Memory::c_msanEnd) {
+        if (usingMsan && PCSX::Memory::inMsanRange(addr)) {
             addr &= 0xfffffffc;
             header = *(uint32_t *) (g_emulator->m_mem->m_msanRAM + (addr - PCSX::Memory::c_msanStart));
         } else {
@@ -699,7 +699,7 @@ void PCSX::GPU::chainedDMAWrite(const uint32_t *memory, uint32_t hwAddr) {
     do {
         uint32_t header;
         const uint32_t *feed;
-        if (usingMsan && addr >= PCSX::Memory::c_msanStart && addr < PCSX::Memory::c_msanEnd) {
+        if (usingMsan && PCSX::Memory::inMsanRange(addr)) {
             addr &= 0xfffffffc;
             const uint32_t *headerPtr = (uint32_t *) (g_emulator->m_mem->m_msanRAM + (addr - PCSX::Memory::c_msanStart));
             header = *headerPtr;

--- a/src/core/gpu.cc
+++ b/src/core/gpu.cc
@@ -473,7 +473,7 @@ uint32_t PCSX::GPU::gpuDmaChainSize(uint32_t addr) {
         size += (header >> 24) + 1;
 
         // next 32-bit pointer
-        uint32_t nextAddr = header & 0xfffffc;
+        uint32_t nextAddr = header & 0xffffff;
         if (usingMsan && nextAddr == PCSX::Memory::c_msanChainMarker) {
             addr = g_emulator->m_mem->msanGetChainPtr(addr);
             continue;
@@ -745,7 +745,7 @@ void PCSX::GPU::chainedDMAWrite(const uint32_t *memory, uint32_t hwAddr) {
         }
 
         // next 32-bit pointer
-        uint32_t nextAddr = header & 0xfffffc;
+        uint32_t nextAddr = header & 0xffffff;
         if (usingMsan && nextAddr == PCSX::Memory::c_msanChainMarker) {
             addr = g_emulator->m_mem->msanGetChainPtr(addr);
             continue;

--- a/src/core/gpu.cc
+++ b/src/core/gpu.cc
@@ -448,7 +448,7 @@ uint32_t PCSX::GPU::gpuDmaChainSize(uint32_t addr) {
         uint32_t header;
         if (usingMsan && PCSX::Memory::inMsanRange(addr)) {
             addr &= 0xfffffffc;
-            switch (g_emulator->m_mem->msanGetStatus(addr, 4)) {
+            switch (g_emulator->m_mem->msanGetStatus<4>(addr)) {
                 case PCSX::MsanStatus::UNINITIALIZED:
                     g_system->log(LogClass::GPU, _("GPU DMA went into usable but uninitialized msan memory: %8.8lx\n"), addr);
                     g_system->pause();
@@ -714,7 +714,7 @@ void PCSX::GPU::chainedDMAWrite(const uint32_t *memory, uint32_t hwAddr) {
         if (usingMsan && PCSX::Memory::inMsanRange(addr)) {
             addr &= 0xfffffffc;
             const uint32_t *headerPtr = (uint32_t *) (g_emulator->m_mem->m_msanRAM + (addr - PCSX::Memory::c_msanStart));
-            switch (g_emulator->m_mem->msanGetStatus(addr, 4)) {
+            switch (g_emulator->m_mem->msanGetStatus<4>(addr)) {
                 case PCSX::MsanStatus::UNINITIALIZED:
                     g_system->log(LogClass::GPU, _("GPU DMA went into usable but uninitialized msan memory: %8.8lx\n"), addr);
                     g_system->pause();

--- a/src/core/psxdma.cc
+++ b/src/core/psxdma.cc
@@ -99,8 +99,7 @@ void dma6(uint32_t madr, uint32_t bcr, uint32_t chcr) {
         // already 32-bit size
         size = bcr;
 
-        if (PCSX::g_emulator->m_mem->msanInitialized() && madr >= PCSX::Memory::c_msanStart && madr < PCSX::Memory::c_msanEnd) {
-            uint32_t msanAddress = madr - PCSX::Memory::c_msanStart;
+        if (PCSX::g_emulator->m_mem->msanInitialized() && PCSX::Memory::inMsanRange(madr)) {
             while (bcr--) {
                 // use write32 instead of the direct pointer so that the msan memory gets marked as usable
                 PCSX::g_emulator->m_mem->write32(madr, PCSX::Memory::c_msanChainMarker);

--- a/src/core/psxhw.h
+++ b/src/core/psxhw.h
@@ -77,7 +77,7 @@ class HW {
                 do {
 					if (usingMsan && PCSX::Memory::inMsanRange(madr)) {
                         madr &= 0xfffffffc;
-						switch (g_emulator->m_mem->msanGetStatus(madr, 4)) {
+						switch (g_emulator->m_mem->msanGetStatus<4>(madr)) {
 							case PCSX::MsanStatus::UNINITIALIZED:
 								g_system->log(LogClass::GPU, _("GPU DMA went into usable but uninitialized msan memory: %8.8lx\n"), madr);
 								g_system->pause();

--- a/src/core/psxhw.h
+++ b/src/core/psxhw.h
@@ -50,7 +50,7 @@ class HW {
         if ((chcr & 0x01000000) && mem->template isDMAEnabled<n>()) {
             uint32_t madr = mem->template getMADR<n>();
             bool usingMsan = g_emulator->m_mem->msanInitialized();
-            if (usingMsan && madr >= Memory::c_msanStart && madr < Memory::c_msanEnd) {
+			if (usingMsan && PCSX::Memory::inMsanRange(madr)) {
                 madr &= 0xfffffffc;
             } else {
                 madr &= 0x7ffffc;
@@ -75,8 +75,7 @@ class HW {
                 uint32_t DMACommandCounter = 0;
 
                 do {
-                    uint32_t *madrAsPtr;
-                    if (usingMsan && madr >= Memory::c_msanStart && madr < Memory::c_msanEnd) {
+					if (usingMsan && PCSX::Memory::inMsanRange(madr)) {
                         madr &= 0xfffffffc;
                     } else {
                         madr &= 0x7ffffc;

--- a/src/core/psxhw.h
+++ b/src/core/psxhw.h
@@ -77,6 +77,18 @@ class HW {
                 do {
 					if (usingMsan && PCSX::Memory::inMsanRange(madr)) {
                         madr &= 0xfffffffc;
+						switch (g_emulator->m_mem->msanGetStatus(madr, 4)) {
+							case PCSX::MsanStatus::UNINITIALIZED:
+								g_system->log(LogClass::GPU, _("GPU DMA went into usable but uninitialized msan memory: %8.8lx\n"), madr);
+								g_system->pause();
+								return;
+							case PCSX::MsanStatus::UNUSABLE:
+								g_system->log(LogClass::GPU, _("GPU DMA went into unusable msan memory: %8.8lx\n"), madr);
+								g_system->pause();
+								return;
+							case PCSX::MsanStatus::OK:
+								break;
+						}
                     } else {
                         madr &= 0x7ffffc;
                     }

--- a/src/core/psxinterpreter.cc
+++ b/src/core/psxinterpreter.cc
@@ -997,7 +997,9 @@ void InterpretedCPU::psxSW(uint32_t code) {
 void InterpretedCPU::psxSWL(uint32_t code) {
     uint32_t addr = _oB_;
     uint32_t shift = addr & 3;
-    uint32_t mem = PCSX::g_emulator->m_mem->read32(addr & ~3);
+    // the check avoids msan interpreting a fully aligned store as a read
+    // however it may still interpret misaligned stores as reads
+    uint32_t mem = shift != 3? PCSX::g_emulator->m_mem->read32(addr & ~3): 0;
 
     PCSX::g_emulator->m_mem->write32(addr & ~3, (_u32(_rRt_) >> SWL_SHIFT[shift]) | (mem & SWL_MASK[shift]));
     /*
@@ -1012,7 +1014,9 @@ void InterpretedCPU::psxSWL(uint32_t code) {
 void InterpretedCPU::psxSWR(uint32_t code) {
     uint32_t addr = _oB_;
     uint32_t shift = addr & 3;
-    uint32_t mem = PCSX::g_emulator->m_mem->read32(addr & ~3);
+    // the check avoids msan interpreting a fully aligned store as a read
+    // however it may still interpret misaligned stores as reads
+    uint32_t mem = shift != 0? PCSX::g_emulator->m_mem->read32(addr & ~3): 0;
 
     PCSX::g_emulator->m_mem->write32(addr & ~3, (_u32(_rRt_) << SWR_SHIFT[shift]) | (mem & SWR_MASK[shift]));
 

--- a/src/core/psxmem.cc
+++ b/src/core/psxmem.cc
@@ -935,18 +935,6 @@ uint32_t PCSX::Memory::msanRealloc(uint32_t ptr, uint32_t size) {
     return newPtr + c_msanStart;
 }
 
-bool PCSX::Memory::msanValidateWrite(uint32_t addr, uint32_t size) {
-    uint32_t msanAddr = addr - c_msanStart;
-    if (!(m_msanUsableBitmap[msanAddr / 8] & (1 << msanAddr % 8))) {
-        return false;
-    }
-    for (uint32_t checkAddr = msanAddr; checkAddr < msanAddr + size; checkAddr++) {
-        m_msanWrittenBitmap[checkAddr / 8] |= 1 << checkAddr % 8;
-    }
-    [[likely]];
-    return true;
-}
-
 uint32_t PCSX::Memory::msanSetChainPtr(uint32_t headerAddr, uint32_t nextPtr, uint32_t wordCount) {
     if (!inMsanRange(headerAddr)) {
         headerAddr &= 0xffffff;

--- a/src/core/psxmem.h
+++ b/src/core/psxmem.h
@@ -47,6 +47,12 @@
 
 namespace PCSX {
 
+enum class MsanStatus {
+    UNUSABLE,      // memory that hasn't been allocated or has been freed
+    UNINITIALIZED, // allocated memory that has never been written to; unreliable
+    OK             // free to use
+};
+
 class Memory {
   public:
     Memory();
@@ -84,6 +90,8 @@ class Memory {
     uint32_t msanRealloc(uint32_t ptr, uint32_t size);
     uint32_t msanSetChainPtr(uint32_t headerAddr, uint32_t ptrToNext, uint32_t size);
     uint32_t msanGetChainPtr(uint32_t addr) const;
+	MsanStatus msanGetStatus(uint32_t addr, uint32_t size) const;
+	bool msanValidateWrite(uint32_t addr, uint32_t size);
 
     static inline bool inMsanRange(uint32_t addr) {
         return addr >= c_msanStart && addr < c_msanEnd;
@@ -271,7 +279,7 @@ class Memory {
     static constexpr uint32_t c_msanStart = 0x20000000;
     static constexpr uint32_t c_msanEnd = c_msanStart + c_msanSize;
     uint8_t *m_msanRAM = nullptr;
-    uint8_t *m_msanBitmap = nullptr;
+    uint8_t *m_msanUsableBitmap = nullptr;
     uint8_t *m_msanWrittenBitmap = nullptr;
     uint32_t m_msanPtr = 1024;
     EventBus::Listener m_listener;

--- a/src/core/psxmem.h
+++ b/src/core/psxmem.h
@@ -78,12 +78,16 @@ class Memory {
     static constexpr uint16_t DMA_ICR = 0x10f4;
 
     void initMsan(bool reset);
-    bool msanInitialized() { return m_msanRAM != nullptr; }
+    inline bool msanInitialized() const { return m_msanRAM != nullptr; }
     uint32_t msanAlloc(uint32_t size);
     void msanFree(uint32_t ptr);
     uint32_t msanRealloc(uint32_t ptr, uint32_t size);
     uint32_t msanSetChainPtr(uint32_t headerAddr, uint32_t ptrToNext, uint32_t size);
-    uint32_t msanGetChainPtr(uint32_t addr);
+    uint32_t msanGetChainPtr(uint32_t addr) const;
+
+    static inline bool inMsanRange(uint32_t addr) {
+        return addr >= c_msanStart && addr < c_msanEnd;
+    }
 
     template <unsigned n>
     void dmaInterrupt() {
@@ -139,7 +143,7 @@ class Memory {
 
     template <unsigned n>
     void setMADR(uint32_t value) {
-        if (!msanInitialized() || value < c_msanStart || value >= c_msanEnd) {
+        if (!msanInitialized() || !inMsanRange(value)) {
             value &= 0xffffff;
         }
         writeHardwareRegister<DMA_BASE + DMA_MADR + n * 0x10>(value);

--- a/src/core/system.h
+++ b/src/core/system.h
@@ -168,7 +168,7 @@ class System {
     bool quitting() { return m_quitting; }
     int exitCode() { return m_exitCode; }
     bool emergencyExit() { return m_emergencyExit; }
-    void pause(bool exception = false) {
+    [[gnu::cold]] void pause(bool exception = false) {
         if (!m_running) return;
         m_running = false;
         m_eventBus->signal(Events::ExecutionFlow::Pause{exception});
@@ -179,7 +179,7 @@ class System {
         m_eventBus->signal(Events::ExecutionFlow::Run{});
     }
     virtual void testQuit(int code) = 0;
-    void quit(int code = 0) {
+    [[gnu::cold]] void quit(int code = 0) {
         m_quitting = true;
         pause();
         m_exitCode = code;

--- a/src/mips/common/hardware/pcsxhw.h
+++ b/src/mips/common/hardware/pcsxhw.h
@@ -47,5 +47,14 @@ static __inline__ void* pcsx_msanRealloc(void* ptr, uint32_t size) {
     register uint32_t a1 asm("a1") = size;
     return *((void* volatile* const)0x1f802090);
 }
+static __inline__ void pcsx_msanSetChainPtr(void* headerAddr, void* ptrToNext, uint32_t wordCount) {
+    register void* a0 asm("a0") = ptrToNext;
+    register uint32_t a1 asm("a1") = wordCount;
+    *((void* volatile* const)0x1f802094) = headerAddr;
+}
+static __inline__ void* pcsx_msanGetChainPtr(void* headerAddr) {
+    register void* a0 asm("a0") = headerAddr;
+    return *((void* volatile* const)0x1f802094);
+}
 
 static __inline__ int pcsx_present() { return *((volatile uint32_t* const)0x1f802080) == 0x58534350; }


### PR DESCRIPTION
Adds `pcsx_msanSetChainPtr` and `pcsx_msanGetChainPtr` as an API to create special headers for chained DMA that work on msan memory, and makes DMAs to GPU support msan memory (other DMA types might also work but I haven't tried them)