### PR TITLE
ucl: measure the in-place decompression overlap instead of assuming 16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ ifeq ($(CROSS),arm64)
         CPPFLAGS += -Ithird_party/vixl/src -Ithird_party/vixl/src/aarch64
 endif
 SUPPORT_SRCS := src/support/container-file.cc src/support/file.cc src/support/mem4g.cc src/support/zfile.cc
-SUPPORT_SRCS += src/supportpsx/adpcm.cc src/supportpsx/binloader.cc src/supportpsx/iec-60908b.cc src/supportpsx/iso9660-builder.cc src/supportpsx/ps1-packer.cc
+SUPPORT_SRCS += src/supportpsx/adpcm.cc src/supportpsx/binloader.cc src/supportpsx/iec-60908b.cc src/supportpsx/iso9660-builder.cc src/supportpsx/ps1-packer.cc src/supportpsx/ucl-utils.cc
 SUPPORT_SRCS += third_party/fmt/src/os.cc third_party/fmt/src/format.cc
 SUPPORT_SRCS += third_party/ucl/src/n2e_99.c third_party/ucl/src/alloc.c third_party/ucl/src/n2e_ds.c
 SUPPORT_SRCS += $(wildcard third_party/iec-60908b/*.c)

--- a/src/mips/psyqo-paths/archive-manager.hh
+++ b/src/mips/psyqo-paths/archive-manager.hh
@@ -231,7 +231,18 @@ class ArchiveManager {
      *
      * @return uint32_t The number of entries in the index.
      */
-    uint32_t getIndexCount() const { return m_index[0].asArray[2]; }
+    uint32_t getIndexCount() const { return m_index[0].asArray[2] & 0xffffff; }
+
+    /**
+     * @brief Get the safe margin length for decompression.
+     *
+     * @details This function returns the safe margin length for decompression.
+     * Calling this function before the archive manager is initialized
+     * successfully is undefined behavior.
+     *
+     * @return uint32_t The safe margin length for decompression.
+     */
+    uint32_t getSafeMarginLength() const { return ((m_index[0].asArray[2] >> 24) + 1) * 16; }
 
     /**
      * @brief Get the IndexEntry object for a given path.

--- a/src/mips/psyqo-paths/src/archive-manager.cpp
+++ b/src/mips/psyqo-paths/src/archive-manager.cpp
@@ -130,7 +130,7 @@ void psyqo::paths::ArchiveManager::setupQueue(const IndexEntry* entry, CDRom& de
         m_data.resize(sectorCount * 2048);
         m_request.buffer = m_data.data();
     } else {
-        uint32_t actualSize = eastl::max<uint32_t>(((decompSize + 3) & ~3) + 16, sectorCount * 2048);
+        uint32_t actualSize = eastl::max<uint32_t>(((decompSize + 3) & ~3) + getSafeMarginLength(), sectorCount * 2048);
         m_data.resize(actualSize);
         m_request.buffer = m_data.data() + actualSize - sectorCount * 2048;
     }

--- a/src/mips/psyqo-paths/tools/mkarchive.lua
+++ b/src/mips/psyqo-paths/tools/mkarchive.lua
@@ -57,7 +57,8 @@ The index is a header, and a list of files.
 
 The archive header format is as follows:
 - 8 bytes: "PSX-ARC1" (ASCII) - This is the magic number for the archive
-- 4 bytes: number of files in the archive (32-bit unsigned integer)
+- 3 bytes: number of files in the archive (24-bit unsigned integer)
+- 1 byte: decompression margin in 16-bytes blocks + 1 (8-bit unsigned integer) - This is the number of 16-byte blocks that the decompressor will read past the end of the compressed data, to ensure that it has enough data to decompress the last block. This is only relevant for the UCL-NRV2E compression method, and is ignored for other methods.
 - 4 bytes: total size of the archive (in sectors, 32-bit unsigned integer)
 
 Then, there are the file entries, one for each file in the archive. Each entry is
@@ -298,6 +299,8 @@ function mkarchive(index, out)
 
     out:wSeek(indexSectors * 2048)
 
+    local maxMargin = 0
+
     for k, v in ipairs(index) do
         print('Packing', v.path)
         local path = v.path
@@ -307,6 +310,10 @@ function mkarchive(index, out)
         index[k].offset = out:wTell() / 2048
         local srcData = file:readToSlice(file:size())
         local compressedData = PCSX.Misc.uclPack(srcData)
+        local margin = PCSX.Misc.uclGetOverlapMargin(compressedData, file:size())
+        if margin > maxMargin then
+            maxMargin = margin
+        end
         local compressedSize = #compressedData
         local compressedSectors = math.ceil((compressedSize + 2047) / 2048)
         local decompressedSectors = math.ceil((index[k].decompressedSize + 2047) / 2048)
@@ -341,7 +348,9 @@ function mkarchive(index, out)
 
     out:wSeek(0)
     out:write('PSX-ARC1')
-    out:writeU32(fileCount)
+    local margin = math.floor(maxMargin / 16)
+    local field = bit.bor(bit.band(fileCount, 0xffffff), bit.lshift(margin, 24))
+    out:writeU32(field)
     out:writeU32(totalSize)
 
     table.sort(index, function(a, b)

--- a/src/supportpsx/binffi.lua
+++ b/src/supportpsx/binffi.lua
@@ -50,6 +50,7 @@ void ps1PackerPack(LuaFile* src, LuaFile* dest, uint32_t addr, uint32_t pc, uint
           struct PS1PackerOptions options);
 uint32_t uclWrapper(const uint8_t* in, uint32_t size, uint8_t* out);
 uint32_t uclUnpackWrapper(const uint8_t* in, uint32_t inSize, uint8_t* out, uint32_t expectedOutSize);
+uint32_t uclGetOverlapMargin(const uint8_t* src, size_t srcLen, size_t expectedDstLen);
 uint32_t writeUclDecomp(LuaFile* dest);
 
 ]]
@@ -277,6 +278,38 @@ PCSX.Misc.uclUnpack = function(src, decompressedSize, dest)
     end
 
     return retIsDest and dest or outSize
+end
+
+-- Returns the number of bytes of overlap that UCL may read past the end of a compressed buffer.
+-- This is used to determine how much extra space to allocate when decompressing a buffer in-place.
+-- The `src` argument is the compressed buffer (File / string / LuaBuffer / Slice),
+-- and `decompressedSize` is the known final size of the decompressed data.
+-- The return value is the number of bytes of overlap.
+PCSX.Misc.uclGetOverlapMargin = function(src, decompressedSize)
+    if type(decompressedSize) ~= 'number' then
+        error('Expected the decompressed size as the second argument')
+    end
+
+    local srcPtr
+    local srcSize
+    if type(src) == 'table' and src._type == 'File' then
+        src = src:read(src:size())
+        srcPtr = ffi.cast('uint8_t*', src.data)
+        srcSize = src.size
+    elseif type(src) == 'string' then
+        srcPtr = ffi.cast('uint8_t*', src)
+        srcSize = #src
+    elseif Support.isLuaBuffer(src) then
+        srcPtr = ffi.cast('uint8_t*', src.data)
+        srcSize = src.size
+    elseif type(src) == 'table' and src._type == 'Slice' then
+        srcPtr = src.data
+        srcSize = src.size
+    else
+        error('Expected a File object, string, LuaBuffer, or Slice as first argument')
+    end
+
+    return C.uclGetOverlapMargin(srcPtr, srcSize, decompressedSize)
 end
 
 -- )EOF"

--- a/src/supportpsx/binlua.cc
+++ b/src/supportpsx/binlua.cc
@@ -35,6 +35,7 @@ SOFTWARE.
 #include "supportpsx/binloader.h"
 #include "supportpsx/n2e-d.h"
 #include "supportpsx/ps1-packer.h"
+#include "supportpsx/ucl-utils.h"
 #include "ucl/ucl.h"
 
 namespace {
@@ -86,6 +87,12 @@ uint32_t uclWrapper(const uint8_t* in, uint32_t size, uint8_t* out) {
     return r == UCL_E_OK ? outSize : 0;
 }
 
+uint32_t uclGetOverlapMargin(const uint8_t* src, size_t srcLen, size_t expectedDstLen) {
+    auto margin = PCSX::UCLUtils::inPlaceOverlapMargin(src, srcLen, expectedDstLen);
+    ssize_t relMargin = margin - srcLen + expectedDstLen;
+    return std::clamp<uint32_t>(relMargin, 0L, static_cast<long>(std::numeric_limits<uint32_t>::max()));
+}
+
 // Decompress an NRV2E-compressed payload into a caller-allocated buffer of capacity
 // expectedOutSize. The decompressor is the bounds-checked "safe" variant so corrupted
 // input produces an error return rather than a buffer overrun. Returns the actual
@@ -107,6 +114,7 @@ void registerAllSymbols(PCSX::Lua L) {
     REGISTER(L, ps1PackerPack);
     REGISTER(L, uclWrapper);
     REGISTER(L, uclUnpackWrapper);
+    REGISTER(L, uclGetOverlapMargin);
     REGISTER(L, writeUclDecomp);
     L.settable();
     L.pop();

--- a/src/supportpsx/ps1-packer.cc
+++ b/src/supportpsx/ps1-packer.cc
@@ -35,6 +35,7 @@ SOFTWARE.
 #include "mips/common/util/encoder.hh"
 #include "n2e-d.h"
 #include "support/polyfills.h"
+#include "supportpsx/ucl-utils.h"
 #include "ucl/ucl.h"
 
 using namespace Mips::Encoder;
@@ -113,12 +114,17 @@ void PCSX::PS1Packer::pack(IO<File> src, IO<File> dest, uint32_t addr, uint32_t 
         newPC = tload + dataOut.size();
         compLoad = tload;
     } else if (!options.raw) {
-        // If we don't have a tload, it means we're doing
-        // in-place decompression. We need to make sure
-        // we have enough space to decompress our binary
-        // in-place, and ucl-nrv2e requires 16 bytes to
-        // ensure this property.
-        newPC = addr + dataIn.size() + 16;
+        // If we don't have a tload, it means we're doing in-place
+        // decompression. The compressed data has to sit far enough above the
+        // decompression target `addr` that the decompressor's write head never
+        // overtakes its read head. That distance is data-dependent, not a
+        // constant, so measure it exactly for this stream. (It used to be a
+        // hardcoded 16, which silently corrupts any payload whose worst-case
+        // match lands late enough to need more.)
+        size_t margin = UCLUtils::inPlaceOverlapMargin(dataOut.data(), outSize, dataIn.size());
+        size_t relMargin = margin - dataIn.size() + outSize;
+        relMargin = (relMargin + 3) & ~3;
+        newPC = addr + dataIn.size() + relMargin;
         compLoad = newPC - dataOut.size();
         uint32_t rawCompLoad = compLoad & 0x1fffffff;
         if (rawCompLoad < 0x10000) {

--- a/src/supportpsx/ucl-utils.cc
+++ b/src/supportpsx/ucl-utils.cc
@@ -1,0 +1,145 @@
+/*
+
+MIT License
+
+Copyright (c) 2026 PCSX-Redux authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+// Computes the exact overlap margin required to safely decompress an NRV2E
+// stream over itself, as produced by ucl_nrv2e_99_compress and consumed by the
+// MIPS unpacker in n2e-d.S / n2e-d.h.
+//
+// In-place decompression only works if the compressed data sits far enough
+// "above" the decompression target that the decompressor's write head (olen)
+// never overtakes its read head (ilen). ps1-packer historically assumed a fixed
+// 16-byte gap past the end of the decompressed image; that is a data-dependent
+// quantity, not a constant, and a stream whose worst-case match lands late
+// enough will silently corrupt on decompression.
+//
+// This walks the real bitstream exactly as the decompressor would -- the same
+// token grammar as third_party/ucl/src/n2e_d.c and the same byte-consumption
+// cadence as the _8 bit-buffer (which n2e-d.S's getbit reproduces) -- but writes
+// nothing, and instead records the largest value of (olen - ilen) seen across
+// the whole stream. That maximum is precisely the smallest src_off for which an
+// overlapping decode from &buf[src_off] -> &buf[0] is safe: i.e. the value
+// ucl_nrv2e_test_overlap_8 would accept, minimized in a single pass.
+//
+// Keep this in sync with the NRV2E grammar in n2e_d.c and the getbit cadence in
+// n2e-d.S. It deliberately does not depend on the vendored ucl sources.
+
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+
+#include "supportpsx/ucl-utils.h"
+
+size_t PCSX::UCLUtils::inPlaceOverlapMargin(const uint8_t *src, size_t srcLen, size_t expectedDstLen) {
+    uint32_t bb = 0;
+    uint32_t last_m_off = 1;
+    size_t ilen = 0, olen = 0;
+    int64_t peak = 0;
+    bool overrun = false;
+
+    auto bad = []() -> void {
+        throw std::runtime_error("UCLUtils::inPlaceOverlapMargin: malformed NRV2E stream while measuring in-place overlap margin.");
+    };
+
+    // getbit_8-equivalent: MSB-first, one source byte per 8 bits, refill when the
+    // low-7 sentinel window clears. This matches n2e-d.S's getbit cadence exactly,
+    // so `ilen` tracks the real decompressor's source consumption.
+    auto getbit = [&]() -> uint32_t {
+        if ((bb & 0x7f) == 0) {
+            if (ilen >= srcLen) {
+                overrun = true;
+                return 0;
+            }
+            bb = static_cast<uint32_t>(src[ilen++]) * 2 + 1;
+        } else {
+            bb *= 2;
+        }
+        return (bb >> 8) & 1;
+    };
+    auto sample = [&]() {
+        int64_t diff = static_cast<int64_t>(olen) - static_cast<int64_t>(ilen);
+        if (diff > peak) peak = diff;
+    };
+
+    for (;;) {
+        uint32_t m_off, m_len;
+
+        // Literal run: read and write advance in lockstep, so the gap is
+        // unchanged here. The peak only ever lands on a match, but we sample
+        // anyway to mirror the decoder's check points and stay conservative.
+        while (getbit()) {
+            if (overrun || ilen >= srcLen || (expectedDstLen && olen >= expectedDstLen)) bad();
+            olen++;
+            ilen++;
+            sample();
+        }
+
+        // Match offset, NRV2E gamma-coded two bits at a time.
+        m_off = 1;
+        for (;;) {
+            m_off = m_off * 2 + getbit();
+            if (overrun || m_off > 0xffffffu + 3) bad();
+            if (getbit()) break;
+            m_off = (m_off - 1) * 2 + getbit();
+        }
+        if (m_off == 2) {
+            m_off = last_m_off;  // repeat last offset (the NRV2E rep-match)
+            m_len = getbit();
+        } else {
+            if (ilen >= srcLen) bad();
+            m_off = (m_off - 3) * 256 + src[ilen++];
+            if (m_off == 0xffffffffu) break;  // end-of-stream marker
+            m_len = (m_off ^ 0xffffffffu) & 1;
+            m_off >>= 1;
+            last_m_off = ++m_off;
+        }
+
+        // Match length, gamma-coded, plus the +1 for far offsets.
+        if (m_len) {
+            m_len = 1 + getbit();
+        } else if (getbit()) {
+            m_len = 3 + getbit();
+        } else {
+            m_len++;
+            do {
+                m_len = m_len * 2 + getbit();
+                if (overrun) bad();
+            } while (!getbit());
+            m_len += 3;
+        }
+        m_len += (m_off > 0x500);
+        if (overrun || m_off > olen) bad();
+
+        // Match copy: the write head leaps forward by m_len + 1 bytes while the
+        // read head stays put. This is the checkpoint where the overlap peaks.
+        olen += m_len + 1;
+        if (expectedDstLen && olen > expectedDstLen) bad();
+        sample();
+    }
+
+    if (overrun || (expectedDstLen && olen != expectedDstLen) || ilen != srcLen) bad();
+
+    return peak < 0 ? 0 : static_cast<size_t>(peak);
+}

--- a/src/supportpsx/ucl-utils.h
+++ b/src/supportpsx/ucl-utils.h
@@ -2,7 +2,7 @@
 
 MIT License
 
-Copyright (c) 2023 PCSX-Redux authors
+Copyright (c) 2026 PCSX-Redux authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -32,20 +32,14 @@ SOFTWARE.
 
 #include "support/file.h"
 
-namespace PCSX::PS1Packer {
+namespace PCSX::UCLUtils {
 
-struct Options {
-    uint32_t tload = 0;
-    bool shell = false;
-    bool nokernel = false;
-    bool resetstack = false;
-    bool nopad = false;
-    bool booty = false;
-    bool raw = false;
-    bool rom = false;
-    bool cpe = false;
-};
+// Returns the exact number of bytes the compressed NRV2E stream must sit above
+// the decompression target for safe in-place (overlapping) decompression, i.e.
+// the smallest src_off for which decoding &buf[src_off] -> &buf[0] never lets
+// the write head overtake the read head. `src`/`srcLen` is the compressed
+// stream; `expectedDstLen` is the uncompressed size. Throws std::runtime_error
+// on a malformed stream.
+size_t inPlaceOverlapMargin(const uint8_t* src, size_t srcLen, size_t expectedDstLen);
 
-void pack(IO<File> src, IO<File> dest, uint32_t addr, uint32_t pc, uint32_t gp, uint32_t sp, const Options&);
-
-}  // namespace PCSX::PS1Packer
+}  // namespace PCSX::UCLUtils

--- a/tests/supportpsx/ps1-packer-overlap.cc
+++ b/tests/supportpsx/ps1-packer-overlap.cc
@@ -1,0 +1,127 @@
+/***************************************************************************
+ *   Copyright (C) 2026 PCSX-Redux authors                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.           *
+ ***************************************************************************/
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "supportpsx/ucl-utils.h"
+#include "ucl/ucl.h"
+
+// The build only links the SAFE decoder (n2e_ds.c renames the entry). It still
+// performs the real overlapping write, so it is the correct round-trip decoder.
+extern "C" int ucl_nrv2e_decompress_safe_8(const unsigned char* src, ucl_uint src_len, unsigned char* dst,
+                                           ucl_uint* dst_len, void* wrkmem);
+
+namespace {
+
+std::vector<uint8_t> compress(const std::vector<uint8_t>& orig) {
+    std::vector<uint8_t> comp(orig.size() * 12 / 10 + 4096);
+    ucl_uint compLen = comp.size();
+    int r = ucl_nrv2e_99_compress(orig.data(), orig.size(), comp.data(), &compLen, nullptr, 10, nullptr, nullptr);
+    EXPECT_EQ(r, UCL_E_OK);
+    comp.resize(compLen);
+    return comp;
+}
+
+// Performs the real overlapping in-place decode: the compressed bytes live at
+// buf[srcOff..], the output is written to buf[0..]. Returns true iff the decode
+// reproduced `orig` exactly.
+bool overlapDecodeReproduces(const std::vector<uint8_t>& comp, const std::vector<uint8_t>& orig, size_t srcOff) {
+    std::vector<uint8_t> buf(orig.size() + srcOff + comp.size() + 64, 0);
+    std::copy(comp.begin(), comp.end(), buf.begin() + srcOff);
+    ucl_uint dstLen = orig.size();
+    int r = ucl_nrv2e_decompress_safe_8(buf.data() + srcOff, comp.size(), buf.data(), &dstLen, nullptr);
+    if (r != UCL_E_OK || dstLen != orig.size()) return false;
+    return std::equal(orig.begin(), orig.end(), buf.begin());
+}
+
+// The computed margin must reconstruct exactly, AND be tight: one byte closer
+// must corrupt. A loose (too-large) margin would be safe but is not what the
+// single-pass measurement should ever produce.
+void checkExactMargin(const std::vector<uint8_t>& orig) {
+    auto comp = compress(orig);
+    size_t margin = PCSX::UCLUtils::inPlaceOverlapMargin(comp.data(), comp.size(), orig.size());
+    EXPECT_TRUE(overlapDecodeReproduces(comp, orig, margin))
+        << "in-place decode at the computed margin did not reconstruct";
+    if (margin > 0) {
+        EXPECT_FALSE(overlapDecodeReproduces(comp, orig, margin - 1)) << "computed margin is not tight";
+    }
+}
+
+std::vector<uint8_t> pseudoRandom(size_t n, uint32_t seed) {
+    std::vector<uint8_t> v;
+    v.reserve(n);
+    uint32_t s = seed;
+    for (size_t i = 0; i < n; i++) {
+        s = s * 1103515245u + 12345u;
+        v.push_back(static_cast<uint8_t>(s >> 16));
+    }
+    return v;
+}
+
+}  // namespace
+
+TEST(PS1PackerOverlap, Compressible) {
+    std::vector<uint8_t> v;
+    for (int i = 0; i < 2000; i++) v.push_back(i & 1 ? 0xAA : 0x55);
+    for (int i = 0; i < 4000; i++) v.push_back(0x00);
+    checkExactMargin(v);
+}
+
+TEST(PS1PackerOverlap, PseudoRandom) { checkExactMargin(pseudoRandom(8192, 0x12345678)); }
+
+TEST(PS1PackerOverlap, MixedTail) {
+    auto v = pseudoRandom(4096, 0xC0FFEE11);
+    for (int i = 0; i < 16384; i++) v.push_back(0x42);
+    checkExactMargin(v);
+}
+
+TEST(PS1PackerOverlap, RepeatedText) {
+    std::vector<uint8_t> v;
+    const char* frag = "the quick brown fox jumps over the lazy dog. ";
+    for (int i = 0; i < 400; i++)
+        for (const char* p = frag; *p; p++) v.push_back(static_cast<uint8_t>(*p));
+    checkExactMargin(v);
+}
+
+TEST(PS1PackerOverlap, TinyRle) { checkExactMargin(std::vector<uint8_t>(37, 0x7F)); }
+
+TEST(PS1PackerOverlap, TinyLiteral) { checkExactMargin({'H', 'e', 'l', 'l', 'o'}); }
+
+// The regression this whole change exists for: a highly compressible head races
+// the decompressor's write head far ahead of its read head, so the required
+// margin lands well above the old hardcoded 16-byte gap. If the margin ever
+// silently reverts to a constant, this reconstruction fails.
+TEST(PS1PackerOverlap, CompressibleHeadDefeatsFixedGap) {
+    std::vector<uint8_t> v;
+    for (int i = 0; i < 20000; i++) v.push_back(0x00);
+    auto tail = pseudoRandom(12000, 0xBEEFCAFE);
+    v.insert(v.end(), tail.begin(), tail.end());
+
+    auto comp = compress(v);
+    size_t margin = PCSX::UCLUtils::inPlaceOverlapMargin(comp.data(), comp.size(), v.size());
+    size_t gain = v.size() > comp.size() ? v.size() - comp.size() : 0;
+    // The gap the old fixed constant had to cover is (margin - gain); this
+    // payload needs far more than 16, which is exactly why the constant was a bug.
+    EXPECT_GT(margin - gain, static_cast<size_t>(16));
+    EXPECT_TRUE(overlapDecodeReproduces(comp, v, margin));
+    EXPECT_FALSE(overlapDecodeReproduces(comp, v, margin - 1));
+}

--- a/tools/authoring/authoring.cc
+++ b/tools/authoring/authoring.cc
@@ -41,6 +41,7 @@
 #include "supportpsx/iso9660-builder.h"
 #include "supportpsx/iso9660-lowlevel.h"
 #include "supportpsx/ps1-packer.h"
+#include "supportpsx/ucl-utils.h"
 #include "ucl/ucl.h"
 
 template <PCSX::PolyFill::IntegralConcept T, std::endian endianess = std::endian::little>
@@ -230,6 +231,7 @@ Usage: {} input.json [-h] -o output.bin
 
     const unsigned executableSectorsCount = compressedExecutable->size() / 2048;
     unsigned currentSector = 23 + indexSectorsCount;
+    std::atomic<uint32_t> maxMargin;
 
     for (unsigned i = 0; i < executableSectorsCount; i++) {
         auto sector = compressedExecutable.asA<PCSX::BufferFile>()->borrow(i * 2048);
@@ -246,6 +248,7 @@ Usage: {} input.json [-h] -o output.bin
         std::binary_semaphore semaphore;
         std::vector<uint8_t> sectorData;
         nlohmann::json fileInfo;
+        uint32_t margin;
         bool failed;
     };
     static WorkUnit work[c_maximumSectorCount];
@@ -305,6 +308,16 @@ Usage: {} input.json [-h] -o output.bin
                     workUnit.semaphore.release();
                     continue;
                 }
+
+                ssize_t margin = PCSX::UCLUtils::inPlaceOverlapMargin(dataOut.data() + 2048, outSize, size);
+                ssize_t relMargin = margin - size + outSize;
+                workUnit.margin =
+                    std::clamp<uint32_t>(relMargin, 0L, static_cast<long>(std::numeric_limits<uint32_t>::max()));
+                do {
+                    auto oldOverlap = maxMargin.load();
+                    if (workUnit.margin <= oldOverlap) break;
+                    if (maxMargin.compare_exchange_weak(oldOverlap, workUnit.margin)) break;
+                } while (1);
 
                 unsigned compressedSectorsCount = (outSize + 2047) / 2048;
 
@@ -368,6 +381,7 @@ Usage: {} input.json [-h] -o output.bin
             fmt::print("  Compressed size: {}\n", entry->getCompressedSize() * 2048);
             fmt::print("  Compression method: {}\n", static_cast<uint32_t>(entry->getCompressionMethod()));
             fmt::print("  Sector offset: {}\n", currentSector);
+            fmt::print("  Margin: {}\n", workUnit.margin);
         }
         entry->setSectorOffset(currentSector);
         unsigned sectorCount = entry->getCompressedSize();
@@ -380,6 +394,7 @@ Usage: {} input.json [-h] -o output.bin
 
     if (!quiet) {
         fmt::print("Processed {} files.\n", filesCount);
+        fmt::print("Maximum margin: {}\n", maxMargin.load());
     }
 
     uint8_t empty[2048] = {0};
@@ -398,7 +413,9 @@ Usage: {} input.json [-h] -o output.bin
     indexEntryDataBuffer[5] = 'R';
     indexEntryDataBuffer[6] = 'C';
     indexEntryDataBuffer[7] = '1';
+    uint32_t maxMarginValue = maxMargin.load() >> 4;
     writeToBuffer(indexEntryDataBuffer.get() + 8, filesCount);
+    writeToBuffer<uint8_t>(indexEntryDataBuffer.get() + 11, maxMarginValue);
     writeToBuffer(indexEntryDataBuffer.get() + 12, totalSectorCount);
     std::sort(indexEntryData.begin(), indexEntryData.end(),
               [](const IndexEntry& a, const IndexEntry& b) { return a.hash < b.hash; });

--- a/vsprojects/supportpsx/supportpsx.vcxproj
+++ b/vsprojects/supportpsx/supportpsx.vcxproj
@@ -150,6 +150,7 @@
     <ClCompile Include="..\..\src\supportpsx\iso9660-builder.cc" />
     <ClCompile Include="..\..\src\supportpsx\ps1-packer.cc" />
     <ClCompile Include="..\..\src\supportpsx\ucl-glue.c" />
+    <ClCompile Include="..\..\src\supportpsx\ucl-utils.cc" />
     <ClCompile Include="..\..\third_party\iec-60908b\edcecc.c" />
     <ClCompile Include="..\..\third_party\iec-60908b\tables.c" />
     <ClCompile Include="..\..\third_party\ucl\src\alloc.c" />
@@ -181,6 +182,7 @@
     <ClInclude Include="..\..\src\supportpsx\iso9660-lowlevel.h" />
     <ClInclude Include="..\..\src\supportpsx\memory.h" />
     <ClInclude Include="..\..\src\supportpsx\ps1-packer.h" />
+    <ClInclude Include="..\..\src\supportpsx\ucl-utils.h" />
     <ClInclude Include="..\..\third_party\iec-60908b\edcecc.h" />
     <ClInclude Include="..\..\third_party\iec-60908b\tables.h" />
   </ItemGroup>

--- a/vsprojects/supportpsx/supportpsx.vcxproj.filters
+++ b/vsprojects/supportpsx/supportpsx.vcxproj.filters
@@ -60,6 +60,9 @@
     <ClCompile Include="..\..\src\supportpsx\iso9660-builder.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\supportpsx\ucl-utils.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\src\supportpsx\binffi.lua">
@@ -132,6 +135,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\supportpsx\iso9660-dirtree.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\supportpsx\ucl-utils.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/vsprojects/tests/support/testsupport.vcxproj
+++ b/vsprojects/tests/support/testsupport.vcxproj
@@ -78,6 +78,7 @@
     <Microsoft-googletest-v140-windesktop-msvcstl-static-rt-dyn-Disable-gtest_main>true</Microsoft-googletest-v140-windesktop-msvcstl-static-rt-dyn-Disable-gtest_main>
   </PropertyGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\tests\supportpsx\ps1-packer-overlap.cc" />
     <ClCompile Include="..\..\..\tests\support\binstruct.cc" />
     <ClCompile Include="..\..\..\tests\support\circular.cc" />
     <ClCompile Include="..\..\..\tests\support\gnu-c++-demangler.cc" />
@@ -91,6 +92,9 @@
     <ProjectReference Include="..\..\gtest\gtest.vcxproj">
       <Project>{432d6160-7127-4005-bfa6-7c301c0cf3d3}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\..\supportpsx\supportpsx.vcxproj">
+      <Project>{b2e2ad84-9d7f-4976-9572-e415819ffd7f}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\..\support\support.vcxproj">
       <Project>{0e621321-093c-4d60-bd8b-027fdc2b0f63}</Project>
     </ProjectReference>
@@ -101,7 +105,11 @@
       <Project>{dd5acb0a-e326-4ea9-b5a8-c23d66c27650}</Project>
     </ProjectReference>
   </ItemGroup>
-  <ItemDefinitionGroup />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseWithClangCL|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\third_party\ucl;$(SolutionDir)..\third_party\ucl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -113,6 +121,7 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <ProgramDataBaseFileName>$(IntDir)$(TargetName)-vc$(PlatformToolsetVersion).pdb</ProgramDataBaseFileName>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\third_party\ucl;$(SolutionDir)..\third_party\ucl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -127,6 +136,7 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <ProgramDataBaseFileName>$(IntDir)$(TargetName)-vc$(PlatformToolsetVersion).pdb</ProgramDataBaseFileName>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\third_party\ucl;$(SolutionDir)..\third_party\ucl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -143,6 +153,7 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <ProgramDataBaseFileName>$(IntDir)$(TargetName)-vc$(PlatformToolsetVersion).pdb</ProgramDataBaseFileName>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\third_party\ucl;$(SolutionDir)..\third_party\ucl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>


### PR DESCRIPTION
The in-place path placed the compressed payload a fixed 16 bytes past the end of the decompressed image. That gap is data-dependent, not a constant: the NRV2E decompressor's write head can race well ahead of its read head across a compressible region, and a payload whose worst-case match lands late enough overruns the gap and silently corrupts on decompression.

Compute the real number. inPlaceOverlapMargin walks the bitstream exactly as the unpacker does, writes nothing, and records the peak (olen - ilen); that maximum is the smallest offset at which an overlapping decode is safe, and the compressed load address is derived from it.

Includes a round-trip test, with a compressible-head payload that needs far more than 16 bytes and would have corrupted under the old constant.