### PR TITLE
Look for pcsx.json next to the binary when detecting portable mode

### DIFF
--- a/src/core/arguments.cc
+++ b/src/core/arguments.cc
@@ -21,6 +21,8 @@
 
 #include <filesystem>
 
+#include "support/binpath.h"
+
 PCSX::Arguments::Arguments(const CommandLine::args& args) {
     if (args.get<bool>("lua_stdout") || args.get<bool>("no-ui") || args.get<bool>("cli")) {
         m_luaStdoutEnabled = true;
@@ -35,6 +37,19 @@ PCSX::Arguments::Arguments(const CommandLine::args& args) {
     if (std::filesystem::exists("pcsx.json")) m_portable = true;
     if (std::filesystem::exists(std::filesystem::path("vsprojects") / "pcsx-redux.sln")) m_portable = true;
     if (std::filesystem::exists(std::filesystem::path("..") / "pcsx-redux.sln")) m_portable = true;
+    if (!m_portable) {
+        // The probes above are relative to the current directory, which is only the install
+        // directory when the binary was started from it. A shortcut with its own start-in, a
+        // file association on a disc image, or a frontend will all hand us something else, so
+        // look next to the binary too, and anchor the portable directory there when that's
+        // what matched. Without this, whether an install is portable depends on how it was
+        // launched rather than on where it lives.
+        std::filesystem::path binDir = std::filesystem::path(BinPath::getExecutablePath()).parent_path();
+        if (!binDir.empty() && std::filesystem::exists(binDir / "pcsx.json")) {
+            m_portable = true;
+            m_portablePath = binDir.string();
+        }
+    }
     if (args.get<bool>("no-portable")) m_portable = false;
     if (args.get<bool>("safe") || args.get<bool>("testmode") || args.get<bool>("cli")) m_safeModeEnabled = true;
     if (args.get<bool>("resetui")) m_uiResetRequested = true;

--- a/src/core/arguments.h
+++ b/src/core/arguments.h
@@ -51,9 +51,9 @@ class Arguments {
     // Returns true if the the flag -testmode was used.
     bool isTestModeEnabled() const { return m_testModeEnabled; }
 
-    // Returns true if the the flag -portable was used, if the executable is
-    // located in the same directory as the pcsx.json file, or if the
-    // executable is being run from its source tree.
+    // Returns true if the flag -portable was used, if a pcsx.json file exists in
+    // the current directory or next to the executable, or if the executable is
+    // being run from its source tree.
     bool isPortable() const { return m_portable; }
 
     // Returns true if the safe mode was enabled. This implies
@@ -77,8 +77,9 @@ class Arguments {
     // Toggled with the flags -viewports / -no-viewports.
     bool isViewportsEnabled() const { return m_viewportsEnabled; }
 
-    // Returns the path to the portable directory.
-    // Set with the flag -portable.
+    // Returns the path to the portable directory. Set with the flag -portable, or
+    // to the executable's directory when that is where the pcsx.json was found.
+    // Empty means the current directory.
     std::string_view getPortablePath() const { return m_portablePath; }
 
   private:

--- a/src/main/main.cc
+++ b/src/main/main.cc
@@ -246,7 +246,7 @@ int pcsxMain(int argc, char **argv) {
         auto argPath1 = args.get<std::string>("memcard1");
         auto argPath2 = args.get<std::string>("memcard2");
         if (argPath1.has_value()) emuSettings.get<PCSX::Emulator::SettingMcd1>() = argPath1.value();
-        if (argPath2.has_value()) emuSettings.get<PCSX::Emulator::SettingMcd2>() = argPath1.value();
+        if (argPath2.has_value()) emuSettings.get<PCSX::Emulator::SettingMcd2>() = argPath2.value();
         PCSX::u8string path1 = emuSettings.get<PCSX::Emulator::SettingMcd1>().string();
         PCSX::u8string path2 = emuSettings.get<PCSX::Emulator::SettingMcd2>().string();
 


### PR DESCRIPTION
The portable checks were all relative to the current directory, so whether an install was portable depended on how it got launched rather than on where it lives. A shortcut with its own start-in, a file association on a disc image, or a frontend all hand us a different cwd, and we'd quietly fall back to %APPDATA% with a perfectly good pcsx.json sitting right next to the executable. Look next to the binary as well, and anchor the portable directory there when that's what matched.

An explicit -portable is left alone, since the vscode extension deliberately points its cwd somewhere other than the binary, and on Linux the binary lives in a read-only AppImage mount that goes away on exit.

Also fixes -memcard2 reading the -memcard1 optional, which threw when the flag was used on its own.
