### PR TITLE
Fix a missing cstdlib and the unsupported-platform throw.

### DIFF
--- a/src/support/sharedmem-unix.cc
+++ b/src/support/sharedmem-unix.cc
@@ -26,6 +26,8 @@ SOFTWARE.
 
 #if !defined(_WIN32) && !defined(_WIN64)
 
+#include <cstdlib>
+
 #include <assert.h>
 #include <fcntl.h>
 #include <string.h>

--- a/src/support/version.cc
+++ b/src/support/version.cc
@@ -267,7 +267,7 @@ bool PCSX::Update::getDownloadUrl(const VersionInfo& versionInfo, std::function<
 // All these defines need to be matching what we see in version-{platform}.cc
 #if (!defined(__APPLE__) || !defined(__MACH__)) && !defined(__linux__) && !defined(_WIN32) && !defined(_WIN64)
 bool PCSX::Update::applyUpdate(const std::filesystem::path& binDir) {
-    throw std::runtime_exception("No platform support for updates");
+    throw std::runtime_error("No platform support for updates");
     return false;
 }
 #endif


### PR DESCRIPTION
sharedmem-unix.cc calls calloc without including it.

version.cc's unsupported-platform fallback throws std::runtime_exception, which is not a type. Nothing had ever preprocessed that block in, so it tripped as a compile error the first time a new target reached it rather than at runtime.
