### PR TITLE
MacOS bundling fixes

### DIFF
--- a/.github/scripts/create-app.sh
+++ b/.github/scripts/create-app.sh
@@ -57,6 +57,8 @@ PlistBuddy ${APPROOT}/Contents/Info.plist -c "add CFBundleInfoDictionaryVersion 
 PlistBuddy ${APPROOT}/Contents/Info.plist -c "add CFBundleName string ${APP}"
 PlistBuddy ${APPROOT}/Contents/Info.plist -c "add CFBundlePackageType string APPL"
 PlistBuddy ${APPROOT}/Contents/Info.plist -c "add NSHumanReadableCopyright string Copyright PCSX-Redux Authors"
+PlistBuddy ${APPROOT}/Contents/Info.plist -c "add LSApplicationCategoryType string public.app-category.games"
+PlistBuddy ${APPROOT}/Contents/Info.plist -c "add LSSupportsGameMode bool true"
 
 PlistBuddy ${APPROOT}/Contents/Info.plist -c "add LSMinimumSystemVersion string 10.15"
 

--- a/.github/scripts/create-app.sh
+++ b/.github/scripts/create-app.sh
@@ -40,6 +40,9 @@ cp pcsx-redux.icns ${APPROOT}/Contents/Resources/AppIcon.icns
 # Remove source images that were used to create the app icon.
 rm -rfv ${APPROOT}/Contents/Resources/share/icons
 
+# Remove temporary image files
+rm -rfv pcsx-redux.iconset pcsx-redux.icns
+
 # Create the required Info.plist and version.plist files
 # with the minimum information.
 PlistBuddy ${APPROOT}/Contents/Info.plist -c "add CFBundleDisplayName string ${APP}"

--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,7 @@ fb.bat
 
 # macos files
 .DS_store
-
+PCSX-Redux.app
 
 # Savestate files
 *.sstate


### PR DESCRIPTION
- Adds bundle file to gitignore
- Enables support for Game Mode, which tells MacOS to give higher CPU/GPU priority to the application and reduces input & audio latency (See [here](https://support.apple.com/en-us/105118))
- Cleans up temporary icon files created during bundling