### PR TITLE
Fix quitting issue again

### DIFF
--- a/src/core/DynaRec_x64/recompiler.cc
+++ b/src/core/DynaRec_x64/recompiler.cc
@@ -186,7 +186,6 @@ void DynaRecCPU::emitDispatcher() {
         gen.push(reg.cvt64());
     }
     gen.mov(qword[contextPointer + HOST_REG_CACHE_OFFSET(0)], runningPointer);  // Backup running pointer
-    gen.mov(runningPointer, (uintptr_t)PCSX::g_system->runningPtr());           // Load pointer to "running" variable
 
     // Allocate shadow stack space on Windows
     if constexpr (isWindows()) {
@@ -202,8 +201,12 @@ void DynaRecCPU::emitDispatcher() {
 
     // Poll events
     emitMemberFunctionCall(&PCSX::R3000Acpu::branchTest, this);
+    gen.mov(runningPointer, (uintptr_t)PCSX::g_system->runningPtr());  // Load pointer to "running" variable
     gen.test(Xbyak::util::byte[runningPointer], 1);  // Check if PCSX::g_system->running is true
     gen.jz(done);                                    // If it's not, return
+    gen.mov(runningPointer, (uintptr_t)PCSX::g_system->quittingPtr());  // Load pointer to "quitting" variable
+    gen.test(Xbyak::util::byte[runningPointer], 1);  // Check if PCSX::g_system->running is true
+    gen.jnz(done);                                   // If it is, return
     emitBlockLookup();                               // Otherwise, look up next block
 
     gen.align(16);

--- a/src/core/system.h
+++ b/src/core/system.h
@@ -168,6 +168,7 @@ class System {
         return m_running && !m_quitting;
     }
     const bool *runningPtr() { return &m_running; }
+    const bool *quittingPtr() { return &m_quitting; }
     bool quitting() { return m_quitting; }
     int exitCode() { return m_exitCode; }
     bool emergencyExit() { return m_emergencyExit; }

--- a/src/main/main.cc
+++ b/src/main/main.cc
@@ -166,7 +166,7 @@ struct Cleaner {
     std::function<void()> f;
 };
 
-void handleSignal(auto signal) {
+void handleSignal(int signal) {
     PCSX::g_system->terminateSignalSafe();
 }
 
@@ -200,7 +200,7 @@ int pcsxMain(int argc, char **argv) {
     auto sigint = std::signal(SIGINT, handleSignal);
     auto sigterm = std::signal(SIGTERM, handleSignal);
 #ifndef _WIN32
-    signal(SIGPIPE, SIG_IGN);
+    std::signal(SIGPIPE, SIG_IGN);
 #endif
     const auto &logfileArgOpt = args.get<std::string>("logfile");
     const PCSX::u8string logfileArg = MAKEU8(logfileArgOpt.has_value() ? logfileArgOpt->c_str() : "");


### PR DESCRIPTION
In the other PR I fixed the signal handler, but I missed that it only caught signals when the emulation was paused, so here I moved the flag to the system class and made it turn off m_running, now it works as expected