### PR TITLE
a64 JIT: Fix `setRWX` returning nothing on Apple

### DIFF
--- a/src/core/DynaRec_aa64/emitter.h
+++ b/src/core/DynaRec_aa64/emitter.h
@@ -71,6 +71,8 @@ class Emitter : public MacroAssembler {
         return VirtualProtect(s_codeCache, allocSize, PAGE_EXECUTE_READWRITE, &oldProtect) != 0;
 #elif !defined(__APPLE__)
         return mprotect(s_codeCache, allocSize, PROT_READ | PROT_WRITE | PROT_EXEC) != -1;
+#else
+        return false;
 #endif
     }
 

--- a/src/core/DynaRec_aa64/recompiler.cc
+++ b/src/core/DynaRec_aa64/recompiler.cc
@@ -67,8 +67,7 @@ bool DynaRecCPU::Init() {
         PCSX::g_system->message("[Dynarec] Failed to allocate executable memory.\nTry disabling the Dynarec CPU.");
         return false;
     }
-#endif
-#if defined(__APPLE__)
+#else
     gen.setRW();  // M1 wants buffer marked as readable/writable with mprotect before emitting code
 #endif
     emitDispatcher();  // Emit our assembly dispatcher


### PR DESCRIPTION
This shouldn't change anything because the function was not being called at all on MacOS, but it's best to avoid any future happy accidents in case that changes.

On a relevant note, I need to fix Windows support for the a64 JIT, but I haven't gotten my WoA dev setup running yet.