### PR TITLE
Add intuitive dockspace

### DIFF
--- a/src/core/arguments.cc
+++ b/src/core/arguments.cc
@@ -33,7 +33,7 @@ PCSX::Arguments::Arguments(const CommandLine::args& args) {
     auto portablePath = args.get<std::string_view>("portable");
     if (portablePath.has_value()) m_portablePath = portablePath.value();
     if (std::filesystem::exists("pcsx.json")) m_portable = true;
-    if (std::filesystem::exists("Makefile")) m_portable = true;
+    if (std::filesystem::exists(std::filesystem::path("vsprojects") / "pcsx-redux.sln")) m_portable = true;
     if (std::filesystem::exists(std::filesystem::path("..") / "pcsx-redux.sln")) m_portable = true;
     if (args.get<bool>("safe") || args.get<bool>("testmode") || args.get<bool>("cli")) m_safeModeEnabled = true;
     if (args.get<bool>("resetui")) m_uiResetRequested = true;

--- a/src/gui/gui.cc
+++ b/src/gui/gui.cc
@@ -1169,12 +1169,14 @@ void PCSX::GUI::endFrame() {
                 // if output is the only visible window in dockspace, switch to full window render mode automatically
                 outputWindowShown = false;
             }
-            ImVec2 textureSize = ImGui::GetContentRegionAvail();
+            ImVec2 contentRegion = ImGui::GetContentRegionAvail();
+            ImVec2 textureSize = contentRegion;
             if ((m_outputWindowSize.x != textureSize.x) || (m_outputWindowSize.y != textureSize.y)) {
                 m_outputWindowSize = textureSize;
                 m_setupScreenSize = true;
             }
             ImGuiHelpers::normalizeDimensions(textureSize, renderRatio);
+			ImGui::SetCursorPos(ImGui::GetCursorPos() + (contentRegion - textureSize) * 0.5f);
             ImTextureID texture = m_offscreenTextures[m_currentTexture];
             if (g_system->getArgs().isShadersDisabled()) {
                 ImGui::Image(texture, textureSize, ImVec2(0, 0), ImVec2(1, 1));

--- a/src/gui/gui.cc
+++ b/src/gui/gui.cc
@@ -1127,12 +1127,12 @@ void PCSX::GUI::endFrame() {
     m_offscreenShaderEditor.configure(this);
     m_outputShaderEditor.configure(this);
 
-    ImGuiID dockspace = ImGui::DockSpaceOverViewport(0, nullptr, ImGuiDockNodeFlags_PassthruCentralNode);
+    ImGuiID dockspaceId = ImGui::DockSpaceOverViewport(0, nullptr, ImGuiDockNodeFlags_PassthruCentralNode);
     ImGuiContext* context = ImGui::GetCurrentContext();
-    ImGuiDockNode* dockspaceNode = ImGui::DockContextFindNodeByID(context, dockspace);
+    ImGuiDockNode* dockspaceNode = ImGui::DockContextFindNodeByID(context, dockspaceId);
     if (m_fullWindowRender && !dockspaceNode->IsEmpty()) {
         m_fullWindowRender = false;
-        ImGui::SetNextWindowDockID(dockspace);
+        ImGui::SetNextWindowDockID(dockspaceId);
     }
     if (m_fullWindowRender) {
         ImTextureID texture = m_offscreenTextures[m_currentTexture];
@@ -1186,7 +1186,7 @@ void PCSX::GUI::endFrame() {
         if (!outputWindowShown) {
             m_fullWindowRender = true;
             // full window render mode can't have anything docked in the dockspace
-            ImGui::DockContextClearNodes(context, dockspace, true);
+            ImGui::DockContextClearNodes(context, dockspaceId, true);
         }
     }
 
@@ -1451,7 +1451,7 @@ in Configuration->Emulation, restart PCSX-Redux, then try again.)"));
                     if (ImGui::MenuItem(_("Full window render"), nullptr, &m_fullWindowRender)) {
                         m_setupScreenSize = true;
                         // full window render mode can't have anything docked in the dockspace
-                        ImGui::DockContextClearNodes(context, dockspace, true);
+                        ImGui::DockContextClearNodes(context, dockspaceId, true);
                     }
                     if (ImGui::MenuItem(_("Fullscreen"), nullptr, &m_fullscreen)) {
                         setFullscreen(m_fullscreen);


### PR DESCRIPTION
This adds a dockspace to the entire window that switches the full window render option on and off automatically. Specifically:
When full window render is on, docking anything onto the dockspace will cause full window render to be disabled, and the output window will be placed in the remaining dock space.
When full window render is off, if the output window is the only visible window docked on the dockspace and there are no other tabs, full window render will be enabled and any hidden windows on the dockspace will be undocked.
The toggle still works as before, it undocks everything when you click it in order to bypass this system.

What is now possible:
![image](https://github.com/user-attachments/assets/8cde04ed-462d-414f-9e2e-d12ab9de972a)