### PR TITLE
Fix ELF loader ignoring non-PROGBITS sections that should be allocated

### DIFF
--- a/src/supportpsx/binloader.cc
+++ b/src/supportpsx/binloader.cc
@@ -225,13 +225,15 @@ bool loadELF(IO<File> file, IO<File> dest, BinaryLoader::Info& info, std::map<ui
     Elf_Half sec_num = reader.sections.size();
     for (unsigned i = 0; i < sec_num; i++) {
         section* psec = reader.sections[i];
+
+        if (!(psec->get_flags() & SHF_ALLOC)) continue;
+        if (psec->get_type() == SHT_NOBITS) continue;
+
         auto name = psec->get_name();
-
         if (StringsHelpers::endsWith(name, "_Header")) continue;
+#if 0
         if (StringsHelpers::startsWith(name, ".comment")) continue;
-
-        auto type = psec->get_type();
-        if (type != SHT_PROGBITS) continue;
+#endif
 
         auto size = psec->get_size();
         auto data = psec->get_data();

--- a/src/supportpsx/binloader.cc
+++ b/src/supportpsx/binloader.cc
@@ -231,9 +231,6 @@ bool loadELF(IO<File> file, IO<File> dest, BinaryLoader::Info& info, std::map<ui
 
         auto name = psec->get_name();
         if (StringsHelpers::endsWith(name, "_Header")) continue;
-#if 0
-        if (StringsHelpers::startsWith(name, ".comment")) continue;
-#endif
 
         auto size = psec->get_size();
         auto data = psec->get_data();


### PR DESCRIPTION
A quick fix to pcsx-redux's ELF file loader that makes it skip sections in the file only if their type is set to `NOBITS` and/or they do not have the allocate flag set. The current behavior is to skip all sections whose type is not `PROGBITS`, which results in incorrect loading of binaries with sections such as `.preinit_array`, `.init_array` and `.fini_array` (which may be assigned type IDs other than `PROGBITS` by the linker).