### PR TITLE
cdrom: fix cdread_2048 writing the sector header into the wrong buffer

### DIFF
--- a/src/cdrom/cdriso.cc
+++ b/src/cdrom/cdriso.cc
@@ -227,13 +227,13 @@ ssize_t PCSX::CDRIso::cdread_2048(IO<File> f, unsigned int base, void *dest_, in
     dest[10] = 0xff;
     dest[11] = 0x00;
     IEC60908b::MSF(sector + 150).toBCD(dest + 12);
-    m_cdbuffer[15] = 2;
-    m_cdbuffer[16] = m_cdbuffer[20] = 0;
-    m_cdbuffer[17] = m_cdbuffer[21] = 0;
-    m_cdbuffer[18] = m_cdbuffer[22] = 8;
-    m_cdbuffer[19] = m_cdbuffer[23] = 0;
+    dest[15] = 2;
+    dest[16] = dest[20] = 0;
+    dest[17] = dest[21] = 0;
+    dest[18] = dest[22] = 8;
+    dest[19] = dest[23] = 0;
 
-    IEC60908b::computeEDCECC(m_cdbuffer);
+    IEC60908b::computeEDCECC(dest);
 
     return ret;
 }


### PR DESCRIPTION
cdread_2048 writes the sync pattern and MSF into the caller's dest, but the
mode byte, subheader and EDC/ECC into the member scratch m_cdbuffer. readTrack
passes m_cdbuffer as dest so the two alias there and it never showed; every
other caller, in practice every Lua read through CDRIsoFile, gets bytes 15..23
and the EDC/ECC tail as leftover garbage. GUESS then reads the bogus mode byte,
falls through to RAW, and hands back the sync pattern where user data should be.

Verified against an ISO9660 image: GUESS on sector 16 now returns the CD001
volume descriptor instead of the sync pattern.
