### PR TITLE
prevent buffer overflow in directDMARead

### DIFF
--- a/src/core/gpu.cc
+++ b/src/core/gpu.cc
@@ -700,6 +700,7 @@ void PCSX::GPU::directDMARead(uint32_t *dest, int transferSize, uint32_t hwAddr)
     dest += size / 4;
     while (transferSize != 0) {
         *dest++ = m_dataRet;
+        transferSize--;
     }
 }
 


### PR DESCRIPTION
In the directDMARead function, when the requested transferSize exceeds the available data in m_readFifo, the code attempts to pad the remainder of the destination buffer with m_dataRet.

Due to a missing transferSize-- operation within the while loop, the dest pointer continues to increment indefinitely (or until a segmentation fault occurs), causing a heap buffer overflow.

This fix resolves the crash observed when running the original Japanese version of Planet Laika, which triggers this specific DMA padding scenario.