### PR TITLE
Use ftpmirror.gnu.org to fetch GNU files

### DIFF
--- a/tools/linux-mips/spawn-compiler.sh
+++ b/tools/linux-mips/spawn-compiler.sh
@@ -13,8 +13,8 @@ set -ex
 
 PREFIX=${PREFIX:-"/usr/local"}
 
-for url in https://ftp.gnu.org/gnu/binutils/binutils-2.43.tar.gz https://mirrors.kernel.org/gnu/binutils/binutils-2.43.tar.gz ; do
-    wget --timeout=60 --continue $url && break
+for url in https://ftpmirror.gnu.org/gnu/binutils/binutils-2.43.tar.gz https://mirrors.kernel.org/gnu/binutils/binutils-2.43.tar.gz ; do
+    wget --max-redirect=2 --timeout=60 --continue --trust-server-names $url && break
 done
 tar xvfz binutils-2.43.tar.gz
 cd binutils-2.43
@@ -23,8 +23,8 @@ make
 make install-strip
 cd ..
 
-for url in https://ftp.gnu.org/gnu/gcc/gcc-14.2.0/gcc-14.2.0.tar.gz https://mirrors.kernel.org/gnu/gcc/gcc-14.2.0/gcc-14.2.0.tar.gz ; do
-    wget --timeout=60 --continue $url && break
+for url in https://ftpmirror.gnu.org/gnu/gcc/gcc-14.2.0/gcc-14.2.0.tar.gz https://mirrors.kernel.org/gnu/gcc/gcc-14.2.0/gcc-14.2.0.tar.gz ; do
+    wget --max-redirect=2 --timeout=60 --continue --trust-server-names $url && break
 done
 tar xvfz gcc-14.2.0.tar.gz
 cd gcc-14.2.0

--- a/tools/macos-mips/mipsel-none-elf-binutils.rb
+++ b/tools/macos-mips/mipsel-none-elf-binutils.rb
@@ -1,7 +1,7 @@
 class MipselNoneElfBinutils < Formula
   desc "FSF Binutils for mipsel cross development"
   homepage "https://www.gnu.org/software/binutils/"
-  url "https://ftp.gnu.org/gnu/binutils/binutils-2.43.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/binutils/binutils-2.43.tar.gz"
   mirror "https://mirrors.kernel.org/gnu/binutils/binutils-2.43.tar.gz"
   sha256 "025c436d15049076ebe511d29651cc4785ee502965a8839936a65518582bdd64"
 

--- a/tools/macos-mips/mipsel-none-elf-gcc.rb
+++ b/tools/macos-mips/mipsel-none-elf-gcc.rb
@@ -1,7 +1,7 @@
 class MipselNoneElfGcc < Formula
   desc "The GNU compiler collection for mipsel"
   homepage "https://gcc.gnu.org"
-  url "https://ftp.gnu.org/gnu/gcc/gcc-14.2.0/gcc-14.2.0.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gcc/gcc-14.2.0/gcc-14.2.0.tar.xz"
   mirror "https://mirrors.kernel.org/gnu/gcc/gcc-14.2.0/gcc-14.2.0.tar.xz"
   sha256 "a7b39bc69cbf9e25826c5a60ab26477001f7c08d85cec04bc0e29cabed6f3cc9"
 

--- a/tools/macos-mips/mipsel-none-elf-gdb.rb
+++ b/tools/macos-mips/mipsel-none-elf-gdb.rb
@@ -1,7 +1,7 @@
 class MipselNoneElfGdb < Formula
   desc "GDB: The GNU Project Debugger compiled for Mips"
   homepage "https://sourceware.org/gdb/"
-  url "https://ftp.gnu.org/gnu/gdb/gdb-15.1.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gdb/gdb-15.1.tar.xz"
   mirror "https://mirrors.kernel.org/gnu/gdb/gdb-15.1.tar.xz"
   sha256 "38254eacd4572134bca9c5a5aa4d4ca564cbbd30c369d881f733fb6b903354f2"
 

--- a/tools/vscode-extension/scripts/mipsel-none-elf-binutils.rb
+++ b/tools/vscode-extension/scripts/mipsel-none-elf-binutils.rb
@@ -1,7 +1,7 @@
 class MipselNoneElfBinutils < Formula
   desc "FSF Binutils for mipsel cross development"
   homepage "https://www.gnu.org/software/binutils/"
-  url "https://ftp.gnu.org/gnu/binutils/binutils-2.43.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/binutils/binutils-2.43.tar.gz"
   mirror "https://mirrors.kernel.org/gnu/binutils/binutils-2.43.tar.gz"
   sha256 "025c436d15049076ebe511d29651cc4785ee502965a8839936a65518582bdd64"
 

--- a/tools/vscode-extension/scripts/mipsel-none-elf-gcc.rb
+++ b/tools/vscode-extension/scripts/mipsel-none-elf-gcc.rb
@@ -1,7 +1,7 @@
 class MipselNoneElfGcc < Formula
   desc "The GNU compiler collection for mipsel"
   homepage "https://gcc.gnu.org"
-  url "https://ftp.gnu.org/gnu/gcc/gcc-14.2.0/gcc-14.2.0.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gcc/gcc-14.2.0/gcc-14.2.0.tar.xz"
   mirror "https://mirrors.kernel.org/gnu/gcc/gcc-14.2.0/gcc-14.2.0.tar.xz"
   sha256 "a7b39bc69cbf9e25826c5a60ab26477001f7c08d85cec04bc0e29cabed6f3cc9"
 

--- a/tools/vscode-extension/scripts/mipsel-none-elf-gdb.rb
+++ b/tools/vscode-extension/scripts/mipsel-none-elf-gdb.rb
@@ -1,7 +1,7 @@
 class MipselNoneElfGdb < Formula
   desc "GDB: The GNU Project Debugger compiled for Mips"
   homepage "https://sourceware.org/gdb/"
-  url "https://ftp.gnu.org/gnu/gdb/gdb-15.1.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gdb/gdb-15.1.tar.xz"
   mirror "https://mirrors.kernel.org/gnu/gdb/gdb-15.1.tar.xz"
   sha256 "38254eacd4572134bca9c5a5aa4d4ca564cbbd30c369d881f733fb6b903354f2"
 

--- a/tools/win32-gdb/Dockerfile
+++ b/tools/win32-gdb/Dockerfile
@@ -45,7 +45,7 @@ RUN C:\msys64\usr\bin\bash.exe -l -c 'pacman -S --needed --noconfirm mingw-w64-x
 RUN C:\msys64\usr\bin\bash.exe -l -c 'pacman -S --needed --noconfirm mingw-w64-x86_64-python mingw-w64-x86_64-readline'
 RUN C:\msys64\usr\bin\bash.exe -l -c 'pacman -Scc --noconfirm'
 
-ARG GDB=https://ftp.gnu.org/gnu/gdb/gdb-15.1.tar.xz
+ARG GDB=https://ftpmirror.gnu.org/gnu/gdb/gdb-15.1.tar.xz
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     Invoke-WebRequest $env:GDB -OutFile "C:\Windows\Temp\gdb-15.1.tar.xz"; `

--- a/tools/win32-mips/Dockerfile
+++ b/tools/win32-mips/Dockerfile
@@ -45,8 +45,8 @@ RUN C:\msys64\usr\bin\bash.exe -l -c 'pacman -S --needed --noconfirm mingw-w64-x
 RUN C:\msys64\usr\bin\bash.exe -l -c 'pacman -S --needed --noconfirm mingw-w64-x86_64-python mingw-w64-x86_64-readline'
 RUN C:\msys64\usr\bin\bash.exe -l -c 'pacman -Scc --noconfirm'
 
-ARG BINUTILS=https://ftp.gnu.org/gnu/binutils/binutils-2.43.tar.xz
-ARG GCC=https://ftp.gnu.org/gnu/gcc/gcc-14.2.0/gcc-14.2.0.tar.xz
+ARG BINUTILS=https://ftpmirror.gnu.org/gnu/binutils/binutils-2.43.tar.xz
+ARG GCC=https://ftpmirror.gnu.org/gnu/gcc/gcc-14.2.0/gcc-14.2.0.tar.xz
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     Invoke-WebRequest $env:BINUTILS -OutFile "C:\Windows\Temp\binutils-2.43.tar.xz"; `


### PR DESCRIPTION
According to the [GNU Mirror List page](https://www.gnu.org/prep/ftp.en.html), ftpmirror.gnu.org automatically emits an HTTP 302 to the user's nearest GNU mirror.
This substantially increases download speeds for GNU files, especially for users geographically distant from Boston, USA.

I have replaced all mentions of ftp.gnu.org with ftpmirror.gnu.org. However, tests must be made to ensure downloads work properly, given the redirect.