### PR TITLE
Added Reload Disk Image option to file menu

### DIFF
--- a/src/gui/gui.cc
+++ b/src/gui/gui.cc
@@ -1206,6 +1206,13 @@ void PCSX::GUI::endFrame() {
         if (ImGui::BeginMainMenuBar()) {
             if (ImGui::BeginMenu(_("File"))) {
                 showOpenIsoFileDialog = ImGui::MenuItem(_("Open Disk Image"));
+                auto currentIso = PCSX::g_emulator->m_cdrom->getIso();
+                if (ImGui::MenuItem(_("Reload Disk Image"), nullptr, nullptr, currentIso && !currentIso->failed())) {
+                    PCSX::g_emulator->m_cdrom->clearIso();
+                    PCSX::g_emulator->m_cdrom->setIso(new CDRIso(currentIso->getIsoPath()));
+                    PCSX::g_emulator->m_cdrom->check();
+                    g_system->hardReset();
+                }
                 if (ImGui::MenuItem(_("Close Disk Image"))) {
                     PCSX::g_emulator->m_cdrom->setIso(new CDRIso(new FailedFile));
                     PCSX::g_emulator->m_cdrom->check();


### PR DESCRIPTION
I find myself reloading images a lot, so I've added a simple Reload Image feature to the File menu. This code works for me, I've used it for a few months now in a previous iteration. Hopefully everything is in order.