### PR TITLE
OpenBIOS: Add ZN-2 support

### DIFF
--- a/src/mips/openbios/Makefile
+++ b/src/mips/openbios/Makefile
@@ -87,11 +87,21 @@ uC-sdk-glue/init.c \
 ../../../third_party/uC-sdk/os/src/osdebug.c \
 
 # Ensure all files are always cleaned up.
+CLEANSRCS = \
+boot/psx.s \
+boot/system573.s \
+boot/zn1.s \
+boot/zn2.s \
+\
+font1.o \
+font2.o \
+./psexe_data.o \
+
 ifeq ($(MAKECMDGOALS),clean)
-SRCS += boot/psx.s boot/system573.s boot/zn.s font1.o font2.o ./psexe_data.o
+SRCS += $(CLEANSRCS)
 endif
 ifeq ($(MAKECMDGOALS),deepclean)
-SRCS += boot/psx.s boot/system573.s boot/zn.s font1.o font2.o ./psexe_data.o
+SRCS += $(CLEANSRCS)
 endif
 
 CPPFLAGS =
@@ -102,8 +112,10 @@ BOOT = rom
 BOOT_MODE = psexe
 ifeq ($(BOARD),system573)
 CPPFLAGS += -DOPENBIOS_BOARD_SYS573
-else ifeq ($(BOARD),zn)
-CPPFLAGS += -DOPENBIOS_BOARD_ZN
+else ifeq ($(BOARD),zn1)
+CPPFLAGS += -DOPENBIOS_BOARD_ZN1
+else ifeq ($(BOARD),zn2)
+CPPFLAGS += -DOPENBIOS_BOARD_ZN2
 endif
 endif
 

--- a/src/mips/openbios/README.md
+++ b/src/mips/openbios/README.md
@@ -33,7 +33,7 @@ The Makefile features several toggles to mutate the way the compilation works. D
 - `BUILD=SmallDebug` will produce a working, yet somewhat debuggable version of the code.
 - `BOOT=cart` will build the kernel as an expansion port ROM, bootable from an Action Replay or similar cheat carts. This will disable support for booting from a cart in order to prevent bootlooping.
 - `BOARD=system573` will build a kernel that can run on the Konami System 573 arcade board. This option is only useful alongside `EMBED_PSEXE`, as it will force `BOOT=rom` and `BOOT_MODE=psexe`; as with Konami's BIOS, game booting is not implemented in the kernel and must be handled by a custom shell.
-- `BOARD=zn` will build a kernel that can run on the Sony ZN-1 arcade board (ZN-2 support is currently broken and needs further testing). This option is only useful alongside `EMBED_PSEXE`, as it will force `BOOT=rom` and `BOOT_MODE=psexe`; unlike the official ZN BIOSes, OpenBIOS does *not* implement game decryption and booting in the kernel.
+- `BOARD=zn1` or `BOARD=zn2` will build a kernel that can run on the Sony ZN-1 or ZN-2 arcade boards respectively. This option is only useful alongside `EMBED_PSEXE`, as it will force `BOOT=rom` and `BOOT_MODE=psexe`; unlike the official ZN BIOSes, OpenBIOS does *not* implement game decryption and booting in the kernel.
 - `EMBED_PSEXE=binary.ps-exe` will embed the specified executable into the kernel and run it before the shell.
 - `BOOT_MODE=fast` will skip running the shell and try booting from the CD-ROM after the embedded executable returns, or immediately on boot if `EMBED_PSEXE` is not used. Note that the code will *not* wait for a disc to be inserted after the executable returns. The old `FASTBOOT=true` option is kept for compatibility and is equivalent to `BOOT_MODE=fast`.
 - `BOOT_MODE=psexe` will remove the shell and CD-ROM boot code altogether. This is meant to be used alongside `EMBED_PSEXE` to build ROMs for arcade systems and such, which typically use non-standard storage devices and require a custom shell.
@@ -54,7 +54,7 @@ While the first part is the main one that's being targeted here, the second one 
 
 The original code was most likely chunked into several sub-projects, that were all linked together like a giant patchwork. This approach is less readable, and for this reason, we're not going to do this. However this will result in the ROM/RAM split to be less obvious, and slower at times than the original. Tuning of the hot functions is eventually required.
 
-The startup point for the ROM version is the function `_reset` located in [`boot/psx.s`](boot/psx.s) (or [`system573.s`](boot/system573.s) or [`zn.s`](boot/zn.s) depending on which board the kernel is compiled for). The rom cart version is the function `_cartBoot` in the same file.
+The startup point for the ROM version is the function `_reset` located in [`boot/psx.s`](boot/psx.s) (or [`system573.s`](boot/system573.s), [`zn1.s`](boot/zn1.s) or [`zn2.s`](boot/zn2.s) depending on which board the kernel is compiled for). The rom cart version is the function `_cartBoot` in the same file.
 
 ## Direction
 

--- a/src/mips/openbios/boot/zn1.s
+++ b/src/mips/openbios/boot/zn1.s
@@ -96,9 +96,7 @@ _boot:
     li    $t0, 0x1734ff
     sw    $t0, SBUS_DEV0_CTRL
 
-    /* Read/write waitstates increased to 15 cycles from the default value in
-       psx.s (for ZN-2, the ZN-1 BIOS uses the same configuration as psx.s) */
-    li    $t0, 0x200931ff
+    li    $t0, 0x200931e1
     sw    $t0, SBUS_DEV4_CTRL
 
     /* 1 byte with an 8-bit bus, different value from the default one in psx.s
@@ -112,17 +110,17 @@ _boot:
     sw    $t0, SBUS_DEV1_CTRL
 
     /* 256 bytes with a 16-bit bus, different value from the default one in psx.s
-       (the ZN-1/ZN-2 kernels actually use 0x71011/0x71077 respectively here, but
-       it needs to be extended from 128 to 256 bytes in order for the writes to
-       0x1f802080 not to crash on real hardware) */
-    li    $t0, 0x81077
+       (the ZN-1 kernel actually uses 0x71011 here, but it needs to be extended
+       from 128 to 256 bytes in order for the writes to 0x1f802080 not to crash
+       on real hardware) */
+    li    $t0, 0x81011
     sw    $t0, SBUS_DEV8_CTRL
 
     /* The ZN BIOS probes the board configuration register to determine the RAM
        layout and sets up both the DRAM controller and __globals60.ramsize
        accordingly. */
     lbu   $t1, ZN_BOARD_CONFIG
-    la    $t0, _zn_ram_configs
+    la    $t0, _zn1_ram_configs
     andi  $t1, 3
     sll   $t1, 1
     addu  $t0, $t1
@@ -232,7 +230,7 @@ bss_init_skip:
 
     /* set __globals60.ramsize */
     lbu   $t1, ZN_BOARD_CONFIG
-    la    $t0, _zn_ram_sizes
+    la    $t0, _zn1_ram_sizes
     andi  $t1, 3
     addu  $t0, $t1
 
@@ -248,21 +246,21 @@ bss_init_skip:
 stop:
     b     stop
 
-    .section .rodata._zn_ram_configs, "a", @progbits
+    .section .rodata._zn1_ram_configs, "a", @progbits
     .align 2
-    .type _zn_ram_configs, @object
+    .type _zn1_ram_configs, @object
 
-_zn_ram_configs:
+_zn1_ram_configs:
     .hword 0xcbc /* 00: two 2 MB banks, bit 3 set */
     .hword 0xcb4 /* 01: two 2 MB banks */
     .hword 0xbb4 /* 10: single 8 MB bank */
     .hword 0xfa4 /* 11: two 8 MB banks */
 
-    .section .rodata._zn_ram_sizes, "a", @progbits
+    .section .rodata._zn1_ram_sizes, "a", @progbits
     .align 1
-    .type _zn_ram_sizes, @object
+    .type _zn1_ram_sizes, @object
 
-_zn_ram_sizes:
+_zn1_ram_sizes:
     .byte 4  /* 00: two 2 MB banks, bit 3 set */
     .byte 4  /* 01: two 2 MB banks */
     .byte 8  /* 10: single 8 MB bank */

--- a/src/mips/openbios/boot/zn2.s
+++ b/src/mips/openbios/boot/zn2.s
@@ -1,0 +1,271 @@
+/*
+
+MIT License
+
+Copyright (c) 2019 PCSX-Redux authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+.include "common/hardware/hwregs.inc"
+
+    .section .boot, "ax", @progbits
+    .align 2
+    .global flushCache
+    .global _reset
+    .type _reset, @function
+
+_reset:
+    /* Set up the BIOS ROM bus. Note that the read delay is increased by 3
+       cycles from the default value in psx.s to compensate for the higher CPU
+       clock. */
+    li    $t0, (19 << 16) | 0x246f
+    sw    $t0, SBUS_DEV2_CTRL
+
+    /* psx.s configures the DRAM controller here, but we are going to do that
+       after setting up DEV1/EXP3 as we have to probe a bit in there first. */
+    nop
+    nop
+    nop
+    nop
+
+    /* this may be here to let the hardware pick up the new bus settings
+       before moving on with the actual code. Also, some tools like IDA
+       or even PCSX-Redux use it as a signature to detect this is a PS1
+       BIOS file. */
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+
+    /* jumping over the interrupt vector. */
+    j     _boot
+
+.ascii "OpenBIOS"
+
+    .section .text._boot, "ax", @progbits
+    .align 2
+    .global _boot
+    .type _boot, @function
+
+_boot:
+    /* initializing all of the buses now */
+
+    /* Floating time increased by 1 cycle from the default value in psx.s */
+    li    $t0, 0x31225
+    sw    $t0, SBUS_COM_CTRL
+
+    li    $t0, 0x1f000000
+    sw    $t0, SBUS_DEV0_ADDR
+
+    li    $t0, 0x1f802000
+    sw    $t0, SBUS_DEV8_ADDR
+
+    /* 8 MB with a 16-bit bus, different value from the default one in psx.s */
+    li    $t0, 0x1734ff
+    sw    $t0, SBUS_DEV0_CTRL
+
+    /* Read/write waitstates increased to 15 cycles from the default value in
+       psx.s */
+    li    $t0, 0x200931ff
+    sw    $t0, SBUS_DEV4_CTRL
+
+    /* 1 byte with an 8-bit bus, different value from the default one in psx.s
+       (probably a failed attempt to set the CD-ROM region size to 0 bytes so
+       that any access would have generated an exception) */
+    li    $t0, 0x843
+    sw    $t0, SBUS_DEV5_CTRL
+
+    /* 2 MB with a 16-bit bus, different value from the default one in psx.s */
+    li    $t0, 0x153410
+    sw    $t0, SBUS_DEV1_CTRL
+
+    /* 256 bytes with a 16-bit bus, different value from the default one in psx.s
+       (the ZN-2 kernel actually uses 0x71077 here, but it needs to be extended
+       from 128 to 256 bytes in order for the writes to 0x1f802080 not to crash
+       on real hardware) */
+    li    $t0, 0x81077
+    sw    $t0, SBUS_DEV8_CTRL
+
+    /* The ZN BIOS probes the board configuration register to determine the RAM
+       layout and sets up both the DRAM controller and __globals60.ramsize
+       accordingly. */
+    lbu   $t1, ZN_BOARD_CONFIG
+    la    $t0, _zn2_ram_configs
+    andi  $t1, 3
+    sll   $t1, 1
+    addu  $t0, $t1
+
+    lhu   $t0, 0($t0)
+    sw    $t0, RAM_SIZE
+
+    /* clearing out all registers */
+    .set push
+    .set noat
+    move  $1, $0
+    .set pop
+    move  $2, $0
+    move  $3, $0
+    move  $4, $0
+    move  $5, $0
+    move  $6, $0
+    move  $7, $0
+    move  $8, $0
+    move  $9, $0
+    move  $10, $0
+    move  $11, $0
+    move  $12, $0
+    move  $13, $0
+    move  $14, $0
+    move  $15, $0
+    move  $16, $0
+    move  $17, $0
+    move  $18, $0
+    move  $19, $0
+    move  $20, $0
+    move  $21, $0
+    move  $22, $0
+    move  $23, $0
+    move  $24, $0
+    move  $25, $0
+    move  $26, $0
+    move  $27, $0
+    move  $28, $0
+    move  $29, $0
+    move  $30, $0
+    move  $31, $0
+
+    jal  flushCache
+
+    /* ensuring cop0 is fully reset */
+    mtc0  $0, $7
+    nop
+    mtc0  $0, $3
+    nop
+    mtc0  $0, $5
+    nop
+    mtc0  $0, $6
+    nop
+    mtc0  $0, $9
+    nop
+    mtc0  $0, $11
+    nop
+    mtc0  $0, $12
+    nop
+    mtc0  $0, $13
+    nop
+
+    /* Extra from OpenBIOS, not in the original BIOS:
+       Enable cop2, as some games may rely on it being
+       enabled as a side effect of the shell running,
+       and our replacement shell does not enable it. */
+    lui   $t0, 0x4000
+    mtc0  $t0, $12
+    nop
+
+    /* Now we are ready for a typical crt0.
+       The original bios does not do this, most likely
+       for speed reasons. It would be more efficient to
+       run these loops in RAM instead of the ROM. But
+       we have enough code that would rely in all this
+       to be set up already before starting, it would
+       be a mistake to not do it here. */
+    la    $t0, __data_start
+    la    $t1, __data_end
+    la    $t2, __rom_data_start
+
+    beq   $t0, $t1, data_copy_skip
+
+data_copy:
+    lw    $t3, 0($t2)
+    sw    $t3, 0($t0)
+    addiu $t0, 4
+    addiu $t2, 4
+    bne   $t0, $t1, data_copy
+
+data_copy_skip:
+    la    $t0, __bss_start
+    la    $t1, __bss_end
+
+    beq   $t0, $t1, bss_init_skip
+
+bss_init:
+    sw    $0, 0($t0)
+    addiu $t0, 4
+    bne   $t0, $t1, bss_init
+
+bss_init_skip:
+    /* technically have to set $gp, but we are not using it, so, not */
+    la    $sp, __sp
+    move  $fp, $sp
+
+    /* set __globals60.ramsize */
+    lbu   $t1, ZN_BOARD_CONFIG
+    la    $t0, _zn2_ram_sizes
+    andi  $t1, 3
+    addu  $t0, $t1
+
+    lbu   $t0, 0($t0)
+    sw    $t0, 0x60($0)
+
+    jal   _ucsdk_start
+
+    li    $t0, 0x1f802080
+    li    $t1, 10
+    sb    $t1, 0($t0)
+    sb    $t1, 1($t0)
+stop:
+    b     stop
+
+    .section .rodata._zn2_ram_configs, "a", @progbits
+    .align 2
+    .type _zn2_ram_configs, @object
+
+_zn2_ram_configs:
+    .hword 0x433e /* 00: single 4 MB bank */
+    .hword 0x433e /* 01: same as 00 */
+    .hword 0x473e /* 10: two 4 MB banks */
+    .hword 0x4f3e /* 11: two 8 MB banks */
+
+    .section .rodata._zn2_ram_sizes, "a", @progbits
+    .align 1
+    .type _zn2_ram_sizes, @object
+
+_zn2_ram_sizes:
+    .byte 4  /* 00: single 4 MB bank */
+    .byte 4  /* 01: same as 00 */
+    .byte 8  /* 10: two 4 MB banks */
+    .byte 16 /* 11: two 8 MB banks */

--- a/src/mips/openbios/kernel/misc.c
+++ b/src/mips/openbios/kernel/misc.c
@@ -33,15 +33,25 @@ SOFTWARE.
 #if defined(OPENBIOS_BOARD_SYS573)
 static const char s_kernelName[] = "OpenBIOS (System 573)";
 static const int s_kernelFlags = 2;
+#elif defined(OPENBIOS_BOARD_ZN1)
+static const char s_kernelName[] = "OpenBIOS (ZN-1)";
+static const int s_kernelFlags = 0x11001;
+#elif defined(OPENBIOS_BOARD_ZN2)
+static const char s_kernelName[] = "OpenBIOS (ZN-2)";
+static const int s_kernelFlags = 0x13000;
+#else
+static const char s_kernelName[] = "OpenBIOS";
+static const int s_kernelFlags = 3;
+#endif
+
+#if defined(OPENBIOS_BOARD_SYS573)
 static const int s_isArcadeBoard = 1;
 static const int s_unknownFlag = 0;
 
 static __inline__ int getBoardRevision() { return 0; }
 static __inline__ int getVRAMSize() { return 2048; }
 static __inline__ int getSPURAMSize() { return 512; }
-#elif defined(OPENBIOS_BOARD_ZN)
-static const char s_kernelName[] = "OpenBIOS (ZN-1/ZN-2)";
-static const int s_kernelFlags = 0x11001; // ZN-1: 0x11001, ZN-2: 0x13000
+#elif defined(OPENBIOS_BOARD_ZN1) || defined(OPENBIOS_BOARD_ZN2)
 static const int s_isArcadeBoard = 1;
 static const int s_unknownFlag = 1;
 
@@ -49,8 +59,6 @@ static __inline__ int getBoardRevision() { return ((ZN_BOARD_CONFIG >> 5) & 7) -
 static __inline__ int getVRAMSize() { return ((ZN_BOARD_CONFIG >> 3) & 1) ? 2048 : 1024; }
 static __inline__ int getSPURAMSize() { return ((ZN_BOARD_CONFIG >> 2) & 1) ? 2048 : 512; }
 #else
-static const char s_kernelName[] = "OpenBIOS";
-static const int s_kernelFlags = 3;
 static const int s_isArcadeBoard = 0;
 static const int s_unknownFlag = 1;
 

--- a/src/mips/openbios/main/main.c
+++ b/src/mips/openbios/main/main.c
@@ -300,7 +300,7 @@ extern struct BuildId __build_id, __build_id_end;
 // hint at the fact there may have been a version of the SPU with support for
 // more than 512 KB of RAM.
 static void printBoardConfiguration() {
-#ifdef OPENBIOS_BOARD_ZN
+#if defined(OPENBIOS_BOARD_ZN1) || defined(OPENBIOS_BOARD_ZN2)
     uint8_t config = ZN_BOARD_CONFIG;
     int is2MBSPURAM = (config >> 2) & 1;
     int is2MBVRAM = (config >> 3) & 1;

--- a/src/mips/openbios/main/main.h
+++ b/src/mips/openbios/main/main.h
@@ -43,7 +43,7 @@ static __inline__ void clearWatchdog() {
 // Similar to the case above. The ZN kernel clears these registers in a few
 // different places but they are all gathered here for simplicity's sake.
 static __inline__ void clearZNRegisters() {
-#ifdef OPENBIOS_BOARD_ZN
+#if defined(OPENBIOS_BOARD_ZN1) || defined(OPENBIOS_BOARD_ZN2)
     ZN_SIO0_MUX = 0;
     ZN_COIN_CTRL = 0;
     ZN_IRQ10_MUX = 0;


### PR DESCRIPTION
A relatively small PR that splits the existing OpenBIOS `BOARD=zn` target into `zn1` and `zn2`, with the latter tested and known to be working on a real ZN-2 arcade PCB; the former is untested but unlikely to have regressed from the original tested implementation, as no critical changes were made.

The only meaningful difference between the ZN-1 and ZN-2 targets is the boot code. The ZN-2 turned out to require a different `_zn*_ram_configs` array due to being fitted with different main RAM layouts, as well as some changes to the system bus waitstate configuration in order to compensate for the faster CPU clock.