### PR TITLE
Build and publish the build image from CI.

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,90 @@
+name: Build image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'tools/build/Dockerfile'
+      - 'tools/linux-mips/spawn-compiler.sh'
+      - '.dockerignore'
+      - '.github/workflows/build-image.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/grumpycoders/pcsx-redux-build
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log into ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: tools/build/Dockerfile
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=min,scope=${{ matrix.platform }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Export the digest
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${{ steps.build.outputs.digest }}"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.arch }}
+          path: /tmp/digests/*
+          retention-days: 1
+
+  manifest:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digest-*
+          merge-multiple: true
+      - name: Log into ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push the multi-arch tag
+        run: |
+          docker buildx imagetools create -t $IMAGE:latest \
+            $(cd /tmp/digests && printf "$IMAGE@%s " *)
+      - name: Check what landed
+        run: |
+          docker buildx imagetools inspect $IMAGE:latest

--- a/tools/build/Dockerfile
+++ b/tools/build/Dockerfile
@@ -46,12 +46,13 @@ RUN apt install -y imagemagick-6.q16 gtk-update-icon-cache appstream
 RUN apt install -y squashfs-tools zip zsync
 
 WORKDIR /tmp
-RUN wget https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage && \
-    chmod +x appimagetool-x86_64.AppImage && \
-    mv appimagetool-x86_64.AppImage /usr/bin/appimagetool
-RUN wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage && \
-    chmod +x linuxdeploy-x86_64.AppImage && \
-    mv linuxdeploy-x86_64.AppImage /usr/bin/linuxdeploy
+# Both projects name their releases after uname's spelling of the architecture.
+RUN wget https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-`uname -m`.AppImage && \
+    chmod +x appimagetool-`uname -m`.AppImage && \
+    mv appimagetool-`uname -m`.AppImage /usr/bin/appimagetool
+RUN wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-`uname -m`.AppImage && \
+    chmod +x linuxdeploy-`uname -m`.AppImage && \
+    mv linuxdeploy-`uname -m`.AppImage /usr/bin/linuxdeploy
 
 RUN mkdir /project
 RUN mkdir -p /home/coder/dconf

--- a/tools/build/Dockerfile
+++ b/tools/build/Dockerfile
@@ -54,6 +54,10 @@ RUN wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous
     chmod +x linuxdeploy-`uname -m`.AppImage && \
     mv linuxdeploy-`uname -m`.AppImage /usr/bin/linuxdeploy
 
+# Links the package to the repository, so its permissions follow from there
+# rather than from a settings page somebody has to remember.
+LABEL org.opencontainers.image.source=https://github.com/grumpycoders/pcsx-redux
+
 RUN mkdir /project
 RUN mkdir -p /home/coder/dconf
 RUN chmod a+rwx /home/coder/dconf


### PR DESCRIPTION
Nothing has ever built ghcr.io/grumpycoders/pcsx-redux-build automatically, so a Dockerfile change lands inert until someone remembers to rebuild by hand. The cross image shows where that ends up: published in 2022, two base bumps went by without ever taking effect, and the lane kept reporting green against a sysroot that had gone stale years earlier.

This builds both architectures on their own runners and pushes a multi-arch tag. It has to land here first, since workflow_dispatch only fires for files that exist on the default branch. The AppImage tools were pinned to x86_64 URLs, which only started to matter once there was an arm64 image to get them wrong in.