### PR TITLE
Fix alignment in logging of psqy-obj-parser

### DIFF
--- a/tools/psyq-obj-parser/psyq-obj-parser.cc
+++ b/tools/psyq-obj-parser/psyq-obj-parser.cc
@@ -766,7 +766,7 @@ void PsyqLnkFile::display() {
         section.display(this);
     }
     fmt::print("\n\n\n  :: Relocations\n\n");
-    fmt::print("    {:8}   {:>12}::{:8}  {}\n", "type", "section", "offset", "expression");
+    fmt::print("    {:10}   {:>10}::{:8}  {}\n", "type", "section", "offset", "expression");
     fmt::print("    ------------------------------------------\n");
     for (auto& section : sectionsList) {
         section.displayRelocs(this);

--- a/tools/psyq-obj-parser/psyq-obj-parser.cc
+++ b/tools/psyq-obj-parser/psyq-obj-parser.cc
@@ -816,7 +816,7 @@ void PsyqLnkFile::Relocation::display(PsyqLnkFile* lnk, PsyqLnkFile::Section* se
         {PsyqRelocType::REL26_BE, "REL26 BE"},     {PsyqRelocType::HI16_BE, "HI16 BE"},
         {PsyqRelocType::LO16_BE, "LO16 BE"},
     };
-    fmt::print("    {:8}   {:>12}::{:08x}  ", typeStr.find(type)->second, sec->name, offset);
+    fmt::print("    {:10}   {:>10}::{:08x}  ", typeStr.find(type)->second, sec->name, offset);
     expression->display(lnk, true);
 }
 


### PR DESCRIPTION
Something I missed from my last PR when adding the types `GPREL16 B/LE`. These types are 10 characters long, whereas the previous max was 8, so they were not being lined up with the rest.