### PR TITLE
Add lua event listener for CPU::Interrupt and scheduleInterrupt

### DIFF
--- a/src/core/eventslua.cc
+++ b/src/core/eventslua.cc
@@ -205,7 +205,10 @@ void PCSX::LuaBindings::open_events(Lua L) {
                 createListener<Events::Keyboard>(L);
             } else if (name == "Memory::SetLuts") {
                 createListener<Events::Memory::SetLuts>(L);
-            } else {
+            } else if (name == "CPU::Interrupt") {
+                createListener<Events::CPU::Interrupt>(L);
+            }
+            else {
                 return L.error("createListener: unknown event name");
             }
             return 1;

--- a/src/core/pcsxffi.lua
+++ b/src/core/pcsxffi.lua
@@ -175,6 +175,7 @@ end
 
 local function scheduleInterrupt(eCycle)
     if type(eCycle) ~= 'number' then error 'PCSX.scheduleInterrupt requires a numeric cycle count' end
+    if (eCycle < 0) or (eCycle > 0xffffffff) then error 'PCSX.scheduleInterrupt cycle count parameter should be an unsigned 32-bit integer'
     C.scheduleInterrupt(eCycle)
 end
 

--- a/src/core/pcsxffi.lua
+++ b/src/core/pcsxffi.lua
@@ -175,7 +175,7 @@ end
 
 local function scheduleInterrupt(eCycle)
     if type(eCycle) ~= 'number' then error 'PCSX.scheduleInterrupt requires a numeric cycle count' end
-    if (eCycle < 0) or (eCycle > 0xffffffff) or (eCycle % 1 ~= 0) then error 'PCSX.scheduleInterrupt cycle count parameter should be an unsigned 32-bit integer'
+    if (eCycle < 0) or (eCycle > 0xffffffff) or (eCycle % 1 ~= 0) then error 'PCSX.scheduleInterrupt cycle count parameter should be an unsigned 32-bit integer' end
     C.scheduleInterrupt(eCycle)
 end
 

--- a/src/core/pcsxffi.lua
+++ b/src/core/pcsxffi.lua
@@ -175,7 +175,7 @@ end
 
 local function scheduleInterrupt(eCycle)
     if type(eCycle) ~= 'number' then error 'PCSX.scheduleInterrupt requires a numeric cycle count' end
-    if (eCycle < 0) or (eCycle > 0xffffffff) then error 'PCSX.scheduleInterrupt cycle count parameter should be an unsigned 32-bit integer'
+    if (eCycle < 0) or (eCycle > 0xffffffff) or (eCycle % 1 ~= 0) then error 'PCSX.scheduleInterrupt cycle count parameter should be an unsigned 32-bit integer'
     C.scheduleInterrupt(eCycle)
 end
 

--- a/src/core/pcsxffi.lua
+++ b/src/core/pcsxffi.lua
@@ -72,6 +72,7 @@ void luaLog(const char* msg);
 void jumpToPC(uint32_t address);
 void jumpToMemory(uint32_t address, unsigned width);
 void invalidateCache();
+void scheduleInterrupt(uint32_t eCycle);
 
 typedef enum { BPP_16, BPP_24 } ScreenShotBPP;
 
@@ -172,6 +173,11 @@ local function jumpToMemory(address, width)
     C.jumpToMemory(address, width)
 end
 
+local function scheduleInterrupt(eCycle)
+    if type(eCycle) ~= 'number' then error 'PCSX.scheduleInterrupt requires a numeric cycle count' end
+    C.scheduleInterrupt(eCycle)
+end
+
 PCSX = {
     getCPUCycles = function() return C.getCPUCycles() end,
     getMemPtr = function() return C.getMemPtr() end,
@@ -187,6 +193,7 @@ PCSX = {
     softResetEmulator = function() C.softResetEmulator() end,
     hardResetEmulator = function() C.hardResetEmulator() end,
     invalidateCache = function() C.invalidateCache() end,
+    scheduleInterrupt = scheduleInterrupt,
     log = function(...) printLike(function(msg) C.luaLog(msg .. '\n') end, ...) end,
     GUI = { jumpToPC = jumpToPC, jumpToMemory = jumpToMemory },
     nextTick = function(f)

--- a/src/core/pcsxlua.cc
+++ b/src/core/pcsxlua.cc
@@ -88,6 +88,7 @@ void jumpToMemory(uint32_t address, unsigned width) {
     PCSX::g_system->m_eventBus->signal(PCSX::Events::GUI::JumpToMemory{address, width});
 }
 void invalidateCache() { PCSX::g_emulator->m_cpu->invalidateCache(); }
+void scheduleInterrupt(uint32_t eCycle) { PCSX::g_emulator->m_cpu->scheduleInterrupt(PCSX::PSXINT_LUA, eCycle); }
 
 struct LuaScreenShot {
     PCSX::Slice* data;
@@ -159,6 +160,7 @@ static void registerAllSymbols(PCSX::Lua L) {
     REGISTER(L, luaLog);
     REGISTER(L, jumpToPC);
     REGISTER(L, jumpToMemory);
+    REGISTER(L, scheduleInterrupt);
     REGISTER(L, invalidateCache);
     REGISTER(L, takeScreenShot);
     REGISTER(L, createSaveState);

--- a/src/core/r3000a.cc
+++ b/src/core/r3000a.cc
@@ -396,6 +396,7 @@ void PCSX::R3000Acpu::branchTest() {
         checkAndUpdate(PSXINT_CDRPLAY, g_emulator->m_cdrom->playInterrupt);
         checkAndUpdate(PSXINT_CDRDBUF, g_emulator->m_cdrom->decodedBufferInterrupt);
         checkAndUpdate(PSXINT_CDRLID, g_emulator->m_cdrom->lidSeekInterrupt);
+        checkAndUpdate(PSXINT_LUA, g_emulator->m_lua->interrupt);
         m_regs.lowestTarget = lowestTarget;
     }
     auto& mem = g_emulator->m_mem;

--- a/src/core/r3000a.h
+++ b/src/core/r3000a.h
@@ -177,7 +177,8 @@ enum {
     PSXINT_SPUASYNC,
     PSXINT_CDRDBUF,
     PSXINT_CDRLID,
-    PSXINT_CDRPLAY
+    PSXINT_CDRPLAY,
+    PSXINT_LUA,
 };
 
 struct psxRegisters {
@@ -316,8 +317,8 @@ class R3000Acpu {
     }
 
     psxRegisters m_regs;
-    float m_interruptScales[15] = {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f,
-                                   1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f};
+    float m_interruptScales[16] = {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f,
+                                   1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f};
     bool m_shellStarted = false;
 
     virtual void Reset() {

--- a/src/core/system.h
+++ b/src/core/system.h
@@ -119,6 +119,9 @@ struct Keyboard {
 namespace Memory {
 struct SetLuts {};
 }  // namespace Memory
+namespace CPU {
+struct Interrupt {};
+}  // namespace CPU
 }  // namespace Events
 
 class System {

--- a/src/lua/luawrapper.cc
+++ b/src/lua/luawrapper.cc
@@ -19,6 +19,8 @@
 
 #include "lua/luawrapper.h"
 
+#include "core/system.h"
+
 #include <assert.h>
 
 static int callwrap(lua_State* raw, lua_CFunction func) {
@@ -673,3 +675,5 @@ void PCSX::Lua::fromJson(const json& j, int t) {
         }
     }
 }
+
+void PCSX::Lua::interrupt() { PCSX::g_system->m_eventBus->signal<PCSX::Events::CPU::Interrupt>({}); }

--- a/src/lua/luawrapper.h
+++ b/src/lua/luawrapper.h
@@ -250,6 +250,8 @@ class Lua {
         return ar;
     }
 
+    void interrupt();
+
   private:
     lua_State* L;
 };


### PR DESCRIPTION
Adding a method for scheduling callbacks into Lua based on elapsed CPU cycles. Builds on existing scheduler and event listener methods.