### PR TITLE
fmt has broken the build again

### DIFF
--- a/src/gui/gui.cc
+++ b/src/gui/gui.cc
@@ -2418,11 +2418,11 @@ bool PCSX::GUI::about() {
                             clip::set_text(
                                 fmt::format("Version: {}\nBuild: {}\nChangeset: {}\nDate & time: {:%Y-%m-%d %H:%M:%S}",
                                             version.version, version.buildId.value(), version.changeset,
-                                            fmt::localtime(version.timestamp)));
+                                            *std::localtime(&version.timestamp)));
                         } else {
                             clip::set_text(fmt::format("Version: {}\nChangeset: {}\nDate & time: {:%Y-%m-%d %H:%M:%S}",
                                                        version.version, version.changeset,
-                                                       fmt::localtime(version.timestamp)));
+                                                       *std::localtime(&version.timestamp)));
                         }
                     }
                     ImGui::Text(_("Version: %s"), version.version.c_str());
@@ -2434,7 +2434,7 @@ bool PCSX::GUI::about() {
                     if (ImGui::SmallButton(version.changeset.c_str())) {
                         openUrl(fmt::format("https://github.com/grumpycoders/pcsx-redux/commit/{}", version.changeset));
                     }
-                    std::tm tm = fmt::localtime(version.timestamp);
+                    std::tm tm = *std::localtime(&version.timestamp);
                     std::string timestamp = fmt::format("{:%Y-%m-%d %H:%M:%S}", tm);
                     ImGui::Text(_("Date & time: %s"), timestamp.c_str());
                 }

--- a/src/main/main.cc
+++ b/src/main/main.cc
@@ -218,7 +218,7 @@ int pcsxMain(int argc, char **argv) {
         fmt::print(
             "{{\n  \"version\": \"{}\",\n  \"changeset\": \"{}\",\n  \"timestamp\": \"{}\",\n  \"timestampDecoded\": "
             "\"{:%Y-%m-%d %H:%M:%S}\"\n}}\n",
-            version.version, version.changeset, version.timestamp, fmt::localtime(version.timestamp));
+            version.version, version.changeset, version.timestamp, *std::localtime(&version.timestamp));
         return 0;
     }
 


### PR DESCRIPTION
fmt::localtime was removed in favor of std::localtime, so I had to change it to that to be able to build the emulator