### PR TITLE
Various psyqo-lua fixes & improvements

### DIFF
--- a/.github/workflows/linux-toolchain.yml
+++ b/.github/workflows/linux-toolchain.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Build OpenBIOS with it
         run: make -C src/mips/openbios -j 6 all
       - name: Build psyqo examples with it
-        run: for d in src/mips/psyqo/examples/* ; do make -C $d -j 6 all TEST=true ; done
+        run: for d in src/mips/psyqo/examples/* src/mips/psyqo-paths/examples/* src/mips/psyqo-lua/examples/* ; do make -C $d -j 6 all TEST=true ; done

--- a/src/mips/common.mk
+++ b/src/mips/common.mk
@@ -108,7 +108,7 @@ DEPS += $(patsubst %.s,   %.dep,$(filter %.s,$(SRCS)))
 
 dep: $(DEPS)
 
-clean: $(EXTRA_CLEAN)
+clean::
 	rm -f $(OBJS) $(BINDIR)*.a $(BINDIR)Overlay.* $(BINDIR)*.elf $(BINDIR)*.ps-exe $(BINDIR)*.map $(DEPS)
 
 ifneq ($(MAKECMDGOALS), clean)

--- a/src/mips/psyqo-lua/Makefile
+++ b/src/mips/psyqo-lua/Makefile
@@ -7,6 +7,7 @@ SRCS = \
 src/lua.cpp \
 
 CPPFLAGS += -I$(PSYQOLUADIR)../../../third_party/psxlua/src
+CPPFLAGS += -DLUA_TARGET_PSX
 
 EXTRA_DEPS += $(PSYQOLUADIR)Makefile
 

--- a/src/mips/psyqo-lua/examples/hello/hello.cpp
+++ b/src/mips/psyqo-lua/examples/hello/hello.cpp
@@ -45,6 +45,12 @@ function factorial(n)
     end
 end
 
+function printfactorial(n)
+    local f = factorial(n)
+    print('Factorial of ' .. tostring(n) .. ' is ' .. tostring(f))
+    return f
+end
+
 -- Calculate some values
 results = {
     factorial = factorial(5),
@@ -159,6 +165,8 @@ void LuaExample::createScene() {
     pushScene(&luaExampleScene);
 }
 
+using namespace psyqo::fixed_point_literals;
+
 void LuaExampleScene::frame() {
     auto& gpu = luaExample.gpu();
     auto& font = luaExample.m_font;
@@ -187,6 +195,20 @@ void LuaExampleScene::frame() {
         } else {
             int factorial7 = luaExample.L.toNumber(-1);
             font.printf(gpu, {{.x = 16, .y = 144}}, textColor, "Calling factorial(7) from C++: %d", factorial7);
+        }
+        luaExample.L.pop();
+
+        // Example of using FixedPoint
+        luaExample.L.getGlobal("printfactorial");
+        luaExample.L.push(6.0_fp);
+        if (luaExample.L.pcall(1, 1) != 0) {
+            // Error occurred
+            font.print(gpu, "Error calling printfactorial(6):", {{.x = 16, .y = 160}}, textColor);
+            font.print(gpu, luaExample.L.toString(-1), {{.x = 16, .y = 176}}, textColor);
+        } else {
+            auto factorial6 = luaExample.L.toFixedPoint(-1);
+            font.print(gpu, "Calling printfactorial(6.0_fp):", {{.x = 16, .y = 176}}, textColor);
+            font.printf(gpu, {{.x = 16, .y = 192}}, textColor, "Factorial(6) is %.2f", factorial6);
         }
         luaExample.L.pop();
     } else {

--- a/src/mips/psyqo-lua/psyqo-lua.mk
+++ b/src/mips/psyqo-lua/psyqo-lua.mk
@@ -4,13 +4,12 @@ PSYQOLUADIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 LIBRARIES += $(PSYQOLUADIR)libpsyqo-lua.a $(PSYQOLUADIR)../../../third_party/psxlua/src/liblua.a
 
 CPPFLAGS += -I$(PSYQOLUADIR)../../../third_party/psxlua/src
+CPPFLAGS += -DLUA_TARGET_PSX
 
 LDFLAGS += \
 -Wl,--defsym,luaI_sprintf=sprintf_for_Lua \
 -Wl,--defsym,luaI_realloc=psyqo_realloc \
 -Wl,--defsym,luaI_free=psyqo_free \
-
-EXTRA_CLEAN += clean-psyqo-lua
 
 include $(PSYQOLUADIR)../psyqo/psyqo.mk
 
@@ -20,9 +19,9 @@ $(PSYQOLUADIR)libpsyqo-lua.a:
 $(PSYQOLUADIR)../../../third_party/psxlua/src/liblua.a:
 	$(MAKE) -C $(PSYQOLUADIR)../../../third_party/psxlua/ psx
 
-clean-psyqo-lua:
+clean::
 	$(MAKE) -C $(PSYQOLUADIR) clean
 	$(MAKE) -C $(PSYQOLUADIR)../../../third_party/psxlua/ clean
 
-.PHONY: clean-psyqo-lua $(PSYQOLUADIR)libpsyqo-lua.a $(PSYQOLUADIR)../../../third_party/psxlua/src/liblua.a
+.PHONY: clean $(PSYQOLUADIR)libpsyqo-lua.a $(PSYQOLUADIR)../../../third_party/psxlua/src/liblua.a
 endif

--- a/src/mips/psyqo-lua/src/lua.cpp
+++ b/src/mips/psyqo-lua/src/lua.cpp
@@ -262,31 +262,36 @@ void psyqo::Lua::setupFixedPointMetatable() {
         end
 
         FixedPoint.newFromRaw = newFromRaw
+        local lshift = bit32.lshift
+        local rshift = bit32.rshift
+        local err = function(op)
+            error('Cannot ' .. op .. ' FixedPoint to this type')
+        end
 
         -- Simple operations can be done directly in Lua
         function FixedPoint.__add(a, b)
             local raw_a = a._raw
-            if type(b) == "number" then
-                -- FixedPoint + number (treated as integer)
-                return newFromRaw(raw_a + bit32.lshift(b, 12))
-            elseif type(b) == "table" and b._raw then
+            if type(b) == 'number' then
+                -- FixedPoint + number
+                return newFromRaw(raw_a + lshift(b, 12))
+            elseif type(b) == 'table' and b._raw then
                 -- FixedPoint + FixedPoint
                 return newFromRaw(raw_a + b._raw)
             else
-                error("Cannot add FixedPoint to this type")
+                err('add')
             end
         end
 
         function FixedPoint.__sub(a, b)
             local raw_a = a._raw
-            if type(b) == "number" then
-                -- FixedPoint - number (treated as integer)
-                return newFromRaw(raw_a - bit32.lshift(b, 12))
-            elseif type(b) == "table" and b._raw then
+            if type(b) == 'number' then
+                -- FixedPoint - number
+                return newFromRaw(raw_a - lshift(b, 12))
+            elseif type(b) == 'table' and b._raw then
                 -- FixedPoint - FixedPoint
                 return newFromRaw(raw_a - b._raw)
             else
-                error("Cannot subtract this type from FixedPoint")
+                err('subtract')
             end
         end
 
@@ -296,35 +301,35 @@ void psyqo::Lua::setupFixedPointMetatable() {
         end
 
         function FixedPoint.__eq(a, b)
-            if type(b) == "table" and b._raw then
+            if type(b) == 'table' and b._raw then
                 return a._raw == b._raw
-            elseif type(b) == "number" then
+            elseif type(b) == 'number' then
                 -- Compare with an integer number (shifted)
-                return a._raw == bit32.lshift(b, 12)
+                return a._raw == lshift(b, 12)
             else
                 return false
             end
         end
 
         function FixedPoint.__lt(a, b)
-            if type(b) == "table" and b._raw then
+            if type(b) == 'table' and b._raw then
                 return a._raw < b._raw
-            elseif type(b) == "number" then
+            elseif type(b) == 'number' then
                 -- Compare with an integer number (shifted)
-                return a._raw < bit32.lshift(b, 12)
+                return a._raw < lshift(b, 12)
             else
-                error("Cannot compare FixedPoint with this type")
+                err('compare')
             end
         end
 
         function FixedPoint.__le(a, b)
-            if type(b) == "table" and b._raw then
+            if type(b) == 'table' and b._raw then
                 return a._raw <= b._raw
-            elseif type(b) == "number" then
+            elseif type(b) == 'number' then
                 -- Compare with an integer number (shifted)
-                return a._raw <= bit32.lshift(b, 12)
+                return a._raw <= lshift(b, 12)
             else
-                error("Cannot compare FixedPoint with this type")
+                err('compare')
             end
         end
 
@@ -335,13 +340,13 @@ void psyqo::Lua::setupFixedPointMetatable() {
 
         -- Method to convert to a simple number (for simple calculations)
         function FixedPoint:toNumber()
-            return bit32.rshift((self._raw + 2048), 12)
+            return rshift((self._raw + 2048), 12)
         end
 
         -- Create a new FixedPoint
         function FixedPoint.new(integer, fraction)
             if fraction == nil then fraction = 0 end
-            return setmetatable({_raw = bit32.lshift(integer, 12) + fraction}, FixedPoint)
+            return setmetatable({_raw = lshift(integer, 12) + fraction}, FixedPoint)
         end
     end
     )lua";

--- a/src/mips/psyqo-paths/psyqo-paths.mk
+++ b/src/mips/psyqo-paths/psyqo-paths.mk
@@ -3,14 +3,12 @@ PSYQOPATHSDIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 LIBRARIES += $(PSYQOPATHSDIR)libpsyqo-paths.a
 
-EXTRA_CLEAN += clean-psyqo-paths
-
 include $(PSYQOPATHSDIR)../psyqo/psyqo.mk
 
 $(PSYQOPATHSDIR)libpsyqo-paths.a:
 	$(MAKE) -C $(PSYQOPATHSDIR) BUILD=$(BUILD)
 
-clean-psyqo-paths:
+clean::
 	$(MAKE) -C $(PSYQOPATHSDIR) clean
 
 .PHONY: clean-psyqo-paths $(PSYQOPATHSDIR)libpsyqo-paths.a

--- a/src/mips/psyqo/psyqo.mk
+++ b/src/mips/psyqo/psyqo.mk
@@ -5,15 +5,13 @@ LIBRARIES += $(PSYQODIR)libpsyqo.a
 CPPFLAGS += -I$(PSYQODIR)../../../third_party/EASTL/include -I$(PSYQODIR)../../../third_party/EABase/include/Common
 CXXFLAGS += -std=c++20
 
-EXTRA_CLEAN += clean-psyqo
-
 include $(PSYQODIR)../common.mk
 
 $(PSYQODIR)libpsyqo.a:
 	$(MAKE) -C $(PSYQODIR) BUILD=$(BUILD) CPPFLAGS_$(BUILD)=$(CPPFLAGS_$(BUILD)) LDFLAGS_$(BUILD)=$(LDFLAGS_$(BUILD))
 
-clean-psyqo:
+clean::
 	$(MAKE) -C $(PSYQODIR) clean
 
-.PHONY: clean-psyqo $(PSYQODIR)libpsyqo.a
+.PHONY: clean $(PSYQODIR)libpsyqo.a
 endif


### PR DESCRIPTION
- proper cleaning cascading
- adding pushv for resolving ambiguity
- adding template to toUserdata
- adding LUA_MULTRET default to call / pcall
- refactored pcall to include a traceback
- properly using bit32 for fixedpoint instead of bit
- capturing newFromRaw locally for speedup
- opening Lua libraries on vm creation
- proper propagation of LUA_TARGET_PSX define