### PR TITLE
Stop dragging libuv through system.h.

### DIFF
--- a/src/core/gdb-server.cc
+++ b/src/core/gdb-server.cc
@@ -17,6 +17,8 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.           *
  ***************************************************************************/
 
+#include <uv.h>
+
 #include "core/gdb-server.h"
 
 #include <assert.h>

--- a/src/core/gdb-server.h
+++ b/src/core/gdb-server.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <uv.h>
+
 #include <assert.h>
 
 #include <cstdarg>

--- a/src/core/memorycard.cc
+++ b/src/core/memorycard.cc
@@ -17,6 +17,8 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.           *
  ***************************************************************************/
 
+#include <sys/stat.h>
+
 #include "core/memorycard.h"
 
 #include "core/sio.h"

--- a/src/core/sio1-server.cc
+++ b/src/core/sio1-server.cc
@@ -17,6 +17,8 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.           *
  ***************************************************************************/
 
+#include <uv.h>
+
 #include "core/sio1-server.h"
 
 #include "core/psxemulator.h"

--- a/src/core/sio1-server.h
+++ b/src/core/sio1-server.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <uv.h>
+
 #include <queue>
 #include <string>
 

--- a/src/core/system.cc
+++ b/src/core/system.cc
@@ -20,6 +20,7 @@
 #include "core/system.h"
 
 #include <stddef.h>
+#include <uv.h>
 
 #include <iomanip>
 #include <sstream>
@@ -38,6 +39,15 @@ static const ImWchar c_polishRanges[] = {0x0020, 0x00ff, 0x0104, 0x0119, 0x0141,
 
 // locale names have to be written in basic latin or extended latin, in order
 // to be properly displayed in the UI with the default range
+PCSX::System::System() : m_loop(new uv_loop_t) { uv_loop_init(m_loop); }
+
+PCSX::System::~System() {
+    if (!m_emergencyExit) uv_loop_close(m_loop);
+    delete m_loop;
+}
+
+uv_loop_t *PCSX::System::getLoop() { return m_loop; }
+
 const std::map<std::string, PCSX::System::LocaleInfo> PCSX::System::LOCALES = {
     {
         "Deutsch",

--- a/src/core/system.h
+++ b/src/core/system.h
@@ -20,7 +20,11 @@
 #pragma once
 
 #include <stdarg.h>
-#include <uv.h>
+// libuv only appears here as an opaque handle. Including <uv.h> from this
+// header dragged it into 110 of 251 translation units, of which only eight
+// actually use it; the ones that do include it themselves.
+struct uv_loop_s;
+typedef struct uv_loop_s uv_loop_t;
 
 #include <chrono>
 #include <filesystem>
@@ -35,7 +39,7 @@
 #include "imgui.h"
 #include "support/djbhash.h"
 #include "support/eventbus.h"
-#include "support/version.h"
+#include "support/version-info.h"
 
 namespace PCSX {
 
@@ -127,10 +131,8 @@ struct SetLuts {};
 
 class System {
   public:
-    System() { uv_loop_init(&m_loop); }
-    virtual ~System() {
-        if (!m_emergencyExit) uv_loop_close(&m_loop);
-    }
+    System();
+    virtual ~System();
     // Requests a system reset
     virtual void softReset() = 0;
     virtual void hardReset() = 0;
@@ -255,10 +257,10 @@ class System {
         VIETNAMESE = 13,
     };
 
-    uv_loop_t *getLoop() { return &m_loop; }
+    uv_loop_t *getLoop();
 
   private:
-    uv_loop_t m_loop;
+    uv_loop_t *m_loop;
     std::map<uint64_t, std::string> m_i18n;
     std::map<std::string, decltype(m_i18n)> m_locales;
     std::string m_currentLocale;

--- a/src/core/ui.cc
+++ b/src/core/ui.cc
@@ -17,6 +17,8 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.           *
  ***************************************************************************/
 
+#include <uv.h>
+
 #include "core/ui.h"
 
 #include <fstream>

--- a/src/core/web-server.cc
+++ b/src/core/web-server.cc
@@ -17,6 +17,8 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.           *
  ***************************************************************************/
 
+#include <uv.h>
+
 #include "core/web-server.h"
 
 #include <llhttp.h>

--- a/src/main/main.cc
+++ b/src/main/main.cc
@@ -17,6 +17,8 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.           *
  ***************************************************************************/
 
+#include <uv.h>
+
 #include <csignal>
 #include <filesystem>
 #include <iostream>

--- a/src/support/uvfile.cc
+++ b/src/support/uvfile.cc
@@ -23,6 +23,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 */
+#include <uv.h>
+
 #include "support/uvfile.h"
 
 #include <curl/curl.h>

--- a/src/support/version-info.h
+++ b/src/support/version-info.h
@@ -26,45 +26,50 @@ SOFTWARE.
 
 #pragma once
 
-#include <uv.h>
+// VersionInfo alone, split out of version.h so that core/system.h can name it
+// without pulling in Update - which needs UvFile, and through it libuv.
 
 #include <ctime>
 #include <filesystem>
-#include <functional>
 #include <optional>
 #include <string>
 
 #include "json.hpp"
 #include "support/file.h"
-#include "support/version-info.h"
-#include "support/uvfile.h"
 
 namespace PCSX {
 
-
-class Update {
-  public:
-    bool downloadUpdateInfo(const VersionInfo&, std::function<void(bool)> callback, uv_loop_t* loop);
-    bool downloadAndApplyUpdate(const VersionInfo&, std::function<void(bool)> callback, uv_loop_t* loop);
-    bool getDownloadUrl(const VersionInfo&, std::function<void(std::string)> callback, uv_loop_t* loop);
-    bool applyUpdate(const std::filesystem::path& binDir);
-    bool canFullyApply();
-
-    float progress() {
-        if (m_download && !m_download->failed()) return m_download->cacheProgress();
-        return 0.0f;
+struct VersionInfo {
+    std::string version;
+    std::optional<unsigned> buildId;
+    std::string changeset;
+    std::time_t timestamp;
+    std::string updateMethod;
+    std::string updateChannel;
+    std::string updateCatalog;
+    std::string updateInfoBase;
+    std::string updateStorageUrl;
+    void loadFromFile(IO<File> file);
+    bool failed() const { return version.empty(); }
+    bool hasUpdateInfo() const {
+        if (version.empty()) return false;
+        if (updateCatalog.empty() || updateInfoBase.empty()) return false;
+        if (updateMethod == "appdistrib") {
+            return buildId.has_value() && !updateStorageUrl.empty();
+        }
+        return (updateMethod == "appcenter");
     }
-
-    bool hasUpdate() const { return m_hasUpdate; }
-
-  private:
-    using json = nlohmann::json;
-    json m_updateCatalog;
-    json m_updateInfo;
-    IO<UvFile> m_download;
-    unsigned m_updateId;
-    std::string m_updateVersion;
-    bool m_hasUpdate = false;
+    void clear() {
+        version.clear();
+        buildId = std::nullopt;
+        changeset.clear();
+        timestamp = 0;
+        updateMethod.clear();
+        updateChannel.clear();
+        updateCatalog.clear();
+        updateInfoBase.clear();
+        updateStorageUrl.clear();
+    }
 };
 
 }  // namespace PCSX

--- a/src/support/version.cc
+++ b/src/support/version.cc
@@ -24,6 +24,8 @@ SOFTWARE.
 
 */
 
+#include <uv.h>
+
 #include "support/version.h"
 
 #include <algorithm>


### PR DESCRIPTION
The loop is an opaque handle to everything except the eight files that use it, but system.h reached <uv.h> twice - directly, and again through version.h, whose Update class holds an IO<UvFile>. Between them they put libuv in 110 of the 251 translation units in the target. Forward declare the loop, move the constructor, destructor and accessor into system.cc, and split VersionInfo into its own header so naming a version string doesn't pull in the auto-updater.

The files that genuinely use libuv now include it themselves, and memorycard.cc picks up sys/stat.h, which it had been getting through uv/win.h and uv/unix.h.
