### PR TITLE
Save window maximized state

### DIFF
--- a/src/gui/gui.cc
+++ b/src/gui/gui.cc
@@ -656,8 +656,11 @@ void PCSX::GUI::init(std::function<void()> applyArguments) {
             if ((settings.get<WindowPosX>().value > 0) && (settings.get<WindowPosY>().value > 0)) {
                 glfwSetWindowPos(m_window, settings.get<WindowPosX>(), settings.get<WindowPosY>());
             }
-
-            glfwSetWindowSize(m_window, windowSizeX, windowSizeY);
+            if (settings.get<WindowMaximized>().value) {
+				glfwMaximizeWindow(m_window);
+			} else {
+				glfwSetWindowSize(m_window, windowSizeX, windowSizeY);
+			}
         } else {
             saveCfg();
         }
@@ -897,9 +900,11 @@ void PCSX::GUI::saveCfg() {
         m_glfwPosY = settings.get<WindowPosY>();
         m_glfwSizeX = settings.get<WindowSizeX>();
         m_glfwSizeY = settings.get<WindowSizeY>();
+        m_glfwMaximized = settings.get<WindowMaximized>();
     } else {
         glfwGetWindowPos(m_window, &m_glfwPosX, &m_glfwPosY);
         glfwGetWindowSize(m_window, &m_glfwSizeX, &m_glfwSizeY);
+        m_glfwMaximized = glfwGetWindowAttrib(m_window, GLFW_MAXIMIZED) != 0;
     }
 
     j["imgui"] = ImGui::SaveIniSettingsToMemory(nullptr);

--- a/src/gui/gui.cc
+++ b/src/gui/gui.cc
@@ -657,10 +657,10 @@ void PCSX::GUI::init(std::function<void()> applyArguments) {
                 glfwSetWindowPos(m_window, settings.get<WindowPosX>(), settings.get<WindowPosY>());
             }
             if (settings.get<WindowMaximized>().value) {
-				glfwMaximizeWindow(m_window);
-			} else {
-				glfwSetWindowSize(m_window, windowSizeX, windowSizeY);
-			}
+                glfwMaximizeWindow(m_window);
+            } else {
+                glfwSetWindowSize(m_window, windowSizeX, windowSizeY);
+            }
         } else {
             saveCfg();
         }

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -116,6 +116,7 @@ class GUI final : public UI {
     typedef Setting<int, TYPESTRING("WindowPosY"), 0> WindowPosY;
     typedef Setting<int, TYPESTRING("WindowSizeX"), 1280> WindowSizeX;
     typedef Setting<int, TYPESTRING("WindowSizeY"), 800> WindowSizeY;
+    typedef Setting<bool, TYPESTRING("WindowMaximized"), false> WindowMaximized;
     typedef Setting<int, TYPESTRING("IdleSwapInterval"), 1> IdleSwapInterval;
     typedef Setting<int, TYPESTRING("MainFontSize"), 16> MainFontSize;
     typedef Setting<int, TYPESTRING("MonoFontSize"), 16> MonoFontSize;
@@ -150,7 +151,7 @@ class GUI final : public UI {
     typedef Setting<size_t, TYPESTRING("HWRegsEditorAddr"), 0> HWRegsEditorAddr;
     typedef Setting<size_t, TYPESTRING("BiosEditorAddr"), 0> BiosEditorAddr;
     typedef Setting<size_t, TYPESTRING("VRAMEditorAddr"), 0> VRAMEditorAddr;
-    Settings<Fullscreen, FullWindowRender, ShowMenu, ShowLog, WindowPosX, WindowPosY, WindowSizeX, WindowSizeY,
+    Settings<Fullscreen, FullWindowRender, ShowMenu, ShowLog, WindowPosX, WindowPosY, WindowSizeX, WindowSizeY, WindowMaximized,
              IdleSwapInterval, ShowLuaConsole, ShowLuaInspector, ShowLuaEditor, ShowMainVRAMViewer, ShowCLUTVRAMViewer,
              ShowVRAMViewer1, ShowVRAMViewer2, ShowVRAMViewer3, ShowVRAMViewer4, ShowMemoryObserver, ShowTypedDebugger,
              ShowPatches, ShowMemcardManager, ShowRegisters, ShowAssembly, ShowDisassembly, ShowBreakpoints,
@@ -297,6 +298,7 @@ class GUI final : public UI {
     int &m_glfwPosY = settings.get<WindowPosY>().value;
     int &m_glfwSizeX = settings.get<WindowSizeX>().value;
     int &m_glfwSizeY = settings.get<WindowSizeY>().value;
+    bool &m_glfwMaximized = settings.get<WindowMaximized>().value;
     GLuint m_VRAMTexture = 0;
     NVGcontext *m_nvgContext = nullptr;
     std::map<unsigned, void *> m_nvgSubContextes;


### PR DESCRIPTION
Saves and restores whether the window is maximized together with the other window state data.

(Note: it's important that the size not be set if the window is to be maximized, that caused it to get stuck in the maximized size without decorations for me)