### PR TITLE
Binding the ISO builder's raw sector writers to Lua.

### DIFF
--- a/src/core/isoffi.lua
+++ b/src/core/isoffi.lua
@@ -64,7 +64,9 @@ ISO9660Builder* createIsoBuilder(LuaFile* out);
 void deleteIsoBuilder(ISO9660Builder* builder);
 bool isoBuilderFailed(ISO9660Builder* builder);
 void isoBuilderWriteLicense(ISO9660Builder* builder, LuaFile*);
-void isoBuilderWriteSector(ISO9660Builder* builder, const uint8_t* sectorData, enum SectorMode mode);
+uint32_t isoBuilderWriteSector(ISO9660Builder* builder, const uint8_t* sectorData, uint32_t dataSize, enum SectorMode mode);
+uint32_t isoBuilderWriteSectorAt(ISO9660Builder* builder, const uint8_t* sectorData, uint32_t dataSize, uint32_t lba, enum SectorMode mode);
+uint32_t isoBuilderGetCurrentLBA(ISO9660Builder* builder);
 void isoBuilderClose(ISO9660Builder* builder, uint32_t threadCount);
 
 // High-level filesystem-aware ISO builder
@@ -235,6 +237,29 @@ local function createDirTreeWrapper(node)
     return wrapper
 end
 
+-- Amount of data a raw sector write consumes, per mode. Modes absent from this table can't be written.
+local sectorDataSize = {
+    RAW = 2352,
+    M2_RAW = 2336,
+    M2_FORM1 = 2048,
+    M2_FORM2 = 2324,
+}
+
+-- Normalizes the (data[, size]) pair of the raw sector writers. Strings carry their own size; anything
+-- else is a pointer and needs one spelled out.
+local function sectorData(data, size, mode)
+    if size == nil then
+        if type(data) ~= 'string' then error('a size is required when writing a sector from a pointer') end
+        size = #data
+    end
+    local needed = sectorDataSize[mode]
+    if needed == nil then error('sector mode ' .. tostring(mode) .. ' cannot be written') end
+    if size < needed then
+        error('sector mode ' .. mode .. ' needs ' .. needed .. ' bytes of data, got ' .. size)
+    end
+    return ffi.cast('const uint8_t*', data), size
+end
+
 local function createIsoBuilderWrapper(wrapper)
     local function pvdGetter(getter)
         return function(self)
@@ -245,6 +270,21 @@ local function createIsoBuilderWrapper(wrapper)
     local builder = {
         _wrapper = ffi.gc(wrapper, C.deleteIsoBuilder),
         failed = function(self) return C.isoBuilderFailed(self._wrapper) end,
+        getCurrentLBA = function(self) return C.isoBuilderGetCurrentLBA(self._wrapper) end,
+        writeSector = function(self, data, a, b)
+            local size, mode
+            if type(a) == 'number' then size, mode = a, b else size, mode = nil, a end
+            if mode == nil then mode = 'M2_FORM1' end
+            local ptr, len = sectorData(data, size, mode)
+            return C.isoBuilderWriteSector(self._wrapper, ptr, len, mode)
+        end,
+        writeSectorAt = function(self, data, a, b, c)
+            local size, lba, mode
+            if type(b) == 'number' then size, lba, mode = a, b, c else size, lba, mode = nil, a, b end
+            if mode == nil then mode = 'M2_FORM1' end
+            local ptr, len = sectorData(data, size, mode)
+            return C.isoBuilderWriteSectorAt(self._wrapper, ptr, len, lba, mode)
+        end,
         writeLicense = function(self, file)
             if file then
                 C.isoBuilderWriteLicense(self._wrapper, file._wrapper)

--- a/src/core/luaiso.cc
+++ b/src/core/luaiso.cc
@@ -228,8 +228,47 @@ bool isoBuilderFailed(PCSX::ISO9660Builder* builder) { return builder->failed();
 void isoBuilderWriteLicense(PCSX::ISO9660Builder* builder, PCSX::LuaFFI::LuaFile* licenseWrapper) {
     builder->writeLicense(licenseWrapper ? licenseWrapper->file : nullptr);
 }
-void isoBuilderWriteSector(PCSX::ISO9660Builder* builder, const uint8_t* sectorData, PCSX::IEC60908b::SectorMode mode) {
-    builder->writeSector(sectorData, mode);
+// Sentinel returned to Lua when a sector write couldn't be performed.
+static constexpr uint32_t c_badLBA = 0xffffffff;
+
+// Amount of data writeSectorAt will read from the caller's buffer for a given mode. Modes that can't
+// be written to return 0.
+static uint32_t sectorDataSize(PCSX::IEC60908b::SectorMode mode) {
+    switch (mode) {
+        case PCSX::IEC60908b::SectorMode::RAW:
+            return PCSX::IEC60908b::FRAMESIZE_RAW;
+        case PCSX::IEC60908b::SectorMode::M2_RAW:
+            return 2336;
+        case PCSX::IEC60908b::SectorMode::M2_FORM1:
+            return 2048;
+        case PCSX::IEC60908b::SectorMode::M2_FORM2:
+            return 2324;
+        default:
+            return 0;
+    }
+}
+
+// The LBAs here are relative to the start of the image, matching the rest of the iso API, while the
+// builder works in MSF. Sector 0 of the image is MSF 00:02:00.
+static uint32_t msfToImageLBA(PCSX::IEC60908b::MSF msf) {
+    uint32_t lba = msf.toLBA();
+    return lba < 150 ? c_badLBA : lba - 150;
+}
+
+uint32_t isoBuilderWriteSectorAt(PCSX::ISO9660Builder* builder, const uint8_t* sectorData, uint32_t dataSize,
+                                 uint32_t lba, PCSX::IEC60908b::SectorMode mode) {
+    uint32_t needed = sectorDataSize(mode);
+    if ((needed == 0) || (dataSize < needed)) return c_badLBA;
+    return msfToImageLBA(builder->writeSectorAt(sectorData, PCSX::IEC60908b::MSF(lba + 150), mode));
+}
+uint32_t isoBuilderWriteSector(PCSX::ISO9660Builder* builder, const uint8_t* sectorData, uint32_t dataSize,
+                               PCSX::IEC60908b::SectorMode mode) {
+    uint32_t needed = sectorDataSize(mode);
+    if ((needed == 0) || (dataSize < needed)) return c_badLBA;
+    return msfToImageLBA(builder->writeSector(sectorData, mode));
+}
+uint32_t isoBuilderGetCurrentLBA(PCSX::ISO9660Builder* builder) {
+    return msfToImageLBA(builder->getCurrentLocation());
 }
 void isoBuilderClose(PCSX::ISO9660Builder* builder, uint32_t threadCount) { builder->close(threadCount); }
 
@@ -421,6 +460,8 @@ static void registerAllSymbols(PCSX::Lua L) {
     REGISTER(L, isoBuilderFailed);
     REGISTER(L, isoBuilderWriteLicense);
     REGISTER(L, isoBuilderWriteSector);
+    REGISTER(L, isoBuilderWriteSectorAt);
+    REGISTER(L, isoBuilderGetCurrentLBA);
     REGISTER(L, isoBuilderClose);
 
     // PVD getters

--- a/tests/lua/isobuilder.lua
+++ b/tests/lua/isobuilder.lua
@@ -346,3 +346,135 @@ function TestIsoBuilder:test_anchorErrorOnBackwardLBA()
     local ok = pcall(function() builder:close() end)
     lu.assertFalse(ok, 'expected close() to throw on backward anchor')
 end
+
+function TestIsoBuilder:test_writeSectorRaw()
+    -- Raw sector writes, without any filesystem on top.
+    local out = Support.File.buffer()
+    local builder = PCSX.isoBuilder(out)
+
+    -- The write cursor starts at the beginning of the image.
+    lu.assertEquals(builder:getCurrentLBA(), 0)
+
+    local sector = string.rep('A', 2048)
+    lu.assertEquals(builder:writeSector(sector, 'M2_FORM1'), 0)
+    lu.assertEquals(builder:getCurrentLBA(), 1)
+    lu.assertEquals(builder:writeSector(sector, 'M2_FORM1'), 1)
+    lu.assertEquals(builder:getCurrentLBA(), 2)
+
+    -- Two sectors written, so two raw frames on the output.
+    lu.assertEquals(out:size(), 2 * 2352)
+
+    -- The payload of the first sector lands after the 24-byte header.
+    out:rSeek(0)
+    for i = 0, 2047 do
+        lu.assertEquals(out:readU8At(24 + i), string.byte('A'),
+            string.format('M2_FORM1 payload mismatch at byte %d', i))
+    end
+end
+
+function TestIsoBuilder:test_writeSectorAtSkipsAhead()
+    -- writeSectorAt places a sector at an explicit LBA and drags the cursor along.
+    local out = Support.File.buffer()
+    local builder = PCSX.isoBuilder(out)
+
+    lu.assertEquals(builder:writeSectorAt(string.rep('B', 2048), 10, 'M2_FORM1'), 10)
+    lu.assertEquals(builder:getCurrentLBA(), 11)
+    lu.assertEquals(out:size(), 11 * 2352)
+
+    -- Writing behind the cursor is allowed, and must not rewind it.
+    lu.assertEquals(builder:writeSectorAt(string.rep('C', 2048), 3, 'M2_FORM1'), 3)
+    lu.assertEquals(builder:getCurrentLBA(), 11)
+
+    out:rSeek(0)
+    lu.assertEquals(out:readU8At(3 * 2352 + 24), string.byte('C'))
+    lu.assertEquals(out:readU8At(10 * 2352 + 24), string.byte('B'))
+end
+
+function TestIsoBuilder:test_writeSectorModeSizes()
+    -- Each writable mode consumes a different amount of data, and short buffers must be refused
+    -- rather than read past the end.
+    local out = Support.File.buffer()
+    local builder = PCSX.isoBuilder(out)
+
+    local sizes = { RAW = 2352, M2_RAW = 2336, M2_FORM1 = 2048, M2_FORM2 = 2324 }
+    local lba = 0
+    for mode, size in pairs(sizes) do
+        lu.assertEquals(builder:writeSectorAt(string.rep('D', size), lba, mode), lba,
+            'failed to write mode ' .. mode)
+        -- One byte short of what the mode needs must throw, not truncate or overread.
+        local ok = pcall(function() builder:writeSectorAt(string.rep('D', size - 1), lba, mode) end)
+        lu.assertFalse(ok, 'expected a short buffer to be refused for mode ' .. mode)
+        lba = lba + 1
+    end
+
+    -- Modes that can't carry a raw sector write must be refused too.
+    for _, mode in ipairs({ 'M1', 'GUESS' }) do
+        local ok = pcall(function() builder:writeSectorAt(string.rep('D', 2352), 0, mode) end)
+        lu.assertFalse(ok, 'expected mode ' .. mode .. ' to be refused')
+    end
+end
+
+function TestIsoBuilder:test_writeSectorFromPointer()
+    -- The raw writers also take a cdata pointer, in which case a size is mandatory.
+    local out = Support.File.buffer()
+    local builder = PCSX.isoBuilder(out)
+
+    local data = ffi.new('uint8_t[?]', 2048)
+    for i = 0, 2047 do data[i] = i % 256 end
+
+    lu.assertEquals(builder:writeSector(data, 2048, 'M2_FORM1'), 0)
+    out:rSeek(0)
+    lu.assertEquals(out:readU8At(24 + 100), 100)
+
+    -- No size means we can't know how much is safe to read.
+    local ok = pcall(function() builder:writeSector(data, 'M2_FORM1') end)
+    lu.assertFalse(ok, 'expected a pointer without a size to be refused')
+end
+
+function TestIsoBuilder:test_writeSectorPatchesAfterClose()
+    -- The lookup-table pattern: build the filesystem, let close() assign the LBAs, then go back and
+    -- write a sector containing them.
+    local out = Support.File.buffer()
+    local builder = PCSX.isoBuilder(out)
+    builder:writeLicense()
+    builder:setVolumeIdent('LBATABLE')
+
+    local root = builder:createRoot(1)
+
+    -- A placeholder sector that will hold the table.
+    local placeholder = Support.File.buffer()
+    placeholder:write(string.rep('\0', 2048))
+    placeholder:rSeek(0)
+    local tableNode = builder:createFile(root, 'LBATABLE.BIN', placeholder)
+
+    local assets = {}
+    for i = 1, 3 do
+        assets[i] = builder:createFile(root, string.format('ASSET%d.DAT', i), generateTestContent(2048))
+    end
+
+    builder:close()
+
+    -- Every asset has a real LBA now, and none of them is the placeholder's.
+    local payload = ''
+    for i = 1, 3 do
+        local lba = assets[i]:getLBA()
+        lu.assertTrue(lba > 0)
+        payload = payload .. string.char(lba % 256, math.floor(lba / 256) % 256, 0, 0)
+    end
+    payload = payload .. string.rep('\0', 2048 - #payload)
+
+    local written = builder:writeSectorAt(payload, tableNode:getLBA(), 'M2_FORM1')
+    lu.assertEquals(written, tableNode:getLBA())
+
+    -- Read the table back through the filesystem, which also proves the rewritten sector still has
+    -- valid EDC/ECC and a correct header.
+    out:rSeek(0)
+    local reader = PCSX.openIso(out):createReader()
+    local back = reader:open('LBATABLE.BIN;1')
+    lu.assertNotNil(back)
+    for i = 1, 3 do
+        local lba = assets[i]:getLBA()
+        lu.assertEquals(back:readU8At((i - 1) * 4), lba % 256)
+        lu.assertEquals(back:readU8At((i - 1) * 4 + 1), math.floor(lba / 256) % 256)
+    end
+end


### PR DESCRIPTION
The high-level filesystem API has been reachable from Lua since the isobuilder merge, but `writeSector` and `writeSectorAt` never got wrapped, so the low-level path was unusable from scripts even though the C shim was registered. This adds both, along with `getCurrentLBA` so the write cursor is visible.

The bindings take an explicit data size and refuse a buffer shorter than the sector mode consumes, since `writeSectorAt` memcpys a fixed 2048/2324/2336/2352 out of it. LBAs are image-relative in both directions to match the rest of the iso API instead of exposing MSF.

Tests cover the four writable modes with a short-buffer case for each, the cursor semantics, and patching a sector after `close()` to fill in a table of computed LBAs.
