### PR TITLE
GPU logger: VRAM region breakpoints

### DIFF
--- a/src/core/gpulogger.cc
+++ b/src/core/gpulogger.cc
@@ -19,11 +19,57 @@
 
 #include "core/gpulogger.h"
 
+#include <algorithm>
+#include <limits>
+
 #include "core/gpu.h"
 #include "core/psxemulator.h"
 #include "core/r3000a.h"
 #include "core/system.h"
 #include "imgui/imgui.h"
+
+namespace {
+
+// Separating axis test between a triangle and an axis aligned rectangle. Logged::getVertices hands
+// out triangles for everything, including lines and palette rows, so this single test covers every
+// command's footprint. Degenerate triangles project down to a segment or a point on the edge
+// normals, which the interval overlap below still handles correctly.
+bool triangleIntersectsRect(PCSX::OpenGL::ivec2 v1, PCSX::OpenGL::ivec2 v2, PCSX::OpenGL::ivec2 v3, int rx, int ry,
+                            int rw, int rh) {
+    const int rx2 = rx + rw;
+    const int ry2 = ry + rh;
+    const int tx[3] = {v1.x(), v2.x(), v3.x()};
+    const int ty[3] = {v1.y(), v2.y(), v3.y()};
+
+    if (std::max({tx[0], tx[1], tx[2]}) < rx || std::min({tx[0], tx[1], tx[2]}) > rx2) return false;
+    if (std::max({ty[0], ty[1], ty[2]}) < ry || std::min({ty[0], ty[1], ty[2]}) > ry2) return false;
+
+    for (unsigned i = 0; i < 3; i++) {
+        const unsigned j = (i + 1) % 3;
+        const int nx = ty[j] - ty[i];
+        const int ny = tx[i] - tx[j];
+        if ((nx == 0) && (ny == 0)) continue;
+        int triMin = std::numeric_limits<int>::max();
+        int triMax = std::numeric_limits<int>::min();
+        for (unsigned k = 0; k < 3; k++) {
+            const int p = nx * tx[k] + ny * ty[k];
+            triMin = std::min(triMin, p);
+            triMax = std::max(triMax, p);
+        }
+        int rectMin = std::numeric_limits<int>::max();
+        int rectMax = std::numeric_limits<int>::min();
+        for (unsigned k = 0; k < 4; k++) {
+            const int p = nx * ((k & 1) ? rx2 : rx) + ny * ((k & 2) ? ry2 : ry);
+            rectMin = std::min(rectMin, p);
+            rectMax = std::max(rectMax, p);
+        }
+        if ((triMax < rectMin) || (rectMax < triMin)) return false;
+    }
+
+    return true;
+}
+
+}  // namespace
 
 static const char* const c_vtx = R"(
 #version 330 core
@@ -135,6 +181,52 @@ void PCSX::GPULogger::flush() {
     m_verticesCount = 0;
 }
 
+void PCSX::GPULogger::checkVramBreakpoints(GPU::Logged* node) {
+    bool watchingReads = false;
+    bool watchingWrites = false;
+    for (auto& bp : m_vramBreakpoints) {
+        if (!bp.enabled) continue;
+        watchingReads |= bp.onRead;
+        watchingWrites |= bp.onWrite;
+    }
+    if (!watchingReads && !watchingWrites) return;
+
+    unsigned hit = m_vramBreakpoints.size();
+    auto scan = [this, node, &hit](GPU::Logged::PixelOp op) {
+        node->getVertices(
+            [this, &hit, op](auto v1, auto v2, auto v3) {
+                if (hit != m_vramBreakpoints.size()) return;
+                for (unsigned i = 0; i < m_vramBreakpoints.size(); i++) {
+                    auto& bp = m_vramBreakpoints[i];
+                    if (!bp.enabled) continue;
+                    if (!(op == GPU::Logged::PixelOp::READ ? bp.onRead : bp.onWrite)) continue;
+                    if (triangleIntersectsRect(v1, v2, v3, bp.area.x, bp.area.y, bp.area.w, bp.area.h)) {
+                        hit = i;
+                        return;
+                    }
+                }
+            },
+            op);
+    };
+
+    const char* what = _("write");
+    if (watchingWrites) scan(GPU::Logged::PixelOp::WRITE);
+    if ((hit == m_vramBreakpoints.size()) && watchingReads) {
+        what = _("read");
+        scan(GPU::Logged::PixelOp::READ);
+    }
+    if (hit == m_vramBreakpoints.size()) return;
+
+    const auto& bp = m_vramBreakpoints[hit];
+    const auto name = node->getName();
+    node->highlight = true;
+    g_system->log(LogClass::GPU,
+                  _("VRAM breakpoint %i triggered: %.*s did a %s intersecting %ix%i at %i,%i - PC = 0x%08x\n"), hit,
+                  int(name.size()), name.data(), what, bp.area.w, bp.area.h, bp.area.x, bp.area.y, node->pc);
+    g_system->m_eventBus->signal(Events::GUI::JumpToPC{node->pc});
+    g_system->pause();
+}
+
 void PCSX::GPULogger::addNodeInternal(GPU::Logged* node, GPU::Logged::Origin origin, uint32_t value, uint32_t length) {
     auto frame = m_frameCounter;
 
@@ -152,6 +244,7 @@ void PCSX::GPULogger::addNodeInternal(GPU::Logged* node, GPU::Logged::Origin ori
     node->frame = frame;
     node->generateStatsInfo();
     m_list.push_back(node);
+    checkVramBreakpoints(node);
 
     if (!m_hasFramebuffers) return;
 

--- a/src/core/gpulogger.h
+++ b/src/core/gpulogger.h
@@ -22,6 +22,7 @@
 #include <stdint.h>
 
 #include <array>
+#include <vector>
 
 #include "core/gpu.h"
 #include "support/eventbus.h"
@@ -36,6 +37,21 @@ class GPULogger;
 
 class GPULogger {
   public:
+    // A rectangle of VRAM to watch. Any logged command whose read or write footprint intersects an
+    // enabled breakpoint pauses the emulator. The footprints come straight from Logged::getVertices,
+    // so this covers primitives, blits, and the palette rows of paletted textures alike.
+    struct VramBreakpoint {
+        union {
+            int raw[4];
+            struct {
+                int x, y, w, h;
+            };
+        } area = {0, 0, 64, 64};
+        bool onRead = false;
+        bool onWrite = true;
+        bool enabled = true;
+    };
+
     GPULogger();
     void clearFrameLog() { m_list.destroyAll(); }
     template <typename T>
@@ -56,10 +72,12 @@ class GPULogger {
   private:
     void startNewFrame();
     void addNodeInternal(GPU::Logged* node, GPU::Logged::Origin, uint32_t value, uint32_t length);
+    void checkVramBreakpoints(GPU::Logged* node);
 
     EventBus::Listener m_listener;
     bool m_enabled = false;
     bool m_breakOnVSync = false;
+    std::vector<VramBreakpoint> m_vramBreakpoints;
     bool m_hasFramebuffers = false;
     uint64_t m_frameCounter = 0;
     GPU::LoggedList m_list;

--- a/src/gui/widgets/gpulogger.cc
+++ b/src/gui/widgets/gpulogger.cc
@@ -144,6 +144,41 @@ void PCSX::Widgets::GPULogger::draw(PCSX::GPULogger* logger, const char* title) 
     std::string label;
 
     ImGui::Separator();
+    if (ImGui::TreeNode(_("VRAM breakpoints"))) {
+        ImGuiHelpers::ShowHelpMarker(
+            _("Pauses emulation when a command reads from or writes to one of these VRAM rectangles. Handy to catch "
+              "the texture upload that stomped an area, since those are hard to spot in a frame that redraws "
+              "everything. The command that triggered gets highlighted in the logger view below. Note the footprints "
+              "are unclipped, so a primitive that ends up entirely outside the drawing area still counts as a write."));
+        if (ImGui::Button(_("Add breakpoint"))) {
+            logger->m_vramBreakpoints.emplace_back();
+        }
+        if (!logger->m_vramBreakpoints.empty()) {
+            ImGui::TextUnformatted(_("Enable, then X, Y, width, height:"));
+        }
+        unsigned toRemove = logger->m_vramBreakpoints.size();
+        for (unsigned i = 0; i < logger->m_vramBreakpoints.size(); i++) {
+            auto& bp = logger->m_vramBreakpoints[i];
+            ImGui::PushID(i);
+            ImGui::Checkbox("##enabled", &bp.enabled);
+            ImGui::SameLine();
+            ImGui::SetNextItemWidth(ImGui::GetFontSize() * 16.0f);
+            ImGui::InputInt4("##area", bp.area.raw);
+            ImGui::SameLine();
+            ImGui::Checkbox(_("Read"), &bp.onRead);
+            ImGui::SameLine();
+            ImGui::Checkbox(_("Write"), &bp.onWrite);
+            ImGui::SameLine();
+            if (ImGui::Button(_("Remove"))) toRemove = i;
+            ImGui::PopID();
+        }
+        if (toRemove != logger->m_vramBreakpoints.size()) {
+            logger->m_vramBreakpoints.erase(logger->m_vramBreakpoints.begin() + toRemove);
+        }
+        ImGui::TreePop();
+    }
+
+    ImGui::Separator();
     label = fmt::format(f_("Frame {}###FrameCounterNode"), logger->m_frameCounter - m_frameCounterOrigin);
     if (ImGui::TreeNode(label.c_str())) {
         if (ImGui::Button(_("Reset frame counter"))) {


### PR DESCRIPTION
Watch a list of VRAM rectangles and pause when a logged command's read or write footprint intersects one. The footprints come from the getVertices callback the heatmaps already use, so a single triangle-vs-rect SAT test covers polys, rects, lines, blits and the palette rows of paletted textures. The triggering node gets highlighted and the PC is thrown at the disassembly.

Break lands after the write: pause() only clears m_running, so an in-flight DMA burst finishes regardless of which side of the execute the test sits on.