### PR TITLE
Show previous symbol at top of assembly view

### DIFF
--- a/src/core/r3000a.cc
+++ b/src/core/r3000a.cc
@@ -516,15 +516,15 @@ std::pair<const uint32_t, std::string>* PCSX::R3000Acpu::findContainingSymbol(ui
                 return nullptr;
             }
         }
-		return &*symBefore;
+        return &*symBefore;
     }
-	return nullptr;
+    return nullptr;
 }
 
 std::string* PCSX::R3000Acpu::getSymbolAt(uint32_t addr) {
     auto symBefore = m_symbols.find(addr);
     if (symBefore != m_symbols.end()) {
-		return &symBefore->second;
+        return &symBefore->second;
     }
-	return nullptr;
+    return nullptr;
 }

--- a/src/core/r3000a.cc
+++ b/src/core/r3000a.cc
@@ -34,6 +34,7 @@
 #include "core/sio.h"
 #include "core/sio1.h"
 #include "core/spu.h"
+#include "supportpsx/memory.h"
 #include "fmt/format.h"
 
 int PCSX::R3000Acpu::psxInit() {
@@ -501,4 +502,29 @@ void PCSX::R3000Acpu::processB0KernelCall(uint32_t call) {
             break;
         }
     }
+}
+
+std::pair<const uint32_t, std::string>* PCSX::R3000Acpu::findContainingSymbol(uint32_t addr) {
+    auto symBefore = m_symbols.upper_bound(addr);
+    if (symBefore != m_symbols.begin()) { // verify there is actually a symbol before addr
+        symBefore--;
+        if (symBefore->first != addr) {
+            PCSX::PSXAddress addrInfo(addr);
+            PCSX::PSXAddress symbolInfo(symBefore->first);
+            if (addrInfo.segment != symbolInfo.segment) {
+                // if the symbol is different and not in the same memory region, it'd be wrong
+                return nullptr;
+            }
+        }
+		return &*symBefore;
+    }
+	return nullptr;
+}
+
+std::string* PCSX::R3000Acpu::getSymbolAt(uint32_t addr) {
+    auto symBefore = m_symbols.find(addr);
+    if (symBefore != m_symbols.end()) {
+		return &symBefore->second;
+    }
+	return nullptr;
 }

--- a/src/core/r3000a.h
+++ b/src/core/r3000a.h
@@ -290,6 +290,9 @@ class R3000Acpu {
 
     std::map<uint32_t, std::string> m_symbols;
 
+	std::pair<const uint32_t, std::string>* findContainingSymbol(uint32_t addr);
+	std::string* getSymbolAt(uint32_t addr);
+
     static int psxInit();
     virtual bool isDynarec() = 0;
     void psxReset();

--- a/src/gui/widgets/assembly.cc
+++ b/src/gui/widgets/assembly.cc
@@ -1150,16 +1150,15 @@ std::list<std::string> PCSX::Widgets::Assembly::findSymbol(uint32_t addr) {
 }
 
 std::optional<std::string> PCSX::Widgets::Assembly::findPreviousSymbol(uint32_t addr) {
-    std::optional<std::string> ret;
-    for (auto& symbol : g_emulator->m_cpu->m_symbols) {
-        if (symbol.first >= addr) {
-            break;
-        }
-        if (symbol.first >= m_ramBase) {
-            ret = symbol.second;
+    auto& symbols = g_emulator->m_cpu->m_symbols;
+    auto symBeforeAddr = symbols.lower_bound(addr);
+    if (symBeforeAddr != symbols.begin()) { // verify there is actually a symbol before addr
+        symBeforeAddr--;
+        if (symBeforeAddr->first < addr && symBeforeAddr->first >= m_ramBase) {
+            return symBeforeAddr->second;
         }
     }
-    return ret;
+    return {};
 }
 
 void PCSX::Widgets::Assembly::rebuildSymbolsCaches() {

--- a/src/gui/widgets/assembly.cc
+++ b/src/gui/widgets/assembly.cc
@@ -302,8 +302,8 @@ void PCSX::Widgets::Assembly::Target(uint32_t value) {
     if (m_displayArrowForJumps) m_arrows.push_back({m_currentAddr, value});
     std::snprintf(label, sizeof(label), "0x%8.8x##%8.8x", value, m_currentAddr);
     std::string longLabel = label;
-    auto symbols = findSymbol(value);
-    if (symbols.size() != 0) longLabel = *symbols.begin() + " ;" + label;
+    std::string* symbol = g_emulator->m_cpu->getSymbolAt(value);
+    if (symbol) longLabel = *symbol + " ;" + label;
     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
     if (ImGui::Button(longLabel.c_str())) {
         m_jumpToPC = value;
@@ -366,8 +366,8 @@ void PCSX::Widgets::Assembly::OfB(int16_t offset, uint8_t reg, int size) {
     uint32_t addr = m_registers->GPR.r[reg] + offset;
 
     std::string longLabel;
-    auto symbols = findSymbol(addr);
-    if (symbols.size() != 0) longLabel = *symbols.begin() + " ; ";
+    std::string* symbol = g_emulator->m_cpu->getSymbolAt(addr);
+    if (symbol) longLabel = *symbol + " ; ";
 
     const auto& io = ImGui::GetIO();
     unsigned targetEditorIndex = io.KeyShift ? 1 : (io.KeyCtrl ? 2 : 0);
@@ -405,17 +405,17 @@ void PCSX::Widgets::Assembly::BranchDest(uint32_t value) {
     sameLine();
     m_arrows.push_back({m_currentAddr, value});
     std::snprintf(label, sizeof(label), "0x%8.8x##%8.8x", value, m_currentAddr);
-    auto symbols = findSymbol(value);
-    if (symbols.size() == 0) {
+    std::string* symbol = g_emulator->m_cpu->getSymbolAt(value);
+    if (symbol) {
+        std::string longLabel = *symbol + " ;" + label;
         ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
-        if (ImGui::Button(label)) {
+        if (ImGui::Button(longLabel.c_str())) {
             m_jumpToPC = value;
         }
         ImGui::PopStyleVar();
     } else {
-        std::string longLabel = *symbols.begin() + " ;" + label;
         ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
-        if (ImGui::Button(longLabel.c_str())) {
+        if (ImGui::Button(label)) {
             m_jumpToPC = value;
         }
         ImGui::PopStyleVar();
@@ -427,8 +427,8 @@ void PCSX::Widgets::Assembly::Offset(uint32_t addr, int size) {
     char label[32];
     std::snprintf(label, sizeof(label), "0x%8.8x##%8.8x", addr, m_currentAddr);
     std::string longLabel = label;
-    auto symbols = findSymbol(addr);
-    if (symbols.size() != 0) longLabel = *symbols.begin() + " ;" + label;
+    std::string* symbol = g_emulator->m_cpu->getSymbolAt(addr);
+    if (symbol) longLabel = *symbol + " ;" + label;
 
     const auto& io = ImGui::GetIO();
     unsigned targetEditorIndex = io.KeyShift ? 1 : (io.KeyCtrl ? 2 : 0);
@@ -680,20 +680,21 @@ settings, otherwise debugging features may not work.)");
                 tcode >>= 8;
                 b[3] = tcode & 0xff;
 
-                auto symbols = findSymbol(dispAddr);
-                if (symbols.size() != 0) {
-                    ImGui::PushStyleColor(ImGuiCol_Text, s_labelColor);
-                    ImGui::Text("%s:", symbols.begin()->c_str());
-                    ImGui::PopStyleColor();
-                } else {
-                    // if the first visible line is not a symbol, show the previous symbol
-                    float y = ImGui::GetCursorScreenPos().y;
-                    if (y + lineHeight >= topleft.y && y <= topleft.y + lineHeight) {
-                        previousSymbol = findPreviousSymbol(dispAddr);
-                        // if the second line is a symbol, push the previous symbol display up
-                        auto secondLineSymbol = findSymbol(dispAddr + 4);
-                        if (secondLineSymbol.size() != 0 && y < previousSymbolY) {
-                            previousSymbolY = y;
+                std::pair<const uint32_t, std::string>* symbol = cpu->findContainingSymbol(dispAddr);
+                if (symbol) {
+                    if (symbol->first == dispAddr) {
+                        ImGui::PushStyleColor(ImGuiCol_Text, s_labelColor);
+                        ImGui::Text("%s:", symbol->second.c_str());
+                        ImGui::PopStyleColor();
+                    } else {
+                        // if this is the first visible line and it's not a label itself, store the previous symbol
+                        float y = ImGui::GetCursorScreenPos().y;
+                        if (y + lineHeight >= topleft.y && y <= topleft.y + lineHeight) {
+                            previousSymbol = symbol->second;
+                            // if the second visible line is a symbol, push the previous symbol display up
+                            if (cpu->getSymbolAt(dispAddr + 4) && y < previousSymbolY) {
+                                previousSymbolY = y;
+                            }
                         }
                     }
                 }
@@ -765,14 +766,14 @@ settings, otherwise debugging features may not work.)");
                 }
                 std::string contextMenuID = fmt::format("assembly address menu {}", dispAddr);
                 if (ImGui::BeginPopupContextItem(contextMenuID.c_str())) {
-                    if (symbols.size() == 0) {
+                    if (symbol) {
+                        if (ImGui::MenuItem(_("Remove symbol"))) {
+                            cpu->m_symbols.erase(dispAddr);
+                        }
+                    } else {
                         if (ImGui::MenuItem(_("Create symbol here"))) {
                             openSymbolAdder = true;
                             m_symbolAddress = dispAddr;
-                        }
-                    } else {
-                        if (ImGui::MenuItem(_("Remove symbol"))) {
-                            cpu->m_symbols.erase(dispAddr);
                         }
                     }
                     if (ImGui::MenuItem(_("Copy Address"))) {
@@ -1100,7 +1101,7 @@ if not success then return msg else return nil end
 
     if (m_showSymbols) {
         if (ImGui::Begin(_("Symbols"), &m_showSymbols)) {
-            if (ImGui::Button(_("Refresh"))) rebuildSymbolsCaches();
+            if (ImGui::Button(_("Refresh"))) rebuildSymbolsCache();
             ImGui::SameLine();
             ImGui::InputText(_("Filter"), &m_symbolFilter);
             ImGui::BeginChild("symbolsList");
@@ -1136,36 +1137,11 @@ if not success then return msg else return nil end
     return changed;
 }
 
-std::list<std::string> PCSX::Widgets::Assembly::findSymbol(uint32_t addr) {
-    auto& cpu = g_emulator->m_cpu;
-    std::list<std::string> ret;
-    auto symbol = cpu->m_symbols.find(addr);
-    if (symbol != cpu->m_symbols.end()) ret.emplace_back(symbol->second);
-
-    if (!m_symbolsCachesValid) rebuildSymbolsCaches();
-    auto elfSymbol = m_elfSymbolsCache.find(addr);
-    if (elfSymbol != m_elfSymbolsCache.end()) ret.emplace_back(elfSymbol->second);
-
-    return ret;
-}
-
-std::optional<std::string> PCSX::Widgets::Assembly::findPreviousSymbol(uint32_t addr) {
-    auto& symbols = g_emulator->m_cpu->m_symbols;
-    auto symBeforeAddr = symbols.lower_bound(addr);
-    if (symBeforeAddr != symbols.begin()) { // verify there is actually a symbol before addr
-        symBeforeAddr--;
-        if (symBeforeAddr->first < addr && symBeforeAddr->first >= m_ramBase) {
-            return symBeforeAddr->second;
-        }
-    }
-    return {};
-}
-
-void PCSX::Widgets::Assembly::rebuildSymbolsCaches() {
+void PCSX::Widgets::Assembly::rebuildSymbolsCache() {
     auto& cpu = g_emulator->m_cpu;
     m_symbolsCache.clear();
     for (auto& symbol : cpu->m_symbols) {
         m_symbolsCache.insert(std::pair(symbol.second, symbol.first));
     }
-    m_symbolsCachesValid = true;
+    m_symbolsCacheValid = true;
 }

--- a/src/gui/widgets/assembly.h
+++ b/src/gui/widgets/assembly.h
@@ -111,6 +111,7 @@ class Assembly : private Disasm {
     };
 
     std::list<std::string> findSymbol(uint32_t addr);
+	std::optional<std::string> findPreviousSymbol(uint32_t addr);
     std::map<std::string, uint32_t> m_symbolsCache;
     std::map<uint32_t, std::string> m_elfSymbolsCache;
     bool m_symbolsCachesValid = false;

--- a/src/gui/widgets/assembly.h
+++ b/src/gui/widgets/assembly.h
@@ -110,13 +110,10 @@ class Assembly : private Disasm {
         uint32_t addr;
     };
 
-    std::list<std::string> findSymbol(uint32_t addr);
-	std::optional<std::string> findPreviousSymbol(uint32_t addr);
     std::map<std::string, uint32_t> m_symbolsCache;
-    std::map<uint32_t, std::string> m_elfSymbolsCache;
-    bool m_symbolsCachesValid = false;
+    bool m_symbolsCacheValid = false;
 
-    void rebuildSymbolsCaches();
+    void rebuildSymbolsCache();
     void addMemoryEditorContext(uint32_t addr, int size);
     void addMemoryEditorSubMenu(uint32_t addr, int size);
 


### PR DESCRIPTION
Unless the top line is already a label or there's no previous symbol. And if the next label is up close, it gets pushed above it.
This is useful for situating yourself in large functions when you have symbol info available.

Before:
![Screenshot_20250225_021419](https://github.com/user-attachments/assets/61da250b-d1e3-4286-9654-c3125470e1f6)

After:
![Screenshot_20250225_022434](https://github.com/user-attachments/assets/2731b0e4-7bb1-4486-a798-2d89e4dd87ed)

Getting pushed up by the next label:
![Screenshot_20250225_011110](https://github.com/user-attachments/assets/c57e7a49-2469-4cd4-807e-1d5b83f735c6)
