### PR TITLE
psyqo: align TexInfo and PageInfo to 32 bits

### DIFF
--- a/src/mips/psyqo/primitives/common.hh
+++ b/src/mips/psyqo/primitives/common.hh
@@ -135,12 +135,13 @@ static_assert(sizeof(ClutIndex) == sizeof(uint16_t), "ClutIndex is not 16 bits")
  * The binary representation is meant to be the same as the texture argument for
  * GPU commands.
  */
-struct TexInfo {
+struct alignas(uint32_t) TexInfo {
     uint8_t u;
     uint8_t v;
     ClutIndex clut;
 };
 static_assert(sizeof(TexInfo) == sizeof(uint32_t), "TexInfo is not 32 bits");
+static_assert(alignof(TexInfo) == alignof(uint32_t), "TexInfo is not 32-bit aligned");
 
 struct TPageAttr;
 /**
@@ -267,12 +268,13 @@ static_assert(sizeof(TPageAttr) == sizeof(uint16_t), "TPageAttr is not 16 bits")
  *
  * @details This is a common building block piece used in primitives.
  */
-struct PageInfo {
+struct alignas(uint32_t) PageInfo {
     uint8_t u;
     uint8_t v;
     TPageAttr attr;
 };
 static_assert(sizeof(PageInfo) == sizeof(uint32_t), "PageInfo is not 32 bits");
+static_assert(alignof(PageInfo) == alignof(uint32_t), "PageInfo is not 32-bit aligned");
 
 /**
  * @brief A primitive's UV coordinates attribute.


### PR DESCRIPTION
Both are four bytes wide but only two-byte aligned - their `sizeof` assert never checked that. So copying one splits into `lhu`/`lhu`/`sh`/`sh` instead of `lw`/`sw`, four memory accesses per glyph in `FontBase` instead of two.

`alignas(uint32_t)` fixes it: 71 halfword loads down to 65 in `libpsyqo.a`, all six in the glyph path, no new `lwl`/`lwr`, `.text` 88 bytes smaller. Neither type moves - both already sat at word-aligned offsets in every primitive that embeds them.