### PR TITLE
Fix: correct the setting label for lua breakpoints

### DIFF
--- a/src/core/pcsxlua.cc
+++ b/src/core/pcsxlua.cc
@@ -47,7 +47,7 @@ LuaBreakpoint* addBreakpoint(uint32_t address, PCSX::Debug::BreakpointType type,
                              bool (*invoker)(uint32_t address, unsigned width, const char* cause), const char* label) {
     LuaBreakpoint* ret = new LuaBreakpoint();
     auto* bp = PCSX::g_emulator->m_debug->addBreakpoint(
-        address, type, width, std::string("Lua Breakpoint ") + cause, label,
+        address, type, width, std::string("Lua Breakpoint"), cause,
         [invoker](const PCSX::Debug::Breakpoint* self, uint32_t address, unsigned width, const char* cause) {
             try {
                 return invoker(address, width, cause);


### PR DESCRIPTION
I wonder to submit another pull request to refactor `pcsxlua.cc` file by removing the `cause `parameter and replacing it with `label `parameter as they serve the same purpose