### PR TITLE
Fix issues with blitting partially out of VRAM bounds

### DIFF
--- a/src/core/gpu.cc
+++ b/src/core/gpu.cc
@@ -826,8 +826,8 @@ void PCSX::GPU::BlitRamVram::processWrite(Buffer &buf, Logged::Origin origin, ui
             [[fallthrough]];
         case READ_XY:
             value = buf.get();
-            x = signExtend<int, 11>(value & 0xffff);
-            y = signExtend<int, 11>(value >> 16);
+            x = value & 0xffff;
+            y = value >> 16;
             m_state = READ_HW;
             if (buf.isEmpty()) return;
             [[fallthrough]];
@@ -883,8 +883,8 @@ void PCSX::GPU::BlitVramRam::processWrite(Buffer &buf, Logged::Origin origin, ui
             [[fallthrough]];
         case READ_XY:
             value = buf.get();
-            x = signExtend<int, 11>(value & 0xffff);
-            y = signExtend<int, 11>(value >> 16);
+            x = value & 0xffff;
+            y = value >> 16;
             m_state = READ_HW;
             if (buf.isEmpty()) return;
             [[fallthrough]];

--- a/src/core/gpu.h
+++ b/src/core/gpu.h
@@ -285,37 +285,19 @@ class GPU {
     template <typename T, T wMax = 1024, T hMax = 512>
     static bool clip(T &x, T &y, T &w, T &h) {
         bool clipped = false;
-        if (x >= wMax || y >= hMax) {
-            x = wMax;
-            y = hMax;
-            if ((w != 0) || (h != 0)) {
-                w = h = 0;
-                return true;
-            }
-            return false;
-        }
-        if (x < 0) {
-            clipped = true;
-            w += x;
-            x = 0;
-        }
-        if (y < 0) {
-            clipped = true;
-            h += y;
-            y = 0;
-        }
-        if (w < 0 || h < 0) {
-            h = w = 0;
-            return true;
-        }
+        x %= wMax;
+        h %= hMax;
+
         if (x + w > wMax) {
+            x = 0;
             clipped = true;
-            w = wMax - x;
         }
+
         if (y + h > hMax) {
+            y = 0;
             clipped = true;
-            h = hMax - y;
         }
+
         return clipped;
     }
 

--- a/src/core/gpu.h
+++ b/src/core/gpu.h
@@ -286,7 +286,7 @@ class GPU {
     static bool clip(T &x, T &y, T &w, T &h) {
         bool clipped = false;
         x %= wMax;
-        h %= hMax;
+        y %= hMax;
 
         if (x + w > wMax) {
             x = 0;


### PR DESCRIPTION
The clipping function for the blit commands was almost entirely incorrect. Replaced it with the (hopefully) proper implementation that doesn't resize the blit rect. This fixes #1657 