### PR TITLE
Make the memory-as-file view cover the scratchpad and hardware registers

### DIFF
--- a/src/core/gdb-server.cc
+++ b/src/core/gdb-server.cc
@@ -770,6 +770,15 @@ void PCSX::GdbClient::processMonitorCommand(const std::string& cmd) {
                 writeEscaped("Unknown type. Valid types: wram");
             }
         }
+    } else if (words[0] == "cache") {
+        // Writing memory over gdb won't invalidate anything by itself: most of what goes through
+        // there is data, and there's no d-cache to worry about. Patching code needs this after.
+        if ((words.size() != 2) || (words[1] != "flush")) {
+            writeEscaped("Usage: cache flush\n");
+        } else {
+            writeEscaped("Flushing i-cache\n");
+            g_emulator->m_cpu->invalidateCache();
+        }
     }
     write("OK");
 }

--- a/src/core/psxmem.cc
+++ b/src/core/psxmem.cc
@@ -809,7 +809,7 @@ ssize_t PCSX::Memory::MemoryAsFile::writeAt(const void *src, size_t size, size_t
 
 void PCSX::Memory::MemoryAsFile::readBlock(void *dest_, size_t size, size_t ptr) {
     auto dest = reinterpret_cast<uint8_t *>(dest_);
-    auto block = m_memory->m_readLUT[ptr / c_blockSize];
+    auto block = m_memory->debugPointer(ptr / c_blockSize);
     if (!block) {
         memset(dest, 0, size);
         if (m_memory->msanInitialized()) {
@@ -828,10 +828,25 @@ void PCSX::Memory::MemoryAsFile::readBlock(void *dest_, size_t size, size_t ptr)
 }
 
 void PCSX::Memory::MemoryAsFile::writeBlock(const void *src_, size_t size, size_t ptr) {
-    // Yes. That's not a bug nor a typo.
+    // The read LUT, on purpose, and not a typo. The write LUT describes what the guest's current
+    // BIU cache configuration lets a store reach, and it goes empty for main RAM whenever the
+    // cache is isolated. That's transient guest state; a write coming in from a debugger has no
+    // business being subject to it. The read LUT is the table that describes what memory is
+    // actually there.
     auto src = reinterpret_cast<const uint8_t *>(src_);
-    auto block = m_memory->m_readLUT[ptr / c_blockSize];
+    const auto page = ptr / c_blockSize;
+    auto block = m_memory->m_readLUT[page];
+    auto offset = ptr % c_blockSize;
     if (!block) {
+        // The scratchpad is plain memory and safe to poke. The hardware registers sharing its page
+        // are stateful, and writing to their shadow behind the hardware's back would only desync
+        // the two, so those are silently dropped.
+        if ((page == 0x1f80) || (page == 0x9f80) || (page == 0xbf80)) {
+            if (offset < c_scratchpadSize) {
+                memcpy(m_memory->m_hard + offset, src, std::min<size_t>(size, c_scratchpadSize - offset));
+            }
+            return;
+        }
         if (m_memory->msanInitialized()) {
             for (size_t i = 0; i < size; ++i) {
                 size_t msanPtr = ptr + i;
@@ -842,7 +857,6 @@ void PCSX::Memory::MemoryAsFile::writeBlock(const void *src_, size_t size, size_
         }
         return;
     }
-    auto offset = ptr % c_blockSize;
     auto toCopy = std::min(size, c_blockSize - offset);
     memcpy(block + offset, src, toCopy);
 }

--- a/src/core/psxmem.h
+++ b/src/core/psxmem.h
@@ -304,6 +304,20 @@ class Memory {
     friend class MemoryAsFile;
     IO<MemoryAsFile> m_memoryAsFile;
 
+    // The scratchpad and the hardware registers share a single 64kB page, and the guest path has
+    // to dispatch register accesses to the hardware itself for their side effects, so that page is
+    // deliberately absent from the read LUT. Both are shadowed by m_hard at the same offsets,
+    // which spans the whole page and is safe to read at any time, so debugger-style accesses -
+    // which want a faithful view of memory and none of the side effects - resolve through here
+    // instead of through the read LUT directly.
+    static constexpr uint32_t c_scratchpadSize = 0x400;
+    uint8_t *debugPointer(uint32_t page) const {
+        auto pointer = m_readLUT[page];
+        if (pointer != nullptr) return pointer;
+        if ((page == 0x1f80) || (page == 0x9f80) || (page == 0xbf80)) return m_hard;
+        return nullptr;
+    }
+
     uint32_t m_biosCRC = 0;
 
     // Shared memory wrappers, pointers below point to these where appropriate


### PR DESCRIPTION
MemoryAsFile only resolved through the read LUT, so the scratchpad and the
hardware registers read back as zeroes through the hex editors, gdb and Lua.
They share a 64kB page that can't have a LUT entry, since the guest path has to
dispatch register accesses to the hardware, so resolve those through the m_hard
shadow instead. Scratchpad writes land, register writes are dropped.

Second commit adds a `cache flush` monitor command to the gdb server, since
writes there deliberately don't invalidate anything.