### PR TITLE
add --syncdeps to install missing PKGBUILD dependencies

### DIFF
--- a/.github/workflows/linux-aur.yml
+++ b/.github/workflows/linux-aur.yml
@@ -22,6 +22,7 @@ jobs:
         run: |
           useradd builduser -m
           passwd -d builduser
+          echo "builduser ALL=(ALL) NOPASSWD: ALL" | tee /etc/sudoers.d/builduser && chmod 440 /etc/sudoers.d/builduser
       - name: Build AUR Package
         run: |
           mkdir /build
@@ -29,4 +30,4 @@ jobs:
           chown -R builduser:builduser /build
           cd /build/pcsx-redux-git
           sed -i s,git+https://github.com/grumpycoders/pcsx-redux.git,git+file://$GITHUB_WORKSPACE#commit=$GITHUB_SHA,g PKGBUILD
-          sudo -u builduser makepkg
+          sudo -u builduser bash -c 'makepkg --noconfirm --syncdeps'


### PR DESCRIPTION
The AUR CI workflow was failing due to new dependencies being added to the PKGBUILD but not the Github action. This PR adds the `--syncdeps` flag to automatically install any missing dependencies from the PKGBUILD when building the package.