### PR TITLE
Fixing casting issue in fixed-point.hh

### DIFF
--- a/src/mips/psyqo/fixed-point.hh
+++ b/src/mips/psyqo/fixed-point.hh
@@ -172,7 +172,7 @@ class FixedPoint {
                 return U((value - scale / 2) / scale);
             }
         }
-        return U(value + scale / 2) / U(scale);
+        return U((value + scale / 2) / scale);
     }
 
     /**


### PR DESCRIPTION
The `integer()` overload with a different type had inconsistent codepath between signed and unsigned, resulting in precision problems.