### PR TITLE
binlua: Expose PCSX.Misc.uclUnpack for NRV2E decompression.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ SRCS_pkg_md4c += third_party/md4c/src/md4c.c
 SRCS_lib_multipart += third_party/multipart-parser-c/multipart_parser.c
 SRCS += third_party/nanovg/src/nanovg.c
 SRCS_ReleaseWithTracy += third_party/tracy/public/TracyClient.cpp
-SRCS_lib_ucl += third_party/ucl/src/n2e_99.c third_party/ucl/src/alloc.c
+SRCS_lib_ucl += third_party/ucl/src/n2e_99.c third_party/ucl/src/alloc.c third_party/ucl/src/n2e_ds.c
 SRCS += $(wildcard third_party/uriparser/src/*.c)
 SRCS += third_party/zep/extensions/repl/mode_repl.cpp
 SRCS += $(wildcard third_party/zep/src/*.cpp)
@@ -171,7 +171,7 @@ endif
 SUPPORT_SRCS := src/support/container-file.cc src/support/file.cc src/support/mem4g.cc src/support/zfile.cc
 SUPPORT_SRCS += src/supportpsx/adpcm.cc src/supportpsx/binloader.cc src/supportpsx/iec-60908b.cc src/supportpsx/iso9660-builder.cc src/supportpsx/ps1-packer.cc
 SUPPORT_SRCS += third_party/fmt/src/os.cc third_party/fmt/src/format.cc
-SUPPORT_SRCS += third_party/ucl/src/n2e_99.c third_party/ucl/src/alloc.c
+SUPPORT_SRCS += third_party/ucl/src/n2e_99.c third_party/ucl/src/alloc.c third_party/ucl/src/n2e_ds.c
 SUPPORT_SRCS += $(wildcard third_party/iec-60908b/*.c)
 LIBS := third_party/luajit/src/libluajit.a
 

--- a/src/supportpsx/binffi.lua
+++ b/src/supportpsx/binffi.lua
@@ -49,6 +49,7 @@ bool binaryLoaderLoad(LuaFile* src, LuaFile* dest, struct BinaryLoaderInfo* info
 void ps1PackerPack(LuaFile* src, LuaFile* dest, uint32_t addr, uint32_t pc, uint32_t gp, uint32_t sp,
           struct PS1PackerOptions options);
 uint32_t uclWrapper(const uint8_t* in, uint32_t size, uint8_t* out);
+uint32_t uclUnpackWrapper(const uint8_t* in, uint32_t inSize, uint8_t* out, uint32_t expectedOutSize);
 uint32_t writeUclDecomp(LuaFile* dest);
 
 ]]
@@ -208,6 +209,74 @@ end
 PCSX.Misc.writeUclDecomp = function(dest)
     if type(dest) ~= 'table' or dest._type ~= 'File' then error('Expected a File object as first argument') end
     return C.writeUclDecomp(dest._wrapper)
+end
+
+-- Decompress an NRV2E-compressed payload. `decompressedSize` is the known final size
+-- and must be supplied; the caller almost always has it from a container header.
+-- `src` accepts File / string / LuaBuffer / Slice (same shapes as uclPack); `dest` is
+-- optional and accepts File / LuaBuffer / Slice. If omitted, a fresh Slice is created
+-- and returned; otherwise the destination is filled and the byte count is returned.
+PCSX.Misc.uclUnpack = function(src, decompressedSize, dest)
+    if type(decompressedSize) ~= 'number' then
+        error('Expected the decompressed size as the second argument')
+    end
+
+    local srcPtr
+    local srcSize
+    if type(src) == 'table' and src._type == 'File' then
+        src = src:read(src:size())
+        srcPtr = ffi.cast('uint8_t*', src.data)
+        srcSize = src.size
+    elseif type(src) == 'string' then
+        srcPtr = ffi.cast('uint8_t*', src)
+        srcSize = #src
+    elseif Support.isLuaBuffer(src) then
+        srcPtr = ffi.cast('uint8_t*', src.data)
+        srcSize = src.size
+    elseif type(src) == 'table' and src._type == 'Slice' then
+        srcPtr = src.data
+        srcSize = src.size
+    else
+        error('Expected a File object, string, LuaBuffer, or Slice as first argument')
+    end
+
+    local retIsDest = false
+    local destPtr
+    local destSlice
+    if not dest then
+        dest = Support.File.createEmptySlice()
+        dest:resize(decompressedSize)
+        destPtr = dest.mutable
+        retIsDest = true
+    elseif type(dest) == 'table' and dest._type == 'File' then
+        destSlice = Support.File.createEmptySlice()
+        destSlice:resize(decompressedSize)
+        destPtr = destSlice.mutable
+    elseif Support.isLuaBuffer(dest) then
+        dest:resize(decompressedSize)
+        destPtr = ffi.cast('uint8_t*', dest.data)
+    elseif type(dest) == 'table' and dest._type == 'Slice' then
+        dest:resize(decompressedSize)
+        destPtr = dest.mutable
+    else
+        error('Expected a File object, LuaBuffer, or Slice as third argument')
+    end
+
+    local outSize = C.uclUnpackWrapper(srcPtr, srcSize, destPtr, decompressedSize)
+
+    if outSize == 0 then
+        error('UCL decompression failed (bad data or wrong expected size).')
+    end
+    if outSize ~= decompressedSize then
+        error(string.format(
+            'UCL decompression produced %d bytes but %d were expected.', outSize, decompressedSize))
+    end
+
+    if type(dest) == 'table' and dest._type == 'File' then
+        dest:writeMoveSlice(destSlice)
+    end
+
+    return retIsDest and dest or outSize
 end
 
 -- )EOF"

--- a/src/supportpsx/binlua.cc
+++ b/src/supportpsx/binlua.cc
@@ -86,6 +86,17 @@ uint32_t uclWrapper(const uint8_t* in, uint32_t size, uint8_t* out) {
     return r == UCL_E_OK ? outSize : 0;
 }
 
+// Decompress an NRV2E-compressed payload into a caller-allocated buffer of capacity
+// expectedOutSize. The decompressor is the bounds-checked "safe" variant so corrupted
+// input produces an error return rather than a buffer overrun. Returns the actual
+// number of bytes written on success, or 0 on any failure (UCL error or size mismatch).
+uint32_t uclUnpackWrapper(const uint8_t* in, uint32_t inSize, uint8_t* out, uint32_t expectedOutSize) {
+    ucl_uint outSize = expectedOutSize;
+    auto r = ucl_nrv2e_decompress_safe_8(in, inSize, out, &outSize, nullptr);
+    if (r != UCL_E_OK) return 0;
+    return outSize;
+}
+
 #define REGISTER(L, s) registerSymbol(L, #s, s)
 
 void registerAllSymbols(PCSX::Lua L) {
@@ -95,6 +106,7 @@ void registerAllSymbols(PCSX::Lua L) {
     REGISTER(L, binaryLoaderLoad);
     REGISTER(L, ps1PackerPack);
     REGISTER(L, uclWrapper);
+    REGISTER(L, uclUnpackWrapper);
     REGISTER(L, writeUclDecomp);
     L.settable();
     L.pop();

--- a/vsprojects/supportpsx/supportpsx.vcxproj
+++ b/vsprojects/supportpsx/supportpsx.vcxproj
@@ -154,6 +154,7 @@
     <ClCompile Include="..\..\third_party\iec-60908b\tables.c" />
     <ClCompile Include="..\..\third_party\ucl\src\alloc.c" />
     <ClCompile Include="..\..\third_party\ucl\src\n2e_99.c" />
+    <ClCompile Include="..\..\third_party\ucl\src\n2e_ds.c" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\src\supportpsx\adpcmffi.lua" />

--- a/vsprojects/supportpsx/supportpsx.vcxproj.filters
+++ b/vsprojects/supportpsx/supportpsx.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClCompile Include="..\..\third_party\ucl\src\n2e_99.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\third_party\ucl\src\n2e_ds.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\supportpsx\ps1-packer.cc">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
Mirror of PCSX.Misc.uclPack on the read side. Calls ucl_nrv2e_decompress_safe_8 so corrupt or truncated input errors out cleanly instead of overrunning the output buffer. Decompressed size is a required argument since callers (SLZ-family chunk readers, archive containers) always have it from a header. Same input/output shape conventions as uclPack: File / string / LuaBuffer / Slice in, File / LuaBuffer / Slice out (or nil for a fresh Slice return).

Adds third_party/ucl/src/n2e_ds.c to the build for the safe-variant entry points.