### PR TITLE
psyqo: split GPU register setup into reinitialize()

### DIFF
--- a/src/mips/psyqo/gpu.hh
+++ b/src/mips/psyqo/gpu.hh
@@ -106,6 +106,7 @@ class GPU {
     enum class Interlace { PROGRESSIVE, INTERLACED };
     enum class MiscSetting { CLEAR_VRAM, KEEP_VRAM };
     void initialize(const Configuration &config);
+    void reinitialize(const Configuration &config);
 
     static constexpr uint32_t US_PER_HBLANK = 64;
     static constexpr unsigned c_chainThreshold = 56;

--- a/src/mips/psyqo/src/gpu.cpp
+++ b/src/mips/psyqo/src/gpu.cpp
@@ -51,7 +51,7 @@ void psyqo::GPU::waitFifo() {
     }
 }
 
-void psyqo::GPU::initialize(const psyqo::GPU::Configuration &config) {
+void psyqo::GPU::reinitialize(const psyqo::GPU::Configuration &config) {
     // Reset
     Hardware::GPU::Ctrl = 0;
     // FIFO polling mode
@@ -72,9 +72,6 @@ void psyqo::GPU::initialize(const psyqo::GPU::Configuration &config) {
 
     // Display Area
     Hardware::GPU::Ctrl = 0x05000000;
-
-    COUNTERS[1].mode = 0x100;
-    COUNTERS[1].value = 0;
 
     if (config.config.videoInterlace == Configuration::VI_ON) {
         m_interlaced = true;
@@ -108,6 +105,13 @@ void psyqo::GPU::initialize(const psyqo::GPU::Configuration &config) {
     } else {
         m_refreshRate = 50;
     }
+}
+
+void psyqo::GPU::initialize(const psyqo::GPU::Configuration &config) {
+    COUNTERS[1].mode = 0x100;
+    COUNTERS[1].value = 0;
+
+    reinitialize(config);
 
     // Install VBlank interrupt handler
     if (Kernel::isKernelTakenOver()) {


### PR DESCRIPTION
Factor the re-runnable part of initialize() - the display-mode, range and
display-area register writes plus the derived width/height/refresh state -
into a new reinitialize(), so the video mode can be reconfigured without
re-installing the VBlank handler, DMA events and timers. initialize() keeps
the one-time setup and calls reinitialize(). Behavior is unchanged: the
register values and write order are identical; only the Timer1 (COUNTERS[1])
setup moves ahead of the register writes, which is independent.
