### PR TITLE
Remove deprecated fmt::localtime API and update fmt to 12.0.0

### DIFF
--- a/src/gui/gui.cc
+++ b/src/gui/gui.cc
@@ -63,7 +63,6 @@ extern "C" {
 #include "core/sstate.h"
 #include "core/web-server.h"
 #include "flags.h"
-#include "fmt/chrono.h"
 #include "gui/gui.h"
 #include "gui/luaimguiextra.h"
 #include "gui/luanvg.h"
@@ -2413,16 +2412,17 @@ bool PCSX::GUI::about() {
                     ImGui::EndDisabled();
                     ImGui::TextUnformatted(_("No version information.\n\nProbably built from source."));
                 } else {
+                    auto timestamp = version.formatTimestamp("{:%Y-%m-%d %H:%M:%S}");
                     if (ImGui::Button(_("Copy to clipboard"))) {
                         if (version.buildId.has_value()) {
                             clip::set_text(
-                                fmt::format("Version: {}\nBuild: {}\nChangeset: {}\nDate & time: {:%Y-%m-%d %H:%M:%S}",
+                                fmt::format("Version: {}\nBuild: {}\nChangeset: {}\nDate & time: {}",
                                             version.version, version.buildId.value(), version.changeset,
-                                            fmt::localtime(version.timestamp)));
+                                            timestamp));
                         } else {
-                            clip::set_text(fmt::format("Version: {}\nChangeset: {}\nDate & time: {:%Y-%m-%d %H:%M:%S}",
+                            clip::set_text(fmt::format("Version: {}\nChangeset: {}\nDate & time: {}",
                                                        version.version, version.changeset,
-                                                       fmt::localtime(version.timestamp)));
+                                                       timestamp));
                         }
                     }
                     ImGui::Text(_("Version: %s"), version.version.c_str());
@@ -2434,8 +2434,6 @@ bool PCSX::GUI::about() {
                     if (ImGui::SmallButton(version.changeset.c_str())) {
                         openUrl(fmt::format("https://github.com/grumpycoders/pcsx-redux/commit/{}", version.changeset));
                     }
-                    std::tm tm = fmt::localtime(version.timestamp);
-                    std::string timestamp = fmt::format("{:%Y-%m-%d %H:%M:%S}", tm);
                     ImGui::Text(_("Date & time: %s"), timestamp.c_str());
                 }
                 ImGui::EndTabItem();

--- a/src/main/main.cc
+++ b/src/main/main.cc
@@ -32,7 +32,6 @@
 #include "core/sstate.h"
 #include "core/ui.h"
 #include "flags.h"
-#include "fmt/chrono.h"
 #include "gui/gui.h"
 #include "lua/extra.h"
 #include "lua/luawrapper.h"
@@ -217,8 +216,8 @@ int pcsxMain(int argc, char **argv) {
         }
         fmt::print(
             "{{\n  \"version\": \"{}\",\n  \"changeset\": \"{}\",\n  \"timestamp\": \"{}\",\n  \"timestampDecoded\": "
-            "\"{:%Y-%m-%d %H:%M:%S}\"\n}}\n",
-            version.version, version.changeset, version.timestamp, fmt::localtime(version.timestamp));
+            "\"{}\"\n}}\n",
+            version.version, version.changeset, version.timestamp, version.formatTimestamp("{:%Y-%m-%d %H:%M:%S}"));
         return 0;
     }
 

--- a/src/support/version.cc
+++ b/src/support/version.cc
@@ -27,6 +27,9 @@ SOFTWARE.
 #include "support/version.h"
 
 #include <algorithm>
+#include <chrono>
+#include <fmt/chrono.h>
+#include <fmt/format.h>
 
 #include "json.hpp"
 #include "support/container-file.h"
@@ -63,6 +66,12 @@ void PCSX::VersionInfo::loadFromFile(IO<File> file) {
     updateCatalog = getString("updateCatalog");
     updateInfoBase = getString("updateInfoBase");
     updateStorageUrl = getString("updateStorageUrl");
+}
+
+std::string PCSX::VersionInfo::formatTimestamp(const std::string& format) const {
+    auto timepoint = std::chrono::system_clock::from_time_t(timestamp);
+    auto local = std::chrono::current_zone()->to_local(timepoint);
+    return fmt::format(fmt::runtime(format), floor<std::chrono::seconds>(local));
 }
 
 bool PCSX::Update::downloadUpdateInfo(const VersionInfo& versionInfo, std::function<void(bool)> callback,

--- a/src/support/version.h
+++ b/src/support/version.h
@@ -60,6 +60,7 @@ struct VersionInfo {
         }
         return (updateMethod == "appcenter");
     }
+    std::string formatTimestamp(const std::string& format) const;
     void clear() {
         version.clear();
         buildId = std::nullopt;

--- a/tests/support/version.cc
+++ b/tests/support/version.cc
@@ -17,8 +17,9 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.           *
  ***************************************************************************/
 
+#include <ctime>
+#include <fmt/chrono.h>
 #include "support/version.h"
-
 #include "gtest/gtest.h"
 
 using namespace PCSX;
@@ -31,10 +32,18 @@ protected:
         "06fdac536d1d8301fdc626fe89d1084a3ad241ad",
         1737185273,
     };
+    static std::string formatWithStdLocal(std::time_t ts, const char* fmt_str) {
+        auto tm_ptr = std::localtime(&ts);
+        if (!tm_ptr) {
+            return {};
+        }
+        return fmt::format(fmt::runtime(fmt_str), *tm_ptr);
+    }
 };
 
 TEST_F(VersionInfoTest, TimestampFormatsDateAndTime) {
-    EXPECT_EQ(vi.formatTimestamp("{:%Y-%m-%d %H:%M:%S}"), "2025-01-18 02:27:53");
+    auto format = "{:%Y-%m-%d %H:%M:%S}";
+    EXPECT_EQ(vi.formatTimestamp(format), formatWithStdLocal(vi.timestamp, format));
 }
 
 TEST_F(VersionInfoTest, TimestampNullFormatReturnsNullString) {
@@ -46,10 +55,11 @@ TEST_F(VersionInfoTest, TimestampFormatNoPlaceholderReturnsCopy) {
 }
 
 TEST_F(VersionInfoTest, TimestampFormatReturnsNonPlaceholderText) {
-    EXPECT_EQ(vi.formatTimestamp("123 {}"), "123 2025-01-18 02:27:53");
+    auto format = "123 {}";
+    EXPECT_EQ(vi.formatTimestamp(format), formatWithStdLocal(vi.timestamp, format));
 }
 
 TEST_F(VersionInfoTest, TimestampFormatHandlesNegativeNumber) {
     vi.timestamp = -1;
-    EXPECT_EQ(vi.formatTimestamp("{}"), "1969-12-31 18:59:59");
+    EXPECT_EQ(vi.formatTimestamp("{}"), formatWithStdLocal(vi.timestamp, "{}"));
 }

--- a/tests/support/version.cc
+++ b/tests/support/version.cc
@@ -1,0 +1,55 @@
+/***************************************************************************
+ *   Copyright (C) 2025 PCSX-Redux authors                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.           *
+ ***************************************************************************/
+
+#include "support/version.h"
+
+#include "gtest/gtest.h"
+
+using namespace PCSX;
+
+class VersionInfoTest: public ::testing::Test {
+protected:
+    VersionInfo vi{
+        "06fdac53",
+        159,
+        "06fdac536d1d8301fdc626fe89d1084a3ad241ad",
+        1737185273,
+    };
+};
+
+TEST_F(VersionInfoTest, TimestampFormatsDateAndTime) {
+    EXPECT_EQ(vi.formatTimestamp("{:%Y-%m-%d %H:%M:%S}"), "2025-01-18 02:27:53");
+}
+
+TEST_F(VersionInfoTest, TimestampNullFormatReturnsNullString) {
+    EXPECT_EQ(vi.formatTimestamp(""), "");
+}
+
+TEST_F(VersionInfoTest, TimestampFormatNoPlaceholderReturnsCopy) {
+    EXPECT_EQ(vi.formatTimestamp("abc"), "abc");
+}
+
+TEST_F(VersionInfoTest, TimestampFormatReturnsNonPlaceholderText) {
+    EXPECT_EQ(vi.formatTimestamp("123 {}"), "123 2025-01-18 02:27:53");
+}
+
+TEST_F(VersionInfoTest, TimestampFormatHandlesNegativeNumber) {
+    vi.timestamp = -1;
+    EXPECT_EQ(vi.formatTimestamp("{}"), "1969-12-31 18:59:59");
+}


### PR DESCRIPTION
Fixes #1969 

`fmt::localtime` was deprecated and finally removed in fmt 12, which was pushed to Arch Linux recently, and this caused build failures and runtime errors when linked against the system fmt library. This PR removes the deprecated function and replaces it with a new `formatTimestamp()` function in `VersionInfo` that formats the timestamp based on a format string argument passed by the caller. 

Note that these changes are _**incompatible**_ with fmt10, so we needed to update the submodule as well.