### PR TITLE
psyqo: use portable inline and no_unique_address spellings

### DIFF
--- a/src/mips/common/hardware/spu.h
+++ b/src/mips/common/hardware/spu.h
@@ -66,7 +66,7 @@ struct SPUVoice {
 #define SPU_VOL_EXT_LEFT HW_U16(0x1f801db4)
 #define SPU_VOL_EXT_RIGHT HW_U16(0x1f801db6)
 
-static __inline__ void muteSpu() {
+static inline void muteSpu() {
     SPU_REVERB_RIGHT = 0;
     SPU_REVERB_LEFT = 0;
     SPU_VOL_MAIN_RIGHT = 0;

--- a/src/mips/psyqo/vector.hh
+++ b/src/mips/psyqo/vector.hh
@@ -32,6 +32,14 @@ SOFTWARE.
 #include "psyqo/fixed-point.hh"
 #include "psyqo/primitives/common.hh"
 
+// MSVC and clang-cl target the MSVC ABI, which ignores the standard
+// [[no_unique_address]]; they need the vendor spelling to elide empty members.
+#if __has_cpp_attribute(msvc::no_unique_address)
+#define PSYQO_NO_UNIQUE_ADDR [[msvc::no_unique_address]]
+#else
+#define PSYQO_NO_UNIQUE_ADDR [[no_unique_address]]
+#endif
+
 namespace psyqo {
 
 template <unsigned N, unsigned precisionBits = 12, std::integral T = int32_t>
@@ -40,9 +48,9 @@ struct Vector {
     typedef FixedPoint<precisionBits, T> FixedPointType;
     FixedPoint<precisionBits, T> x, y;
     struct EmptyZ {};
-    [[no_unique_address]] std::conditional_t<(N > 2), FixedPoint<precisionBits, T>, EmptyZ> z;
+    PSYQO_NO_UNIQUE_ADDR std::conditional_t<(N > 2), FixedPoint<precisionBits, T>, EmptyZ> z;
     struct EmptyW {};
-    [[no_unique_address]] std::conditional_t<(N > 3), FixedPoint<precisionBits, T>, EmptyW> w;
+    PSYQO_NO_UNIQUE_ADDR std::conditional_t<(N > 3), FixedPoint<precisionBits, T>, EmptyW> w;
     constexpr FixedPointType& get(unsigned i) {
         if constexpr (N == 2) {
             return (i == 0) ? x : y;


### PR DESCRIPTION
muteSpu() used the GNU __inline__ spelling, which MSVC rejects; plain
static inline is standard C99/C++ and identical on GCC. The Vector members
used the standard [[no_unique_address]], which the MSVC ABI (MSVC and
clang-cl) ignores, so wrap it in a PSYQO_NO_UNIQUE_ADDR macro that
feature-detects [[msvc::no_unique_address]] via __has_cpp_attribute and
falls back to the standard spelling everywhere else. No change on the GCC
toolchain.
