### PR TITLE
Working around a binutils 2.47 regression on Windows.

### DIFF
--- a/tools/win32-mips/Dockerfile
+++ b/tools/win32-mips/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-# Dockerfile to generate the Windows g++-mipsel-none-elf-16.1.0.zip package.
+# Dockerfile to generate the Windows g++-mipsel-none-elf-16.2.0.zip package.
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2025
 WORKDIR C:\windows\temp
@@ -39,7 +39,7 @@ RUN C:\msys64\usr\bin\bash.exe -l -c 'exit 0'; `
 
 RUN C:\msys64\usr\bin\bash.exe -l -c 'pacman -S --needed --noconfirm mingw-w64-x86_64-toolchain'
 RUN C:\msys64\usr\bin\bash.exe -l -c 'pacman -S --needed --noconfirm automake autoconf make intltool libtool zip unzip'
-RUN C:\msys64\usr\bin\bash.exe -l -c 'pacman -S --needed --noconfirm bison diffutils texinfo'
+RUN C:\msys64\usr\bin\bash.exe -l -c 'pacman -S --needed --noconfirm bison diffutils patch texinfo'
 RUN C:\msys64\usr\bin\bash.exe -l -c 'pacman -S --needed --noconfirm mingw-w64-x86_64-expat mingw-w64-x86_64-ncurses'
 RUN C:\msys64\usr\bin\bash.exe -l -c 'pacman -S --needed --noconfirm mingw-w64-x86_64-xxhash mingw-w64-x86_64-pdcurses'
 RUN C:\msys64\usr\bin\bash.exe -l -c 'pacman -S --needed --noconfirm mingw-w64-x86_64-python mingw-w64-x86_64-readline'
@@ -61,6 +61,10 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Remove-Item @('C:\Windows\Temp\*', 'C:\Users\*\Appdata\Local\Temp\*') -Force -Recurse;
 
 ENV MSYSTEM MINGW64
+
+COPY same-inode.patch C:/same-inode.patch
+
+RUN C:\msys64\usr\bin\bash.exe -l -c 'cd /c/binutils-2.47 && patch -p1 --batch --forward -i /c/same-inode.patch'
 
 RUN C:\msys64\usr\bin\bash.exe -l -c 'cd /c/binutils-2.47 && /c/binutils-2.47/configure --target=mipsel-none-elf --disable-multilib --disable-nls --disable-werror --prefix=/DIST || (cat /BUILD/config.log && exit 1)'
 

--- a/tools/win32-mips/same-inode.patch
+++ b/tools/win32-mips/same-inode.patch
@@ -1,0 +1,16 @@
+mingw's stat() leaves st_ino at 0 while setting st_dev to the drive, so binutils 2.47's SAME_INODE
+matches any two files, and ld's duplicate linker script check then rejects every link passing more
+than one -T script. Keying the guard on st_ino alone restores the pre-2.47 behaviour on Windows and
+changes nothing on hosts where st_ino is meaningful. Drop this once it is fixed upstream.
+
+--- a/include/same-inode.h
++++ b/include/same-inode.h
+@@ -31,7 +31,7 @@
+    /* stat() and fstat() set st_dev and st_ino to 0 if information about
+       the inode is not available.  */
+ #  define SAME_INODE(a, b) \
+-    (!((a).st_ino == 0 && (a).st_dev == 0) \
++    ((a).st_ino != 0 \
+      && (a).st_ino == (b).st_ino && (a).st_dev == (b).st_dev)
+ # else
+ #  define SAME_INODE(a, b)    \

--- a/tools/win32-mips/same-inode.patch
+++ b/tools/win32-mips/same-inode.patch
@@ -1,16 +1,28 @@
+Fixed upstream in binutils-gdb commit afa6db16e6508d8ea269557085bc7c301e824382, "windows: remove
+st_dev test from SAME_INODE", which is on master but in no release yet. This is that commit verbatim.
+Drop this file once a binutils release carries it.
+
 mingw's stat() leaves st_ino at 0 while setting st_dev to the drive, so binutils 2.47's SAME_INODE
 matches any two files, and ld's duplicate linker script check then rejects every link passing more
-than one -T script. Keying the guard on st_ino alone restores the pre-2.47 behaviour on Windows and
-changes nothing on hosts where st_ino is meaningful. Drop this once it is fixed upstream.
+than one -T script.
 
+diff --git a/include/same-inode.h b/include/same-inode.h
+index 9d9049843d1..d9aea7b006f 100644
 --- a/include/same-inode.h
 +++ b/include/same-inode.h
-@@ -31,7 +31,7 @@
-    /* stat() and fstat() set st_dev and st_ino to 0 if information about
+@@ -28,11 +28,12 @@
+      && (a).st_dev == (b).st_dev)
+ # elif defined _WIN32 && ! defined __CYGWIN__
+    /* Native Windows.  */
+-   /* stat() and fstat() set st_dev and st_ino to 0 if information about
++   /* stat() and fstat() set st_ino to 0 if information about
        the inode is not available.  */
  #  define SAME_INODE(a, b) \
 -    (!((a).st_ino == 0 && (a).st_dev == 0) \
-+    ((a).st_ino != 0 \
-      && (a).st_ino == (b).st_ino && (a).st_dev == (b).st_dev)
+-     && (a).st_ino == (b).st_ino && (a).st_dev == (b).st_dev)
++    ((a).st_ino != 0			\
++     && (a).st_ino == (b).st_ino	\
++     && (a).st_dev == (b).st_dev)
  # else
  #  define SAME_INODE(a, b)    \
+     ((a).st_ino == (b).st_ino \


### PR DESCRIPTION
mingw's stat() leaves st_ino at 0 while setting st_dev to the drive, so SAME_INODE matches any two files, and ld's duplicate linker script check then rejects every link passing more than one -T script.