### PR TITLE
Deterministic test termination via an exit break, with exit-code readback

### DIFF
--- a/src/mips/tests/uC-sdk-glue/BoardInit.c
+++ b/src/mips/tests/uC-sdk-glue/BoardInit.c
@@ -33,12 +33,26 @@ void BoardInit() {}
 
 void BoardLateInit() {}
 
+// Trap into the resident debugger with the exit code in $a0 via break
+// category 4. Categories 0/6/7/14 are taken (pcdrv / compiler overflow /
+// compiler divide-by-zero / psyqo), so 4 is free. On hardware this halts
+// the program (Unirom reports HLTD) and leaves the exit code readable in
+// $a0, giving the host a deterministic end-of-binary signal instead of a
+// printed sentinel string. On the emulator pcsx_exit() has already exited,
+// so this is never reached there.
+static inline void exitBreak(int code) {
+    register int a0 asm("$4") = code;
+    __asm__ volatile("break 4, 0\n" : : "r"(a0) : "memory");
+}
+
 void BoardShutdown() {
     pcsx_exit(0);
+    exitBreak(0);
     syscall__exit(0);
 }
 
 void BoardExceptionHandler(int code) {
     pcsx_exit(code);
+    exitBreak(code);
     syscall__exit(code);
 }

--- a/tools/serial-tools/psxup.py
+++ b/tools/serial-tools/psxup.py
@@ -98,16 +98,16 @@ def p32(v):
 
 
 def enable_debug_mode(ser):
-    """Send "DEBG" so Unirom installs its kdebug handler. That handler is what
-    catches the binary's `break 0,0x10x` and bridges PCDRV over SIO1; without
-    it the break is never serviced and the PS1 hangs at the first file op.
+    """Send "DEBG" so Unirom installs its kdebug handler. That handler catches
+    every `break`: it bridges PCDRV's `break 0,0x10x` over SIO1, and it halts
+    (HLTD) on the runtime's exit break so the host can detect end-of-binary.
     Unirom echoes the command byte-by-byte, then responds OKAY."""
-    log("[*] Enabling Unirom debug mode (DEBG) for PCDRV...")
+    log("[*] Enabling Unirom debug mode (DEBG)...")
     ser.write(b'DEBG')
     ser.flush()
     tok, pre, _ = read_until_token(ser, [b'OKAY'], timeout=5)
     if tok != b'OKAY':
-        log(f"[!] DEBG: no OKAY (got {pre!r}); PCDRV will not work.")
+        log(f"[!] DEBG: no OKAY (got {pre!r}); kdebug not armed.")
         return False
     log("[*] Debug mode enabled.")
     return True
@@ -326,8 +326,9 @@ def handle_pcdrv_op(ser, reader, pcdrv):
 
 
 def serve_output(ser, reader, pcdrv=None, idle_timeout=30):
-    """Stream TTY output to stdout, servicing PCDRV ops inline. Ends after
-    idle_timeout seconds of silence or on a recognized done marker."""
+    """Stream TTY output to stdout, servicing PCDRV ops inline. Ends on Unirom's
+    HLTD halt token (the program trapping into the debugger, e.g. the exit break)
+    or after idle_timeout seconds of silence."""
     output = bytearray()
     pending_zero = False
     last = time.time()
@@ -354,7 +355,12 @@ def serve_output(ser, reader, pcdrv=None, idle_timeout=30):
         output += b
         sys.stdout.buffer.write(b)
         sys.stdout.buffer.flush()
-        if b'=== Done ===' in output[-16:] or b'Synthesis:' in output[-16:]:
+        # HLTD is Unirom's halt token, emitted whenever a program traps into the
+        # debugger via break - including the deliberate exit break the test
+        # runtime fires on shutdown. It's a protocol-level signal independent of
+        # program output, so it's the only end-of-binary marker we rely on; tests
+        # route their exit through the break rather than printing a sentinel.
+        if b'HLTD' in output[-16:]:
             time.sleep(0.5)
             tail = ser.read(ser.in_waiting or 0)
             if tail:
@@ -383,11 +389,12 @@ def upload_exe(port, filepath, baud=115200, pcdrv_base=None):
     # Drain any pending boot output
     drain(ser, quiet_seconds=2.0)
 
-    # Arm Unirom's kdebug handler before upload so the binary's PCDRV breaks
-    # get bridged over serial.
-    if pcdrv_base is not None:
-        enable_debug_mode(ser)
-        drain(ser, quiet_seconds=0.5)
+    # Always arm Unirom's kdebug handler before upload. It bridges PCDRV ops
+    # over serial when those are in use, and regardless of PCDRV it's what
+    # catches the runtime's exit break and halts (HLTD) - the deterministic
+    # end-of-binary signal serve_output waits on. Harmless to arm when unused.
+    enable_debug_mode(ser)
+    drain(ser, quiet_seconds=0.5)
 
     # === Handshake phase ===
     log("[*] Sending SEXE...")

--- a/tools/serial-tools/psxup.py
+++ b/tools/serial-tools/psxup.py
@@ -325,12 +325,61 @@ def handle_pcdrv_op(ser, reader, pcdrv):
         ser.flush()
 
 
+KD_TCB_PTR_ADDR = 0x80000110   # kernel holds the current TCB pointer here
+KD_A0_TCB_OFFSET = 0x18        # in the TCB: status, badv, then GPRs r0,at,v0,v1,a0,...; a0 is GPR4
+
+
+def _wait_token(reader, expected, timeout=2):
+    """Read from reader until the trailing bytes match the `expected` token,
+    skipping echo/noise. Unirom echoes command bytes back before it responds,
+    so a plain read would see the echo first."""
+    window = bytearray()
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        b = reader.read1(max(0.0, deadline - time.time()))
+        if b is None:
+            continue
+        window += b
+        del window[:-len(expected)]
+        if bytes(window) == expected:
+            return
+    raise IOError(f'kdebug: expected {expected!r}, got {bytes(window)!r}')
+
+
+def kd_dump(ser, reader, addr, size, timeout=2):
+    """Read `size` bytes at `addr` via Unirom's kdebug DUMP command while the
+    program is halted. Wire (u32s little-endian): DUMP -> OKV2 -> [host UPV2] ->
+    OKAY -> [host addr, size] -> size data bytes + a 4-byte sum checksum."""
+    ser.write(b'DUMP')
+    ser.flush()
+    _wait_token(reader, b'OKV2', timeout)
+    ser.write(b'UPV2')
+    ser.flush()
+    _wait_token(reader, b'OKAY', timeout)
+    ser.write(struct.pack('<II', addr, size))
+    ser.flush()
+    data = reader.read_exact(size, timeout)
+    checksum = reader.read_u32(timeout)
+    if (sum(data) & 0xFFFFFFFF) != checksum:
+        log(f"[!] DUMP@0x{addr:08x}: checksum {checksum:#010x} != "
+            f"{sum(data) & 0xFFFFFFFF:#010x} (continuing)")
+    return data
+
+
+def read_exit_code(ser, reader):
+    """Recover the program's exit code from $a0 of the halted thread, right after
+    HLTD. The TCB pointer lives at 0x80000110; $a0 sits at TCB+0x18."""
+    tcb_ptr = struct.unpack('<I', kd_dump(ser, reader, KD_TCB_PTR_ADDR, 4))[0]
+    return struct.unpack('<I', kd_dump(ser, reader, tcb_ptr + KD_A0_TCB_OFFSET, 4))[0]
+
+
 def serve_output(ser, reader, pcdrv=None, idle_timeout=30):
     """Stream TTY output to stdout, servicing PCDRV ops inline. Ends on Unirom's
     HLTD halt token (the program trapping into the debugger, e.g. the exit break)
     or after idle_timeout seconds of silence."""
     output = bytearray()
     pending_zero = False
+    exit_code = None
     last = time.time()
     while time.time() - last < idle_timeout:
         b = reader.read1(timeout=0.2)
@@ -361,12 +410,20 @@ def serve_output(ser, reader, pcdrv=None, idle_timeout=30):
         # program output, so it's the only end-of-binary marker we rely on; tests
         # route their exit through the break rather than printing a sentinel.
         if b'HLTD' in output[-16:]:
-            time.sleep(0.5)
-            tail = ser.read(ser.in_waiting or 0)
-            if tail:
-                sys.stdout.buffer.write(tail.replace(b'\x00', b''))
-                sys.stdout.buffer.flush()
+            # Halted into the debugger via the exit break: the program has
+            # exited, so read its exit code out of $a0 from the halted TCB. We
+            # don't resume - KDCont doesn't step past the break - so we leave it
+            # halted and stop.
+            sys.stdout.buffer.write(b'\n')
+            sys.stdout.buffer.flush()
+            try:
+                exit_code = read_exit_code(ser, reader)
+                log(f"[*] Halted at exit break; program exit code = {exit_code}")
+            except Exception as e:
+                log(f"[!] HLTD but couldn't read exit code: {e}")
             break
+
+    return exit_code
 
 
 def upload_exe(port, filepath, baud=115200, pcdrv_base=None):
@@ -496,10 +553,10 @@ def upload_exe(port, filepath, baud=115200, pcdrv_base=None):
         pcdrv = PCDrv(pcdrv_base)
         log(f"[*] PCDRV enabled, base dir: {pcdrv.base}")
     reader = SerialReader(ser, prime=early_output)
-    serve_output(ser, reader, pcdrv=pcdrv)
+    exit_code = serve_output(ser, reader, pcdrv=pcdrv)
 
     ser.close()
-    return True
+    return exit_code
 
 
 def main():
@@ -510,8 +567,12 @@ def main():
     ap.add_argument('--pcdrv-base', metavar='DIR',
                     help='serve PCDRV file ops out of DIR (enables PCDRV)')
     args = ap.parse_args()
-    ok = upload_exe(args.port, args.file, baud=args.baud, pcdrv_base=args.pcdrv_base)
-    sys.exit(0 if ok else 1)
+    result = upload_exe(args.port, args.file, baud=args.baud, pcdrv_base=args.pcdrv_base)
+    if result is False:
+        sys.exit(1)            # upload / setup failed
+    if result is None:
+        sys.exit(0)            # ran but no exit code captured (idle timeout)
+    sys.exit(result & 0xFF)    # propagate the PS1 program's exit code (from $a0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
psxup decides a binary is finished by string-matching its stdout (cester's `Synthesis:`, or a printed `=== Done ===`). That's fragile: it's framework-specific, false-positives on any program that prints those strings, and can't tell a clean finish from a crash.

This builds the signal on Unirom's debugger instead. The test runtime traps into kdebug on shutdown with a `break` in category 4 (0, 6, 7 and 14 are already taken by pcdrv, overflow, divide-by-zero and psyqo), leaving the exit code in `$a0`. psxup arms kdebug on every run now, catches the halt (`HLTD`), and reads `$a0` back out of the halted thread's TCB - there's no register-dump command, so it's two DUMP reads: the TCB pointer at `0x80000110`, then `$a0` at `TCB+0x18` - and propagates it as its own exit status.

The stdout terminators are dropped in favour of the halt. The two tests that print `=== Done ===` (`2mb-vram`, `regwrites`) will move to the exit break in a follow-up.

Tested on hardware (SCPH-5501): a clean exit and a `return 42` both halt and read back the right code.
