### PR TITLE
Add --webserver and --webserver-port CLI flags

### DIFF
--- a/src/main/main.cc
+++ b/src/main/main.cc
@@ -295,6 +295,17 @@ int pcsxMain(int argc, char **argv) {
             debugSettings.get<PCSX::Emulator::DebugSettings::GdbServerPort>() = args.get<int>("gdb-port").value();
         }
 
+        if (args.get<bool>("webserver")) {
+            debugSettings.get<PCSX::Emulator::DebugSettings::WebServer>() = true;
+        }
+        if (args.get<bool>("no-webserver")) {
+            debugSettings.get<PCSX::Emulator::DebugSettings::WebServer>() = false;
+        }
+
+        if (args.get<int>("webserver-port")) {
+            debugSettings.get<PCSX::Emulator::DebugSettings::WebServerPort>() = args.get<int>("webserver-port").value();
+        }
+
         auto argPCdrvBase = args.get<std::string>("pcdrvbase");
         if (args.get<bool>("pcdrv")) {
             debugSettings.get<PCSX::Emulator::DebugSettings::PCdrv>() = true;


### PR DESCRIPTION
Follows the same pattern as --gdb/--gdb-port. Enables the REST API web server from the command line, which is useful for headless/CLI mode where the GUI settings aren't loaded (--cli implies --safe).