### PR TITLE
Update COMPATIBILITY.md - Merge Libretro cores Beetle PSX, Beetle PSX…

### DIFF
--- a/src/mips/openbios/COMPATIBILITY.md
+++ b/src/mips/openbios/COMPATIBILITY.md
@@ -3,13 +3,15 @@
 ## Emulators shipping with OpenBIOS
 * PCSX-Redux
 
+Libretro cores:
+* Beetle PSX
+* Beetle PSX HW
+* SwanStation
+
 ## Other emulators compatible with OpenBIOS
 
-RetroArch libretro cores:
-* Beetle PSX HW
-* Beetle PSX
+Libretro cores:
 * PCSX ReARMed
-* SwanStation
 
 # Incompatible games
 * [Azure Dreams (NTSC)](https://github.com/grumpycoders/pcsx-redux/issues/1249)


### PR DESCRIPTION
… HW, and SwanStation under the section "Emulators shipping with OpenBIOS"

Beetle PSX, Beetle PSX HW:
* https://github.com/libretro/beetle-psx-libretro/issues/939

SwanStation:
* https://github.com/libretro/swanstation/issues/153