### PR TITLE
Guard keyboard input against missing ImGui context

### DIFF
--- a/src/core/pad.cc
+++ b/src/core/pad.cc
@@ -579,6 +579,7 @@ void PadsImpl::Pad::getButtons() {
     const auto& inputType = m_settings.get<SettingInputType>();
 
     auto getKeyboardButtons = [this]() -> uint16_t {
+        if (!ImGui::GetCurrentContext()) return 0xffff;
         uint16_t result = 0;
         for (unsigned i = 0; i < 16; i++) {
             auto key = GlfwKeyToImGuiKey(m_scancodes[i]);


### PR DESCRIPTION
In --cli/--no-ui mode there's no ImGui context, so getKeyboardButtons
calling ImGui::IsKeyDown crashes. Return 0xffff (no buttons pressed)
when no context exists.