### PR TITLE
psyqo: make fixed-point iDiv/dDiv constexpr

### DIFF
--- a/src/mips/psyqo/fixed-point.hh
+++ b/src/mips/psyqo/fixed-point.hh
@@ -37,9 +37,50 @@ namespace psyqo {
 
 namespace FixedPointInternals {
 
-uint32_t iDiv(uint64_t rem, uint32_t base, unsigned scale);
-int32_t dDiv(int32_t a, int32_t b, unsigned scale);
 void printInt(uint32_t value, const eastl::function<void(char)>&, unsigned scale);
+
+constexpr uint32_t iDiv(uint64_t rem, uint32_t base, unsigned scale) {
+    rem *= scale;
+    uint64_t b = base;
+    uint64_t res, d = 1;
+    uint32_t high = rem >> 32;
+
+    res = 0;
+    if (high >= base) {
+        high /= base;
+        res = static_cast<uint64_t>(high) << 32;
+        rem -= static_cast<uint64_t>(high * base) << 32;
+    }
+
+    while (static_cast<int64_t>(b) > 0 && b < rem) {
+        b = b + b;
+        d = d + d;
+    }
+
+    do {
+        if (rem >= b) {
+            rem -= b;
+            res += d;
+        }
+        b >>= 1;
+        d >>= 1;
+    } while (d);
+
+    return res;
+}
+
+constexpr int32_t dDiv(int32_t a, int32_t b, unsigned scale) {
+    int s = 1;
+    if (a < 0) {
+        a = -a;
+        s = -1;
+    }
+    if (b < 0) {
+        b = -b;
+        s = -s;
+    }
+    return iDiv(a, b, scale) * s;
+}
 
 }  // namespace FixedPointInternals
 

--- a/src/mips/psyqo/src/fixed-point.cpp
+++ b/src/mips/psyqo/src/fixed-point.cpp
@@ -26,48 +26,6 @@ SOFTWARE.
 
 #include "psyqo/fixed-point.hh"
 
-uint32_t psyqo::FixedPointInternals::iDiv(uint64_t rem, uint32_t base, unsigned scale) {
-    rem *= scale;
-    uint64_t b = base;
-    uint64_t res, d = 1;
-    uint32_t high = rem >> 32;
-
-    res = 0;
-    if (high >= base) {
-        high /= base;
-        res = static_cast<uint64_t>(high) << 32;
-        rem -= static_cast<uint64_t>(high * base) << 32;
-    }
-
-    while (static_cast<int64_t>(b) > 0 && b < rem) {
-        b = b + b;
-        d = d + d;
-    }
-
-    do {
-        if (rem >= b) {
-            rem -= b;
-            res += d;
-        }
-        b >>= 1;
-        d >>= 1;
-    } while (d);
-
-    return res;
-}
-
-int32_t psyqo::FixedPointInternals::dDiv(int32_t a, int32_t b, unsigned scale) {
-    int s = 1;
-    if (a < 0) {
-        a = -a;
-        s = -1;
-    }
-    if (b < 0) {
-        b = -b;
-        s = -s;
-    }
-    return iDiv(a, b, scale) * s;
-}
 
 void psyqo::FixedPointInternals::printInt(uint32_t value, const eastl::function<void(char)>& charPrinter,
                                           unsigned scale) {


### PR DESCRIPTION
Move the FixedPointInternals iDiv/dDiv division helpers out of fixed-point.cpp
into the header as constexpr, so fixed-point division can be evaluated at
compile time. The out-of-line definitions are removed; the bodies are
unchanged. printInt stays in the .cpp.
