### PR TITLE
Refactoring top Makefile.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,9 @@ vsprojects/packages
 .Trash-1000/
 
 # Linux files
-*.o
-*.dep
+deps/
+objs/
+bins/
 /pcsx-redux
 /exe2elf
 /exe2iso


### PR DESCRIPTION
Now each build type gets its own subdirectory, so switching build type is simple and fast.