### PR TITLE
arm64 JIT: Fix broken cache invalidation

### DIFF
--- a/src/core/DynaRec_aa64/recompiler.h
+++ b/src/core/DynaRec_aa64/recompiler.h
@@ -237,6 +237,12 @@ class DynaRecCPU final : public PCSX::R3000Acpu {
     virtual void Shutdown() final;
     virtual bool isDynarec() final { return true; }
 
+    virtual void invalidateCache() override final {
+        memset(m_regs.iCacheAddr, 0xff, sizeof(m_regs.iCacheAddr));
+        memset(m_regs.iCacheCode, 0xff, sizeof(m_regs.iCacheCode));
+        uncompileAll();  // Mark all blocks as uncompiled
+    }
+
     virtual void SetPGXPMode(uint32_t pgxpMode) final {
         if (pgxpMode != 0) {
             throw std::runtime_error("PGXP not supported in x64 JIT");


### PR DESCRIPTION
Fully flushes JIT cache when FlushCache is called. Should fix several games. Tested with Castlevania: Symphony of the Night, which fails to read from memcards without this patch.

Unlike the x64 equivalent, this doesn't use optimized SIMD code for invalidation yet, but it should be fine for now since most ARM users are probably on Apple Silicon which is plenty fast.