### PR TITLE
Fix quitting freeze

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,12 +43,10 @@ vsprojects/packages
 /modconv
 /ps1-packer
 /psyq-obj-parser
-/pcsx.json
-/memcard1.mcd
-/memcard2.mcd
 
 # Temporary files from pcsx itself
 pcsx.json
+pcsx.json.tmp
 *.mcd
 
 # FastBuild and msfastbuild stuff

--- a/src/gui/gui.cc
+++ b/src/gui/gui.cc
@@ -892,28 +892,35 @@ void PCSX::GUI::close() {
 
 void PCSX::GUI::saveCfg() {
     if (g_system->getArgs().isTestModeEnabled()) return;
-    std::ofstream cfg(g_system->getPersistentDir() / "pcsx.json");
-    json j;
+	std::filesystem::path cfgTmpPath = g_system->getPersistentDir() / "pcsx.json.tmp";
+	std::filesystem::path cfgPath = g_system->getPersistentDir() / "pcsx.json";
+	{
+		std::ofstream cfg(cfgTmpPath);
+		json j;
 
-    if (m_fullscreen || glfwGetWindowAttrib(m_window, GLFW_ICONIFIED) > 0) {
-        m_glfwPosX = settings.get<WindowPosX>();
-        m_glfwPosY = settings.get<WindowPosY>();
-        m_glfwSizeX = settings.get<WindowSizeX>();
-        m_glfwSizeY = settings.get<WindowSizeY>();
-        m_glfwMaximized = settings.get<WindowMaximized>();
-    } else {
-        glfwGetWindowPos(m_window, &m_glfwPosX, &m_glfwPosY);
-        glfwGetWindowSize(m_window, &m_glfwSizeX, &m_glfwSizeY);
-        m_glfwMaximized = glfwGetWindowAttrib(m_window, GLFW_MAXIMIZED) != 0;
-    }
+		if (m_fullscreen || glfwGetWindowAttrib(m_window, GLFW_ICONIFIED) > 0) {
+			m_glfwPosX = settings.get<WindowPosX>();
+			m_glfwPosY = settings.get<WindowPosY>();
+			m_glfwSizeX = settings.get<WindowSizeX>();
+			m_glfwSizeY = settings.get<WindowSizeY>();
+			m_glfwMaximized = settings.get<WindowMaximized>();
+		} else {
+			glfwGetWindowPos(m_window, &m_glfwPosX, &m_glfwPosY);
+			glfwGetWindowSize(m_window, &m_glfwSizeX, &m_glfwSizeY);
+			m_glfwMaximized = glfwGetWindowAttrib(m_window, GLFW_MAXIMIZED) != 0;
+		}
 
-    j["imgui"] = ImGui::SaveIniSettingsToMemory(nullptr);
-    j["SPU"] = PCSX::g_emulator->m_spu->getCfg();
-    j["emulator"] = PCSX::g_emulator->settings.serialize();
-    j["gui"] = settings.serialize();
-    j["loggers"] = m_log.serialize();
-    j["pads"] = PCSX::g_emulator->m_pads->getCfg();
-    cfg << std::setw(2) << j << std::endl;
+		j["imgui"] = ImGui::SaveIniSettingsToMemory(nullptr);
+		j["SPU"] = PCSX::g_emulator->m_spu->getCfg();
+		j["emulator"] = PCSX::g_emulator->settings.serialize();
+		j["gui"] = settings.serialize();
+		j["loggers"] = m_log.serialize();
+		j["pads"] = PCSX::g_emulator->m_pads->getCfg();
+		cfg << std::setw(2) << j << std::endl;
+	}
+	if (std::filesystem::copy_file(cfgTmpPath, cfgPath, std::filesystem::copy_options::overwrite_existing)) {
+		std::filesystem::remove(cfgTmpPath);
+	}
 }
 
 void PCSX::GUI::glfwKeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods) {


### PR DESCRIPTION
I've always had an issue where trying to close pcsx-redux by pressing Ctrl+C on the terminal (i.e. SIGINT) would make the app hang. It was trying to save settings, but got stuck in glfwGetWindowAttrib, probably a deadlock. This fixes that by moving the quit call into the main loop rather than the signal handler itself.
I've also randomly lost my settings when trying to quit, so I also made it prevent that by writing into pcsx.json.tmp and then moving it into pcsx.json, rather than writing into pcsx.json right away. I'm not sure what exactly caused the data loss, maybe it's related to the issues above, but this should help.