### PR TITLE
Add --no-portable flag

### DIFF
--- a/src/core/arguments.cc
+++ b/src/core/arguments.cc
@@ -35,6 +35,7 @@ PCSX::Arguments::Arguments(const CommandLine::args& args) {
     if (std::filesystem::exists("pcsx.json")) m_portable = true;
     if (std::filesystem::exists(std::filesystem::path("vsprojects") / "pcsx-redux.sln")) m_portable = true;
     if (std::filesystem::exists(std::filesystem::path("..") / "pcsx-redux.sln")) m_portable = true;
+    if (args.get<bool>("no-portable")) m_portable = false;
     if (args.get<bool>("safe") || args.get<bool>("testmode") || args.get<bool>("cli")) m_safeModeEnabled = true;
     if (args.get<bool>("resetui")) m_uiResetRequested = true;
     if (args.get<bool>("noshaders")) m_shadersDisabled = true;


### PR DESCRIPTION
Useful on MacOS where app bundles are always going to store settings, memcards, etc in $HOME/.config/pcsx-redux. I use this flag to make my dev builds use the same persistent directory as app bundles, so as not to have multiple copies of those files.

One could also use the --portable flag with an appropriate path to achieve the same thing, but this is easier to use since you don't need to remember the correct path.