### PR TITLE
Render directory node fully (including extension)

### DIFF
--- a/third_party/ImFileDialog/ImFileDialog.cpp
+++ b/third_party/ImFileDialog/ImFileDialog.cpp
@@ -1072,7 +1072,7 @@ namespace ifd {
 		std::error_code ec;
 		ImGui::PushID(node);
 		bool isClicked = false;
-		std::string displayName = u8StringToString(node->Path.stem().u8string());
+		std::string displayName = u8StringToString(node->Path.filename().u8string());
 		if (displayName.size() == 0)
 			displayName = u8StringToString(node->Path.u8string());
 		if (FolderNode(displayName.c_str(), (ImTextureID)m_getIcon(node->Path), isClicked)) {


### PR DESCRIPTION
Before:

<img width="203" height="109" alt="image" src="https://github.com/user-attachments/assets/c62dad36-a60f-4b78-a0d3-cc4bdfd6c0be" />

After:

<img width="249" height="121" alt="image" src="https://github.com/user-attachments/assets/bad12fb9-a4e0-4c65-8e1c-c40731e6071b" />
